### PR TITLE
Break out of retry loop upon successful upsert

### DIFF
--- a/qdrant_client/uploader/grpc_uploader.py
+++ b/qdrant_client/uploader/grpc_uploader.py
@@ -45,6 +45,7 @@ def upload_batch_grpc(
                     else None,
                 )
             )
+            break
         except Exception as e:
             logging.warning(f"Batch upload failed {attempt + 1} times. Retrying...")
 

--- a/qdrant_client/uploader/rest_uploader.py
+++ b/qdrant_client/uploader/rest_uploader.py
@@ -39,6 +39,7 @@ def upload_batch(
                 point_insert_operations=PointsList(points=points, shard_key=shard_key_selector),
                 wait=wait,
             )
+            break
         except Exception as e:
             logging.warning(f"Batch upload failed {attempt + 1} times. Retrying...")
 


### PR DESCRIPTION
### All Submissions:

* [ X ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ X ] Have you followed the guidelines in our Contributing document?
* [ X ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Discussion:

The current retry logic in the uploader code invokes the upsert operation `max_retries` times, regardless of whether the request succeeds or fails. Then, an exception is raised if the last of the attempts fails. The code should instead `break` upon a successful request and `return True`.