### PR TITLE
Add gnu-sed instructions for macOS in DEVELOPMENT.md

### DIFF
--- a/tools/DEVELOPMENT.md
+++ b/tools/DEVELOPMENT.md
@@ -2,7 +2,7 @@
 
 For breaking changes:
 
-* [ ] Create a new branch from the branch of upcoming release. 
+* [ ] Create a new branch from the branch of upcoming release.
   * E.g. `git checkout v0.7.0 && git pull && git checkout -b v0.7.0-my-changees`
 
 For fixes:
@@ -17,9 +17,9 @@ For fixes:
   * `source venv/bin/activate` - enter venv
   * `pip install poetry` - install package manager
   * `poetry install` - install all dependencies
-* [ ] (MacOS) make sure to have `gnu-sed` installed and aliased to `sed`: `brew install gnu-sed`.
-* [ ] Generate REST code: `bash -x tools/generate_rest_client.sh` - will automatically fetch openapi from `qdrant:master`. 
-* [ ] Generate gRPC code: `bash -x tools/generate_grpc_client.sh` - will automatically fetch proto from `qdrant:master`. 
+* [ ] (MacOS) make sure to have `gnu-sed` installed and aliased to `sed`: `brew install gnu-sed`. Instructions to set alias can be found via `brew info gnu-sed`
+* [ ] Generate REST code: `bash -x tools/generate_rest_client.sh` - will automatically fetch openapi from `qdrant:master`.
+* [ ] Generate gRPC code: `bash -x tools/generate_grpc_client.sh` - will automatically fetch proto from `qdrant:master`.
 
 ---
 

--- a/tools/DEVELOPMENT.md
+++ b/tools/DEVELOPMENT.md
@@ -17,6 +17,7 @@ For fixes:
   * `source venv/bin/activate` - enter venv
   * `pip install poetry` - install package manager
   * `poetry install` - install all dependencies
+* [ ] (MacOS) make sure to have `gnu-sed` installed and aliased to `sed`: `brew install gnu-sed`.
 * [ ] Generate REST code: `bash -x tools/generate_rest_client.sh` - will automatically fetch openapi from `qdrant:master`. 
 * [ ] Generate gRPC code: `bash -x tools/generate_grpc_client.sh` - will automatically fetch proto from `qdrant:master`. 
 


### PR DESCRIPTION
I was struggling to run the `generate_rest_client.sh` script successfully, until 
getting help from @agourlay. Turns out there are differences between `sed` in linux 
and in mac. 

The solution is quite simple: mac users will just have to install 
`gnu-sed` with `brew install gnu-sed` and alias it to regular `sed` using the install instructions


