### PR TITLE
Fix cosine normalization

### DIFF
--- a/qdrant_client/local/local_collection.py
+++ b/qdrant_client/local/local_collection.py
@@ -554,6 +554,9 @@ class LocalCollection:
         for vector_name, named_vectors in self.vectors.items():
             vector = vectors.get(vector_name)
             if vector is not None:
+                params = self.get_vector_params(vector_name)
+                if params.distance == models.Distance.COSINE:
+                    vector = np.array(vector) / np.linalg.norm(vector)
                 self.vectors[vector_name][idx] = vector
                 self.deleted_per_vector[vector_name][idx] = 0
             else:
@@ -587,6 +590,9 @@ class LocalCollection:
                 )
             else:
                 vector_np = np.array(vector)
+                params = self.get_vector_params(vector_name)
+                if params.distance == models.Distance.COSINE:
+                    vector_np = vector_np / np.linalg.norm(vector_np)
                 named_vectors[idx] = vector_np
                 self.vectors[vector_name] = named_vectors
                 self.deleted_per_vector[vector_name] = np.append(

--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, Union
 
 from qdrant_client import grpc as grpc

--- a/tests/congruence_tests/test_common.py
+++ b/tests/congruence_tests/test_common.py
@@ -84,7 +84,7 @@ def compare_collections(
     compare_client_results(
         client_1,
         client_2,
-        lambda client: client.scroll(COLLECTION_NAME, limit=num_vectors * 2),
+        lambda client: client.scroll(COLLECTION_NAME, with_vectors=True, limit=num_vectors * 2)[0],
     )
 
 
@@ -96,11 +96,11 @@ def compare_vectors(vec1: Optional[VectorStruct], vec2: Optional[VectorStruct], 
 
     if isinstance(vec1, dict):
         for key, value in vec1.items():
-            assert np.allclose(vec1[key], vec2[key]), (
+            assert np.allclose(vec1[key], vec2[key], atol=1.e-3), (
                 f"res1[{i}].vectors[{key}] = {value}, " f"res2[{i}].vectors[{key}] = {vec2[key]}"
             )
     else:
-        assert np.allclose(vec1, vec2), f"res1[{i}].vectors = {vec1}, res2[{i}].vectors = {vec2}"
+        assert np.allclose(vec1, vec2, atol=1.e-3), f"res1[{i}].vectors = {vec1}, res2[{i}].vectors = {vec2}"
 
 
 def compare_scored_record(
@@ -149,7 +149,7 @@ def compare_client_results(
     res1 = foo(client1, **kwargs)
     res2 = foo(client2, **kwargs)
 
-    if isinstance(res1, list):
+    if isinstance(res1, (list, tuple)):
         compare_records(res1, res2)
     elif isinstance(res1, models.GroupsResult):
         groups_1 = sorted(res1.groups, key=lambda x: (x.hits[0].score, x.id))


### PR DESCRIPTION
This PR enables the normalization of vectors if cosine distance is used as reported in #212. It also enables vector comparison in tests, as the previous scroll call did not return vectors. In addition to that, the vectors are compared with `atol=1e-3` as random vectors are rounded upon generation: https://github.com/qdrant/qdrant-client/blob/bc08733e77fa3c2860177c90247ddcc8492a34a9/tests/fixtures/points.py#L15