### PR TITLE
Change `top` kwarg to `limit` as per code

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -76,7 +76,7 @@ Search for similar vectors
       query_vector=query_vector,
       query_filter=None,  # Don't use any filters for now, search across all indexed points
       append_payload=True,  # Also return a stored payload for found points
-      top=5  # Return 5 closest points
+      limit=5  # Return 5 closest points
    )
 
 Search for similar vectors with filtering condition
@@ -99,7 +99,7 @@ Search for similar vectors with filtering condition
            ]
        ),
        append_payload=True,  # Also return a stored payload for found points
-       top=5  # Return 5 closest points
+       limit=5  # Return 5 closest points
    )
 
 Check out `full example code <https://github.com/qdrant/qdrant-client/blob/master/tests/test_qdrant_client.py>`_


### PR DESCRIPTION
The `top` keyword argument [is now](https://github.com/qdrant/qdrant-client/blob/ba8063ba897007886393ca403885be1faf8b21c5/qdrant_client/client_base.py#L27) `limit` in v1.3.x. The docs didn't reflect that, so this has been fixed.