### PR TITLE
fix: fix QueryVector isinstance check in local mode

### DIFF
--- a/qdrant_client/conversions/common_types.py
+++ b/qdrant_client/conversions/common_types.py
@@ -30,8 +30,15 @@ def remap_type(tp: type) -> type:
     return typing_remap.get(tp, tp)
 
 
-def get_args_subscribed(tp: type):  # type: ignore
-    """Get type arguments with all substitutions performed. Supports subscripted generics having __origin__"""
+def get_args_subscribed(tp):  # type: ignore
+    """Get type arguments with all substitutions performed. Supports subscripted generics having __origin__
+
+    Args:
+        tp: type to get arguments from. Can be either a type or a subscripted generic
+
+    Returns:
+        tuple of type arguments
+    """
     return tuple(
         remap_type(arg if not hasattr(arg, "__origin__") else arg.__origin__)
         for arg in get_args(tp)

--- a/qdrant_client/local/distances.py
+++ b/qdrant_client/local/distances.py
@@ -40,7 +40,7 @@ class ContextQuery:
         self.context_pairs = context_pairs
 
 
-QueryVector = Union[DiscoveryQuery, ContextQuery, RecoQuery, types.NumpyArray, SparseVector]
+QueryVector = Union[DiscoveryQuery, ContextQuery, RecoQuery, SparseVector]
 
 
 class DistanceOrder(str, Enum):

--- a/qdrant_client/local/distances.py
+++ b/qdrant_client/local/distances.py
@@ -40,7 +40,7 @@ class ContextQuery:
         self.context_pairs = context_pairs
 
 
-QueryVector = Union[DiscoveryQuery, ContextQuery, RecoQuery, SparseVector]
+QueryVector = Union[DiscoveryQuery, ContextQuery, RecoQuery, types.NumpyArray, SparseVector]
 
 
 class DistanceOrder(str, Enum):

--- a/qdrant_client/local/local_collection.py
+++ b/qdrant_client/local/local_collection.py
@@ -9,6 +9,7 @@ from pydantic.version import VERSION as PYDANTIC_VERSION
 from qdrant_client import grpc as grpc
 from qdrant_client._pydantic_compat import construct
 from qdrant_client.conversions import common_types as types
+from qdrant_client.conversions.common_types import get_args_subscribed
 from qdrant_client.conversions.conversion import GrpcToRest
 from qdrant_client.http import models
 from qdrant_client.http.models.models import Distance, ExtendedPointId, SparseVector
@@ -184,8 +185,8 @@ class LocalCollection:
             QueryVector,
             Tuple[str, QueryVector],
         ],
-    ) -> Tuple[str, Union[types.NumpyArray, QueryVector]]:
-        vector: Union[QueryVector, types.NumpyArray]
+    ) -> Tuple[str, QueryVector]:
+        vector: QueryVector
         if isinstance(query_vector, tuple):
             name, query = query_vector
             if isinstance(query, list):
@@ -201,10 +202,7 @@ class LocalCollection:
         elif isinstance(query_vector, list):
             name = DEFAULT_VECTOR_NAME
             vector = np.array(query_vector)
-        elif isinstance(query_vector, np.ndarray):
-            name = DEFAULT_VECTOR_NAME
-            vector = query_vector
-        elif isinstance(query_vector, get_args(QueryVector)):
+        elif isinstance(query_vector, get_args_subscribed(QueryVector)):
             name = DEFAULT_VECTOR_NAME
             vector = query_vector
         else:

--- a/qdrant_client/local/local_collection.py
+++ b/qdrant_client/local/local_collection.py
@@ -9,7 +9,7 @@ from pydantic.version import VERSION as PYDANTIC_VERSION
 from qdrant_client import grpc as grpc
 from qdrant_client._pydantic_compat import construct
 from qdrant_client.conversions import common_types as types
-from qdrant_client.conversions.common_types import Vector
+from qdrant_client.conversions.common_types import get_args_subscribed
 from qdrant_client.conversions.conversion import GrpcToRest
 from qdrant_client.http import models
 from qdrant_client.http.models.models import Distance, ExtendedPointId, SparseVector
@@ -205,7 +205,7 @@ class LocalCollection:
         elif isinstance(query_vector, np.ndarray):
             name = DEFAULT_VECTOR_NAME
             vector = query_vector
-        elif isinstance(query_vector, get_args(QueryVector)):
+        elif isinstance(query_vector, get_args_subscribed(QueryVector)):
             name = DEFAULT_VECTOR_NAME
             vector = query_vector
         else:

--- a/qdrant_client/local/local_collection.py
+++ b/qdrant_client/local/local_collection.py
@@ -9,7 +9,6 @@ from pydantic.version import VERSION as PYDANTIC_VERSION
 from qdrant_client import grpc as grpc
 from qdrant_client._pydantic_compat import construct
 from qdrant_client.conversions import common_types as types
-from qdrant_client.conversions.common_types import get_args_subscribed
 from qdrant_client.conversions.conversion import GrpcToRest
 from qdrant_client.http import models
 from qdrant_client.http.models.models import Distance, ExtendedPointId, SparseVector
@@ -185,8 +184,8 @@ class LocalCollection:
             QueryVector,
             Tuple[str, QueryVector],
         ],
-    ) -> Tuple[str, QueryVector]:
-        vector: QueryVector
+    ) -> Tuple[str, Union[types.NumpyArray, QueryVector]]:
+        vector: Union[QueryVector, types.NumpyArray]
         if isinstance(query_vector, tuple):
             name, query = query_vector
             if isinstance(query, list):
@@ -205,7 +204,7 @@ class LocalCollection:
         elif isinstance(query_vector, np.ndarray):
             name = DEFAULT_VECTOR_NAME
             vector = query_vector
-        elif isinstance(query_vector, get_args_subscribed(QueryVector)):
+        elif isinstance(query_vector, get_args(QueryVector)):
             name = DEFAULT_VECTOR_NAME
             vector = query_vector
         else:

--- a/tests/congruence_tests/test_search.py
+++ b/tests/congruence_tests/test_search.py
@@ -1,6 +1,7 @@
 from typing import List
 
 import numpy as np
+import pytest
 
 from qdrant_client.client_base import QdrantBase
 from qdrant_client.http.models import models
@@ -318,3 +319,20 @@ def test_search_with_persistence_and_skipped_vectors():
             except AssertionError as e:
                 print(f"\nFailed with filter {query_filter}")
                 raise e
+
+
+def test_search_invalid_vector_type():
+    fixture_points = generate_fixtures()
+
+    local_client = init_local()
+    init_client(local_client, fixture_points)
+
+    remote_client = init_remote()
+    init_client(remote_client, fixture_points)
+
+    vector_invalid_type = {"text": [1, 2, 3, 4]}
+    with pytest.raises(ValueError):
+        local_client.search(collection_name=COLLECTION_NAME, query_vector=vector_invalid_type)
+
+    with pytest.raises(ValueError):
+        remote_client.search(collection_name=COLLECTION_NAME, query_vector=vector_invalid_type)


### PR DESCRIPTION
if we pass unexpected type to search, check `isinstance(query_vector, QueryVector)` fails when it gets to numpy arrays