### PR TITLE
Update README.md with an absolute image path

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pip install qdrant-client
 
 <p align="center">
   <!--- https://github.com/qdrant/qdrant-client/raw/master -->
-  <img max-height="180" src="docs/images/try-develop-deploy.png" alt="Qdrant">
+  <img max-height="180" src="https://github.com/qdrant/qdrant-client/raw/master/docs/images/try-develop-deploy.png" alt="Qdrant">
 </p>
 
 Python client allows you to run same code in local mode without running Qdrant server.


### PR DESCRIPTION
The relative path to the "Try-Develop-Deploy" image was not working correctly on pypi.org: https://pypi.org/project/qdrant-client/

![image](https://user-images.githubusercontent.com/2649301/231395804-7cd25d18-0b18-4d1f-a747-f89b09e68b7a.png)
