### PR TITLE
feat: Add monthly download stats badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
     <a href="https://github.com/qdrant/qdrant-client/blob/master/LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-success" alt="Apache 2.0 License"></a>
     <a href="https://qdrant.to/discord"><img src="https://img.shields.io/badge/Discord-Qdrant-5865F2.svg?logo=discord" alt="Discord"></a>
     <a href="https://qdrant.to/roadmap"><img src="https://img.shields.io/badge/Roadmap-2023-bc1439.svg" alt="Roadmap 2023"></a>
+    <a href="https://pypi.org/project/qdrant-client"><img src="https://static.pepy.tech/badge/qdrant-client/month"/></a>
 </p>
 
 # Python Qdrant Client


### PR DESCRIPTION
Add per month download stats badge. It's close to 227k/month (and 47k/week). It's a great number and will attract more devs to try out Qdrant :)

- https://static.pepy.tech/badge/qdrant-client/month
- https://static.pepy.tech/badge/qdrant-client/week