### PR TITLE
Bump to `v1.10.0-dev`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qdrant-client"
-version = "1.4.0"
+version = "1.10.0-dev"
 description = "Client library for the Qdrant vector search engine"
 authors = ["Andrey Vasnetsov <andrey@qdrant.tech>"]
 packages = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qdrant-client"
-version = "1.10.0-dev"
+version = "1.10.2-dev"
 description = "Client library for the Qdrant vector search engine"
 authors = ["Andrey Vasnetsov <andrey@qdrant.tech>"]
 packages = [

--- a/tools/DEVELOPMENT.md
+++ b/tools/DEVELOPMENT.md
@@ -3,7 +3,7 @@
 For breaking changes:
 
 * [ ] Create a new branch from the branch of upcoming release.
-  * E.g. `git checkout v0.7.0 && git pull && git checkout -b v0.7.0-my-changees`
+  * E.g. `git checkout v0.7.0 && git pull && git checkout -b v0.7.0-my-changes`
 
 For fixes:
 


### PR DESCRIPTION
Bumps the poetry dev version to 1.10.0-dev, from 1.4.0. In the same way that we do for the core repo