### PR TITLE
new: add multithreading for local mode in Linux

### DIFF
--- a/qdrant_client/local/local_collection.py
+++ b/qdrant_client/local/local_collection.py
@@ -1,4 +1,3 @@
-import re
 import uuid
 from collections import OrderedDict, defaultdict
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union, get_args

--- a/qdrant_client/local/persistence.py
+++ b/qdrant_client/local/persistence.py
@@ -89,7 +89,7 @@ class CollectionPersistence:
                 self.__class__.CHECK_SAME_THREAD = threadsafe != "THREADSAFE=1"
 
         self.storage = sqlite3.connect(
-            str(self.location), check_same_thread=self.CHECK_SAME_THREAD
+            str(self.location), check_same_thread=self.CHECK_SAME_THREAD  # type: ignore
         )
 
         self._ensure_table()


### PR DESCRIPTION
Local mode uses SQLite under the hood
In some cases SQLite is not threadsafe, it depends on the `THREADSAFE` variable.

https://sqlite.org/compile.html#threadsafe

By default sqlite is threadsafe on linux.
This PR suggests to allow to use local mode in a multithreading environment when THREADSAFE==1 

Previously mentioned in 

#329 #369

