### PR TITLE
disable forcing of http2 for cloud connections

### DIFF
--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -114,7 +114,7 @@ class QdrantRemote(QdrantBase):
             if self._scheme == "http":
                 warnings.warn("Api key is used with unsecure connection.")
 
-            http2 = True
+            # http2 = True
 
             self._rest_headers["api-key"] = api_key
             self._grpc_headers.append(("api-key", api_key))


### PR DESCRIPTION
I was able to reproduce the problem, reported by our users some time ago, regarding random 

```
qdrant_client.http.exceptions.ResponseHandlingException: Server disconnected
```

errors in in consequent calls in FastAPI.

Here is a some fragment to reproduce:


```
app = FastAPI()

client = QdrantClient(
    url=os.getenv("QDRANT_URL", "http://localhost:6333"),
    api_key=os.getenv("QDRANT_API_KEY"),
)

@app.get("/api")
def read_root():
    client.get_collections()
    client.get_collections()
    return client.get_collections()

```

Query with:

```
seq 1000 | xargs -P 2 -I {} curl 'localhost:8000/api'
```
( full code to reproduce available at request)

the error is reproducible with raw httpx Client as well, so it is not some problem of the client wrapper.

Turns out the core reason is usage of http2 in out cloud connections. If http2 is disabled explicitly, no errors reproduced.
I do not remember why we turned it on in a first place, but it seems like everything is working fine with v1.1 as well.
@fabriziobonavita please confirm.


This PR disables automatic http2, but allows user to enable it with parameter.






