### PR TITLE
Use point id in batch upsert

### DIFF
--- a/qdrant_client/local/local_collection.py
+++ b/qdrant_client/local/local_collection.py
@@ -458,7 +458,7 @@ class LocalCollection:
 
                 self._upsert_point(
                     models.PointStruct(
-                        id=idx,
+                        id=point_id,
                         payload=payload,
                         vector=vector,
                     )


### PR DESCRIPTION
While upserting a batch of points, I found out the ids are converted to ints, even though I provided UUID-like identifiers. This PR fixes that. It seems the wrong variable was used.