### PR TITLE
remove deprecated field conversions

### DIFF
--- a/qdrant_client/conversions/conversion.py
+++ b/qdrant_client/conversions/conversion.py
@@ -1120,9 +1120,6 @@ class GrpcToRest:
                     shard_key=shard_key_selector,
                 )
             )
-        # TODO: remove deprecated field in v1.8.0
-        elif name == "delete_deprecated":
-            return rest.DeleteOperation(delete=cls.convert_points_selector(val))
         elif name == "delete_points":
             shard_key_selector = (
                 val.shard_key_selector if val.HasField("shard_key_selector") else None
@@ -1206,9 +1203,6 @@ class GrpcToRest:
                     filter=filter_,
                 )
             )
-        # TODO: remove deprecated field in v1.8.0
-        elif name == "clear_payload_deprecated":
-            return rest.ClearPayloadOperation(clear_payload=cls.convert_points_selector(val))
         elif name == "clear_payload":
             shard_key_selector = (
                 val.shard_key_selector if val.HasField("shard_key_selector") else None
@@ -2527,8 +2521,6 @@ class RestToGrpc:
             )
             return grpc.PointsUpdateOperation(
                 delete_points=delete_points,
-                # TODO: remove deprecated field in v1.8.0
-                delete_deprecated=points_selector,
             )
         elif isinstance(model, rest.SetPayloadOperation):
             if model.set_payload.points:
@@ -2610,8 +2602,6 @@ class RestToGrpc:
             )
             return grpc.PointsUpdateOperation(
                 clear_payload=clear_payload,
-                # TODO: remove deprecated field in v1.8.0
-                clear_payload_deprecated=points_selector,
             )
         elif isinstance(model, rest.UpdateVectorsOperation):
             shard_key_selector = (

--- a/tests/conversions/fixtures.py
+++ b/tests/conversions/fixtures.py
@@ -756,14 +756,10 @@ upsert_operation = grpc.PointsUpdateOperation(
 
 delete_operation_1 = grpc.PointsUpdateOperation(
     delete_points=grpc.PointsUpdateOperation.DeletePoints(points=points_selector_list),
-    # TODO: remove deprecated field in v1.8.0
-    delete_deprecated=points_selector_list,
 )
 
 delete_operation_2 = grpc.PointsUpdateOperation(
     delete_points=grpc.PointsUpdateOperation.DeletePoints(points=points_selector_filter),
-    # TODO: remove deprecated field in v1.8.0
-    delete_deprecated=points_selector_filter,
 )
 
 set_payload_operation_1 = grpc.PointsUpdateOperation(
@@ -810,14 +806,10 @@ delete_payload_operation_2 = grpc.PointsUpdateOperation(
 
 clear_payload_operation_1 = grpc.PointsUpdateOperation(
     clear_payload=grpc.PointsUpdateOperation.ClearPayload(points=points_selector_list),
-    # TODO: remove deprecated field in v1.8.0
-    clear_payload_deprecated=points_selector_list,
 )
 
 clear_payload_operation_2 = grpc.PointsUpdateOperation(
     clear_payload=grpc.PointsUpdateOperation.ClearPayload(points=points_selector_filter),
-    # TODO: remove deprecated field in v1.8.0
-    clear_payload_deprecated=points_selector_filter,
 )
 
 update_vectors_operation = grpc.PointsUpdateOperation(


### PR DESCRIPTION
For client Qdrant 1.8, we no longer need to support both deprecated and undeprecated fields, so this PRs removes these extra conversions.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you installed `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
