### PR TITLE
Fix typing extensions version issue for python 3.8 and 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ version = "1.3.1"
 description = "Client library for the Qdrant vector search engine"
 authors = ["Andrey Vasnetsov <andrey@qdrant.tech>"]
 packages = [
-    {include = "qdrant_client"},
-    {include = "qdrant_openapi_client"}
+    { include = "qdrant_client" },
+    { include = "qdrant_openapi_client" },
 ]
 license = "Apache-2.0"
 readme = "README.md"
@@ -18,10 +18,10 @@ python = ">=3.7,<3.12"
 httpx = { version = ">=0.14.0", extras = ["http2"] }
 numpy = [
     { version = "<1.21", python = "<3.8" },
-    { version = ">=1.21", python = ">=3.8" }
+    { version = ">=1.21", python = ">=3.8" },
 ]
 pydantic = "^1.8"
-typing-extensions = ">=4.0.0,<4.6.0"  # at the moment 4.6.0 breaks support for python3.8,3.9
+typing-extensions = ">=4.6.3,<4.7.0"
 grpcio = { version = ">=1.41.0", allow-prereleases = true }
 grpcio-tools = ">=1.41.0"
 urllib3 = "^1.26.14"


### PR DESCRIPTION
Have issues with poetry complaining about the version collision with other libraries. This seems to fix the typing version issue though haven't tested it locally as I'm using python 3.10 and relying on CI here and [this changelog](https://github.com/python/typing_extensions/blob/main/CHANGELOG.md#release-463-june-1-2023). 