### PR TITLE
Fix incorrect args for grpc.insecure_channel()

### DIFF
--- a/qdrant_client/connection.py
+++ b/qdrant_client/connection.py
@@ -211,7 +211,7 @@ def get_channel(
     else:
         if metadata:
             metadata_interceptor = header_adder_interceptor(metadata)
-            channel = grpc.insecure_channel(f"{host}:{port}", metadata, options)
+            channel = grpc.insecure_channel(f"{host}:{port}", options)
             return grpc.intercept_channel(channel, metadata_interceptor)
         else:
             return grpc.insecure_channel(f"{host}:{port}", options)


### PR DESCRIPTION
This fixes issue #179 by removing the incorrect `metadata` argument to the `grpc.insecure_channel()` call