### PR TITLE
Allow a user to specify the grpc_host

### DIFF
--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -50,6 +50,7 @@ class QdrantRemote(QdrantBase):
         prefix: Optional[str] = None,
         timeout: Optional[float] = None,
         host: Optional[str] = None,
+        grpc_host: Optional[str] = None,
         **kwargs: Any,
     ):
         self._prefer_grpc = prefer_grpc
@@ -63,6 +64,14 @@ class QdrantRemote(QdrantBase):
 
         if url is not None and host is not None:
             raise ValueError(f"Only one of (url, host) can be set. url is {url}, host is {host}")
+
+        if grpc_host is not None and (
+            grpc_host.startswith("http://") or grpc_host.startswith("https://")
+        ):
+            raise ValueError(
+                f"`grpc_host` param is not expected to contain protocol (http:// or https://). "
+                f"Try to use `url` parameter instead."
+            )
 
         if host is not None and (host.startswith("http://") or host.startswith("https://")):
             raise ValueError(
@@ -96,6 +105,7 @@ class QdrantRemote(QdrantBase):
         else:
             self._host = host or "localhost"
             self._port = port
+            self._grpc_host = grpc_host or self._host
 
         self._timeout = timeout
         self._api_key = api_key
@@ -194,7 +204,7 @@ class QdrantRemote(QdrantBase):
 
         if self._grpc_channel is None:
             self._grpc_channel = get_channel(
-                host=self._host,
+                host=self._grpc_host,
                 port=self._grpc_port,
                 ssl=self._https,
                 metadata=self._grpc_headers,
@@ -206,7 +216,7 @@ class QdrantRemote(QdrantBase):
 
         if self._aio_grpc_channel is None:
             self._aio_grpc_channel = get_async_channel(
-                host=self._host,
+                host=self._grpc_host,
                 port=self._grpc_port,
                 ssl=self._https,
                 metadata=self._grpc_headers,


### PR DESCRIPTION
Hi,

In the current state, a user cannot use qdrant-client if qdrant is behind a reverse proxy: the rest endpoint and the gRPC endpoints have different server names and potentially different certificates, and qdrant-client only offers one host parameter.

This PR brings the ability to specify the gRPC host. The newly introduced `self._grpc_host` default to `self._host`.

Usage:

```python
client = qdrant_client.QdrantClient(
    port=443,
    grpc_port=443,
    prefer_grpc=True,
    https=True,
    host="qdrant.domain.com",
    grpc_host="qdrant-grpc.domain.com",
    api_key=qdrant_api_key,
)
```

For completeness, here is how to configure the gRPC reverse proxy on NGINX:

```conf
server {
  server_name qdrant-grpc.domain.com;
  listen 80;

  location / {
    return 301 https://$host$request_uri;
  }

  access_log /var/log/nginx/qdrant-grpc.domain.com-access.log;
  error_log /var/log/nginx/qdrant-grpc.domain.com-error.log;
}

server {
  server_name qdrant-grpc.domain.com;
  listen 443 ssl http2;

  ssl_certificate          /path/to/chained.crt;
  ssl_certificate_key      /path/to/service.key;
  add_header               Strict-Transport-Security "max-age=31536000" always;

  # Allow any size file to be uploaded.
  # Set to a value such as 1000m; to restrict file size to a specific value
  client_max_body_size 0;
  # Disable buffering
  proxy_buffering off;
  proxy_request_buffering off;

  location / {
    grpc_pass grpc://127.0.0.1:6334;
  }

  access_log /var/log/nginx/qdrant-grpc.domain.com-access.log;
  error_log /var/log/nginx/qdrant-grpc.domain.com-error.log;
}
```