### PR TITLE
Fix local mode geo box for antimeridian crossing

### DIFF
--- a/qdrant_client/local/payload_filters.py
+++ b/qdrant_client/local/payload_filters.py
@@ -64,9 +64,19 @@ def check_geo_bounding_box(condition: models.GeoBoundingBox, values: Any) -> boo
         lat = values["lat"]
         lon = values["lon"]
 
+        # handle anti-meridian crossing case
+        if condition.top_left.lon > condition.bottom_right.lon:
+            longitude_condition = (
+                (condition.top_left.lon <= lon <= 180 or -180 <= lon <= condition.bottom_right.lon)
+            )
+        else:
+            longitude_condition = (condition.top_left.lon <= lon <= condition.bottom_right.lon)
+
+        latitude_condition = condition.top_left.lat >= lat >= condition.bottom_right.lat
+
         return (
-            condition.top_left.lat >= lat >= condition.bottom_right.lat
-            and condition.top_left.lon <= lon <= condition.bottom_right.lon
+            longitude_condition
+            and latitude_condition
         )
 
     return False


### PR DESCRIPTION
Our congruence tests are broken since we fixed our implementation on the server side for geo bounding box crossing the antimeridian https://github.com/qdrant/qdrant/pull/4103

This PR propagates the fix to the local mode to fix our congruence tests.