### PR TITLE
fix httpx deprecation warning

### DIFF
--- a/qdrant_client/http/api_client.py
+++ b/qdrant_client/http/api_client.py
@@ -70,6 +70,7 @@ class ApiClient:
         if path_params is None:
             path_params = {}
         url = (self.host or "") + url.format(**path_params)
+        kwargs["content"] = kwargs.pop("data", None)
         request = self._client.build_request(method, url, **kwargs)
         return self.send(request, type_)
 
@@ -142,6 +143,7 @@ class AsyncApiClient:
         if path_params is None:
             path_params = {}
         url = (self.host or "") + url.format(**path_params)
+        kwargs["content"] = kwargs.pop("data", None)
         request = self._async_client.build_request(method, url, **kwargs)
         return await self.send(request, type_)
 


### PR DESCRIPTION
httpx has a deprecation warning that prefer content over data. here is a quick fix to avoid modify all files of building requests

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?