### PR TITLE
Add missing import statements for clarity in 'Get Started' documentat…

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,6 +34,8 @@ Create a new collection
 
 .. code-block:: python
 
+   from qdrant_client.models import VectorParams, Distance
+
    client.recreate_collection(
       collection_name="my_collection",
       vectors_config=VectorParams(size=100, distance=Distance.COSINE),


### PR DESCRIPTION

Addresses issue #475 by adding import statements (`from qdrant_client.models import VectorParams, Distance`) to the code example in the 'Get Started' documentation. This enhances clarity for first-time users. Feel free to review and provide feedback. Thank you!