### PR TITLE
fix: fix portalocker being deleted before closing the client

### DIFF
--- a/qdrant_client/local/async_qdrant_local.py
+++ b/qdrant_client/local/async_qdrant_local.py
@@ -72,7 +72,10 @@ class AsyncQdrantLocal(AsyncQdrantBase):
                     f"Collection appears to be None before closing. The existing collections are: {list(self.collections.keys())}"
                 )
         if self._flock_file is not None:
-            portalocker.unlock(self._flock_file)
+            try:
+                portalocker.unlock(self._flock_file)
+            except TypeError:
+                pass
 
     def _load(self) -> None:
         if not self.persistent:

--- a/qdrant_client/local/qdrant_local.py
+++ b/qdrant_client/local/qdrant_local.py
@@ -66,7 +66,7 @@ class QdrantLocal(QdrantBase):
                 portalocker.unlock(self._flock_file)
             except (
                 TypeError
-            ):  # sometimes portalocker module can be deleted even before qdrant local instance
+            ):  # sometimes portalocker module can be garbage collected before QdrantLocal instance
                 pass
 
     def _load(self) -> None:

--- a/qdrant_client/local/qdrant_local.py
+++ b/qdrant_client/local/qdrant_local.py
@@ -62,7 +62,12 @@ class QdrantLocal(QdrantBase):
                     f"{list(self.collections.keys())}"
                 )
         if self._flock_file is not None:
-            portalocker.unlock(self._flock_file)
+            try:
+                portalocker.unlock(self._flock_file)
+            except (
+                TypeError
+            ):  # sometimes portalocker module can be deleted even before qdrant local instance
+                pass
 
     def _load(self) -> None:
         if not self.persistent:

--- a/qdrant_client/local/qdrant_local.py
+++ b/qdrant_client/local/qdrant_local.py
@@ -64,9 +64,8 @@ class QdrantLocal(QdrantBase):
         if self._flock_file is not None:
             try:
                 portalocker.unlock(self._flock_file)
-            except (
-                TypeError
-            ):  # sometimes portalocker module can be garbage collected before QdrantLocal instance
+            except TypeError:  # sometimes portalocker module can be garbage collected before
+                # QdrantLocal instance
                 pass
 
     def _load(self) -> None:


### PR DESCRIPTION
Sometimes portalocker module being deleted even before deletion of QdrantLocal

In this case when `__del__` method in QdrantClient being called, we can already don't have portalocker object and calling unlock on it will cause an error `NoneType...` https://github.com/qdrant/qdrant-client/issues/365