### PR TITLE
Fix Vector Count Mismatch during Client Migration #403

### DIFF
--- a/qdrant_client/migrate/migrate.py
+++ b/qdrant_client/migrate/migrate.py
@@ -106,6 +106,7 @@ def _migrate_collection(
     dest_client: QdrantBase,
     collection_name: str,
     batch_size: int = 100,
+    wait: bool = True,
 ) -> None:
     """Migrate collection from source client to destination client
 
@@ -116,12 +117,12 @@ def _migrate_collection(
         batch_size (int, optional): Batch size for scrolling and uploading vectors. Defaults to 100.
     """
     records, next_offset = source_client.scroll(collection_name, limit=2, with_vectors=True)
-    dest_client.upload_records(collection_name, records)
+    dest_client.upload_records(collection_name, records, wait=True)
     while next_offset is not None:
         records, next_offset = source_client.scroll(
             collection_name, offset=next_offset, limit=batch_size, with_vectors=True
         )
-        dest_client.upload_records(collection_name, records, wait=True)
+        dest_client.upload_records(collection_name, records, wait=wait)
     source_client_vectors_count = source_client.get_collection(collection_name).vectors_count
     dest_client_vectors_count = dest_client.get_collection(collection_name).vectors_count
     assert (

--- a/qdrant_client/migrate/migrate.py
+++ b/qdrant_client/migrate/migrate.py
@@ -121,7 +121,7 @@ def _migrate_collection(
         records, next_offset = source_client.scroll(
             collection_name, offset=next_offset, limit=batch_size, with_vectors=True
         )
-        dest_client.upload_records(collection_name, records, wait=wait)
+        dest_client.upload_records(collection_name, records, wait=True)
     source_client_vectors_count = source_client.get_collection(collection_name).vectors_count
     dest_client_vectors_count = dest_client.get_collection(collection_name).vectors_count
     assert (

--- a/qdrant_client/migrate/migrate.py
+++ b/qdrant_client/migrate/migrate.py
@@ -106,7 +106,6 @@ def _migrate_collection(
     dest_client: QdrantBase,
     collection_name: str,
     batch_size: int = 100,
-    wait: bool = True,
 ) -> None:
     """Migrate collection from source client to destination client
 


### PR DESCRIPTION
# Client Migration Fix

Resolve vector count mismatch during client migration. The problem was due to missing `<wait=True>` in the `<upload_records>` calls. This commit adds `<wait=True>` to ensure proper synchronization and resolves the vector count mismatch.

### All Submissions:

* [x] Contributions should target the `dev` branch. (Yes, created branch from `dev`)
* [x] Have you followed the guidelines in our Contributing document? (Yes)
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you installed `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them? (Yes, explanation included in the commit message)
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

