### PR TITLE
Fix for close() method of QdrantLocal class

### DIFF
--- a/qdrant_client/local/qdrant_local.py
+++ b/qdrant_client/local/qdrant_local.py
@@ -76,6 +76,7 @@ class QdrantLocal(QdrantBase):
         if self._flock_file is not None:
             try:
                 portalocker.unlock(self._flock_file)
+                self._flock_file.close()
             except TypeError:  # sometimes portalocker module can be garbage collected before
                 # QdrantLocal instance
                 pass


### PR DESCRIPTION
When the close() method of the QdrantLocal class is called, it should also close() the file 'self._flock_file'.

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
