### PR TITLE
refactor: use list_supported_models() from FastEmbed

### DIFF
--- a/qdrant_client/async_qdrant_fastembed.py
+++ b/qdrant_client/async_qdrant_fastembed.py
@@ -23,14 +23,14 @@ try:
     from fastembed import TextEmbedding
 except ImportError:
     TextEmbedding = None
-SUPPORTED_EMBEDDING_MODELS: Dict[str, Tuple[int, models.Distance]] = {
-    "BAAI/bge-base-en": (768, models.Distance.COSINE),
-    "sentence-transformers/all-MiniLM-L6-v2": (384, models.Distance.COSINE),
-    "BAAI/bge-small-en": (384, models.Distance.COSINE),
-    "BAAI/bge-small-en-v1.5": (384, models.Distance.COSINE),
-    "BAAI/bge-base-en-v1.5": (768, models.Distance.COSINE),
-    "intfloat/multilingual-e5-large": (1024, models.Distance.COSINE),
-}
+SUPPORTED_EMBEDDING_MODELS: Dict[str, Tuple[int, models.Distance]] = (
+    {
+        model["model"]: (model["dim"], models.Distance.COSINE)
+        for model in TextEmbedding.list_supported_models()
+    }
+    if TextEmbedding
+    else {}
+)
 _DEPRECATED_MODELS = {"BAAI/bge-base-en", "BAAI/bge-small-en"}
 
 

--- a/qdrant_client/qdrant_fastembed.py
+++ b/qdrant_client/qdrant_fastembed.py
@@ -14,14 +14,14 @@ except ImportError:
     TextEmbedding = None
 
 
-SUPPORTED_EMBEDDING_MODELS: Dict[str, Tuple[int, models.Distance]] = {
-    "BAAI/bge-base-en": (768, models.Distance.COSINE),
-    "sentence-transformers/all-MiniLM-L6-v2": (384, models.Distance.COSINE),
-    "BAAI/bge-small-en": (384, models.Distance.COSINE),
-    "BAAI/bge-small-en-v1.5": (384, models.Distance.COSINE),
-    "BAAI/bge-base-en-v1.5": (768, models.Distance.COSINE),
-    "intfloat/multilingual-e5-large": (1024, models.Distance.COSINE),
-}
+SUPPORTED_EMBEDDING_MODELS: Dict[str, Tuple[int, models.Distance]] = (
+    {
+        model["model"]: (model["dim"], models.Distance.COSINE)
+        for model in TextEmbedding.list_supported_models()
+    }
+    if TextEmbedding
+    else {}
+)
 
 _DEPRECATED_MODELS = {
     "BAAI/bge-base-en",


### PR DESCRIPTION
### Description

To be merged into the `upgrade-fastembed-version` branch. #493.

Updates `qdrant_fastembed.py` and `async_qdrant_fastembed.py` to use `list_supported_models()` from FastEmbed to set the `SUPPORTED_MODELS` value.

Resolves https://github.com/qdrant/fastembed/issues/95.

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you installed `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`?
