### PR TITLE
fix: do not try to close none objects in local mode

### DIFF
--- a/qdrant_client/local/async_qdrant_local.py
+++ b/qdrant_client/local/async_qdrant_local.py
@@ -65,7 +65,12 @@ class AsyncQdrantLocal(AsyncQdrantBase):
     async def close(self, **kwargs: Any) -> None:
         self._closed = True
         for collection in self.collections.values():
-            collection.close()
+            if collection is not None:
+                collection.close()
+            else:
+                logging.warning(
+                    f"Collection appears to be None before closing. The existing collections are: {list(self.collections.keys())}"
+                )
         if self._flock_file is not None:
             portalocker.unlock(self._flock_file)
 

--- a/qdrant_client/local/qdrant_local.py
+++ b/qdrant_client/local/qdrant_local.py
@@ -54,7 +54,13 @@ class QdrantLocal(QdrantBase):
     def close(self, **kwargs: Any) -> None:
         self._closed = True
         for collection in self.collections.values():
-            collection.close()
+            if collection is not None:
+                collection.close()
+            else:
+                logging.warning(
+                    f"Collection appears to be None before closing. The existing collections are: "
+                    f"{list(self.collections.keys())}"
+                )
         if self._flock_file is not None:
             portalocker.unlock(self._flock_file)
 


### PR DESCRIPTION
#365 

I haven't been able to reproduce this issue, despite trying all the code samples from the issue and some modifications from my side.

It is a workaround to replace an annoying exception with an annoying log message, more informative one (hopefully)