### PR TITLE
Remove `async` from `sparse_embedding_model_name` property

### DIFF
--- a/qdrant_client/async_qdrant_fastembed.py
+++ b/qdrant_client/async_qdrant_fastembed.py
@@ -66,7 +66,7 @@ class AsyncQdrantFastembedMixin(AsyncQdrantBase):
         return self._embedding_model_name
 
     @property
-    async def sparse_embedding_model_name(self) -> Optional[str]:
+    def sparse_embedding_model_name(self) -> Optional[str]:
         return self._sparse_embedding_model_name
 
     def set_model(

--- a/tools/async_client_generator/fastembed_generator.py
+++ b/tools/async_client_generator/fastembed_generator.py
@@ -57,6 +57,7 @@ if __name__ == "__main__":
             "get_vector_field_name",
             "get_fastembed_vector_params",
             "embedding_model_name",
+            "sparse_embedding_model_name",
         ],
         class_replace_map={
             "QdrantBase": "AsyncQdrantBase",


### PR DESCRIPTION
Remove async from sparse_embedding_model_name property

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

Prevents:

```
ValueError: Unsupported embedding model: <coroutine object AsyncQdrantFastembedMixin.sparse_embedding_model_name at 0x7f7f0e863d00>. Supported models: {'prithvida/Splade_PP_en_v1': {'model': 'prithvida/Splade_PP_en_v1', 'vocab_size': 30522, 'description': 'Misspelled version of the model. Retained for backward compatibility. Independent Implementation of SPLADE++ Model for English', 'size_in_GB': 0.532, 'sources': {'hf': 'Qdrant/SPLADE_PP_en_v1'}}, 'prithivida/Splade_PP_en_v1': {'model': 'prithivida/Splade_PP_en_v1', 'vocab_size': 30522, 'description': 'Independent Implementation of SPLADE++ Model for English', 'size_in_GB': 0.532, 'sources': {'hf': 'Qdrant/SPLADE_PP_en_v1'}}}
```