### PR TITLE
fix: QdrantClient __init__ docstring

### DIFF
--- a/qdrant_client/async_qdrant_client.py
+++ b/qdrant_client/async_qdrant_client.py
@@ -57,7 +57,7 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
 
     Args:
         location:
-            If `:memory:` - use in-memory Qdrant instance.
+            If `":memory:"` - use in-memory Qdrant instance.
             If `str` - use it as a `url` parameter.
             If `None` - use default values for `host` and `port`.
         url: either host or str of "Optional[scheme], host, Optional[port], Optional[prefix]".

--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -47,7 +47,7 @@ class QdrantClient(QdrantFastembedMixin):
 
     Args:
         location:
-            If `:memory:` - use in-memory Qdrant instance.
+            If `":memory:"` - use in-memory Qdrant instance.
             If `str` - use it as a `url` parameter.
             If `None` - use default values for `host` and `port`.
         url: either host or str of "Optional[scheme], host, Optional[port], Optional[prefix]".


### PR DESCRIPTION
## NOW
<img width="897" alt="Screenshot 2024-05-02 at 10 22 25 PM" src="https://github.com/qdrant/qdrant-client/assets/46051506/1d7426e8-bc74-41f0-9b6c-b8396e2d3d15">

## AFTER THIS PATCH
<img width="897" alt="Screenshot 2024-05-02 at 10 21 47 PM" src="https://github.com/qdrant/qdrant-client/assets/46051506/76594e5d-9b47-41be-8e7a-e2b2e2a20567">
