### PR TITLE
fix: Add document type validation in Fastembed and update test case.

### DIFF
--- a/qdrant_client/async_qdrant_fastembed.py
+++ b/qdrant_client/async_qdrant_fastembed.py
@@ -240,7 +240,7 @@ class AsyncQdrantFastembedMixin(AsyncQdrantBase):
             collection_name (str):
                 Name of the collection to add documents to.
             documents (Iterable[str]):
-                List of documents to embed and add to the collection.
+                List of documents to embed and add to the collection, as strings.
             metadata (Iterable[Dict[str, Any]], optional):
                 List of metadata dicts. Defaults to None.
             ids (Iterable[models.ExtendedPointId], optional):
@@ -275,6 +275,7 @@ class AsyncQdrantFastembedMixin(AsyncQdrantBase):
                 collection_name=collection_name, vectors_config=self.get_fastembed_vector_params()
             )
             collection_info = await self.get_collection(collection_name=collection_name)
+        assert all((isinstance(doc, str) for doc in documents)), "Documents must be strings"
         assert isinstance(
             collection_info.config.params.vectors, dict
         ), f"Collection have incompatible vector params: {collection_info.config.params.vectors}"

--- a/qdrant_client/qdrant_fastembed.py
+++ b/qdrant_client/qdrant_fastembed.py
@@ -244,7 +244,7 @@ class QdrantFastembedMixin(QdrantBase):
             collection_name (str):
                 Name of the collection to add documents to.
             documents (Iterable[str]):
-                List of documents to embed and add to the collection.
+                List of documents to embed and add to the collection, as strings.
             metadata (Iterable[Dict[str, Any]], optional):
                 List of metadata dicts. Defaults to None.
             ids (Iterable[models.ExtendedPointId], optional):
@@ -285,6 +285,9 @@ class QdrantFastembedMixin(QdrantBase):
                 vectors_config=self.get_fastembed_vector_params(),
             )
             collection_info = self.get_collection(collection_name=collection_name)
+
+        # Check if documents only contain strings.
+        assert all(isinstance(doc, str) for doc in documents), "Documents must be strings"
 
         # Check if collection has compatible vector params
         assert isinstance(

--- a/tests/test_fast_embed.py
+++ b/tests/test_fast_embed.py
@@ -8,7 +8,7 @@ from qdrant_client import QdrantClient
 def test_add_without_query(
     local_client: QdrantClient = QdrantClient(":memory:"),
     collection_name: str = "demo_collection",
-    docs: List[str] = None,
+    docs: List[Any] = None,
 ):
     if docs is None:
         docs = [
@@ -21,6 +21,11 @@ def test_add_without_query(
 
     local_client.add(collection_name=collection_name, documents=docs)
     assert local_client.count(collection_name).count == 2
+
+    # Query with invalid document type
+    with pytest.raises(AssertionError, match="Documents must be strings"):
+        docs = [{"source": "Qdrant also has Llama Index integrations"}, 00000, 99999]
+        local_client.add(collection_name=collection_name, documents=docs)
 
 
 def test_no_install(


### PR DESCRIPTION
* [x] Add document type validation to Fastembed as it only supports strings.
* [x] Update test case.


