### PR TITLE
fix: fix type hint for get_args_subscribed and batch operation

### DIFF
--- a/qdrant_client/conversions/common_types.py
+++ b/qdrant_client/conversions/common_types.py
@@ -30,7 +30,7 @@ def remap_type(tp: type) -> type:
     return typing_remap.get(tp, tp)
 
 
-def get_args_subscribed(tp: type) -> Tuple:
+def get_args_subscribed(tp: type):  # type: ignore
     """Get type arguments with all substitutions performed. Supports subscripted generics having __origin__"""
     return tuple(
         remap_type(arg if not hasattr(arg, "__origin__") else arg.__origin__)

--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -1509,7 +1509,9 @@ class QdrantRemote(QdrantBase):
                 ).result
             ]
         else:
-            result: Optional[types.UpdateResult] = self.openapi_client.points_api.batch_update(
+            result: Optional[
+                List[types.UpdateResult]
+            ] = self.openapi_client.points_api.batch_update(
                 collection_name=collection_name,
                 wait=wait,
                 ordering=ordering,


### PR DESCRIPTION
IDE used to highlight types after using `get_args_subscribed`