### PR TITLE
Fix MatchText filters in local mode

### DIFF
--- a/qdrant_client/local/payload_filters.py
+++ b/qdrant_client/local/payload_filters.py
@@ -68,7 +68,7 @@ def check_match(condition: models.Match, value: Any) -> bool:
     if isinstance(condition, models.MatchValue):
         return value == condition.value
     if isinstance(condition, models.MatchText):
-        return value and condition.text in value
+        return value is not None and condition.text in value
     if isinstance(condition, models.MatchAny):
         return value in condition.any
     raise ValueError(f"Unknown match condition: {condition}")

--- a/qdrant_client/local/payload_filters.py
+++ b/qdrant_client/local/payload_filters.py
@@ -68,7 +68,7 @@ def check_match(condition: models.Match, value: Any) -> bool:
     if isinstance(condition, models.MatchValue):
         return value == condition.value
     if isinstance(condition, models.MatchText):
-        return condition.text in value
+        return value and condition.text in value
     if isinstance(condition, models.MatchAny):
         return value in condition.any
     raise ValueError(f"Unknown match condition: {condition}")


### PR DESCRIPTION
I fixed the case when a particular payload does not have a corresponding attribute. In such a case, we have `value = None`, and the condition ends with `TypeError: argument of type 'NoneType' is not iterable`