### PR TITLE
new: update query signature, id type and return type

### DIFF
--- a/qdrant_client/async_client_base.py
+++ b/qdrant_client/async_client_base.py
@@ -69,15 +69,14 @@ class AsyncQdrantBase:
 
     async def query_batch_points(
         self, collection_name: str, requests: Sequence[types.QueryRequest], **kwargs: Any
-    ) -> List[List[types.ScoredPoint]]:
+    ) -> List[types.QueryResponse]:
         raise NotImplementedError()
 
     async def query_points(
         self,
         collection_name: str,
         query: Union[
-            int,
-            str,
+            types.PointId,
             List[float],
             List[List[float]],
             types.SparseVector,
@@ -97,7 +96,7 @@ class AsyncQdrantBase:
         score_threshold: Optional[float] = None,
         lookup_from: Optional[types.LookupLocation] = None,
         **kwargs: Any,
-    ) -> List[types.ScoredPoint]:
+    ) -> types.QueryResponse:
         raise NotImplementedError()
 
     async def recommend_batch(

--- a/qdrant_client/async_qdrant_client.py
+++ b/qdrant_client/async_qdrant_client.py
@@ -341,7 +341,7 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
         consistency: Optional[types.ReadConsistency] = None,
         timeout: Optional[int] = None,
         **kwargs: Any,
-    ) -> List[List[types.ScoredPoint]]:
+    ) -> List[types.QueryResponse]:
         """Perform any search, recommend, discovery, context search operations in batch, and mitigate network overhead
 
         Args:
@@ -373,8 +373,7 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
         self,
         collection_name: str,
         query: Union[
-            int,
-            str,
+            types.PointId,
             List[float],
             List[List[float]],
             types.SparseVector,
@@ -397,7 +396,7 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
         shard_key_selector: Optional[types.ShardKeySelector] = None,
         timeout: Optional[int] = None,
         **kwargs: Any,
-    ) -> List[types.ScoredPoint]:
+    ) -> types.QueryResponse:
         """Universal endpoint to run any available operation, such as search, recommendation, discovery, context search.
 
         Args:
@@ -481,7 +480,7 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
             )
 
         Returns:
-            List of found close points with similarity scores.
+            QueryResponse structure containing list of found close points with similarity scores.
         """
         assert len(kwargs) == 0, f"Unknown arguments: {list(kwargs.keys())}"
         (using, query, prefetch) = self._resolve_query_to_embedding_embeddings_and_prefetch(

--- a/qdrant_client/client_base.py
+++ b/qdrant_client/client_base.py
@@ -65,15 +65,14 @@ class QdrantBase:
         collection_name: str,
         requests: Sequence[types.QueryRequest],
         **kwargs: Any,
-    ) -> List[List[types.ScoredPoint]]:
+    ) -> List[types.QueryResponse]:
         raise NotImplementedError()
 
     def query_points(
         self,
         collection_name: str,
         query: Union[
-            int,
-            str,
+            types.PointId,
             List[float],
             List[List[float]],
             types.SparseVector,
@@ -93,7 +92,7 @@ class QdrantBase:
         score_threshold: Optional[float] = None,
         lookup_from: Optional[types.LookupLocation] = None,
         **kwargs: Any,
-    ) -> List[types.ScoredPoint]:
+    ) -> types.QueryResponse:
         raise NotImplementedError()
 
     def recommend_batch(

--- a/qdrant_client/conversions/common_types.py
+++ b/qdrant_client/conversions/common_types.py
@@ -118,6 +118,7 @@ WriteOrdering: TypeAlias = rest.WriteOrdering
 WithLookupInterface: TypeAlias = rest.WithLookupInterface
 
 GroupsResult: TypeAlias = rest.GroupsResult
+QueryResponse: TypeAlias = rest.QueryResponse
 
 # we can't use `nptyping` package due to numpy/python-version incompatibilities
 # thus we need to define precise type annotations while we support python3.7

--- a/qdrant_client/local/async_qdrant_local.py
+++ b/qdrant_client/local/async_qdrant_local.py
@@ -241,7 +241,7 @@ class AsyncQdrantLocal(AsyncQdrantBase):
         score_threshold: Optional[float] = None,
         lookup_from: Optional[types.LookupLocation] = None,
         **kwargs: Any,
-    ) -> List[types.ScoredPoint]:
+    ) -> types.QueryResponse:
         collection = self._get_collection(collection_name)
         return collection.query_points(
             query=query,
@@ -261,7 +261,7 @@ class AsyncQdrantLocal(AsyncQdrantBase):
 
     async def query_batch_points(
         self, collection_name: str, requests: Sequence[types.QueryRequest], **kwargs: Any
-    ) -> List[List[types.ScoredPoint]]:
+    ) -> List[types.QueryResponse]:
         collection = self._get_collection(collection_name)
         return [
             collection.query_points(

--- a/qdrant_client/local/local_collection.py
+++ b/qdrant_client/local/local_collection.py
@@ -666,7 +666,7 @@ class LocalCollection:
         lookup_from_collection: Optional["LocalCollection"] = None,
         lookup_from_vector_name: Optional[str] = None,
         **kwargs: Any,
-    ) -> List[types.ScoredPoint]:
+    ) -> types.QueryResponse:
         raise NotImplementedError()
 
     def search_groups(

--- a/qdrant_client/local/qdrant_local.py
+++ b/qdrant_client/local/qdrant_local.py
@@ -259,7 +259,7 @@ class QdrantLocal(QdrantBase):
         score_threshold: Optional[float] = None,
         lookup_from: Optional[types.LookupLocation] = None,
         **kwargs: Any,
-    ) -> List[types.ScoredPoint]:
+    ) -> types.QueryResponse:
         collection = self._get_collection(collection_name)
         return collection.query_points(
             query=query,
@@ -282,7 +282,7 @@ class QdrantLocal(QdrantBase):
         collection_name: str,
         requests: Sequence[types.QueryRequest],
         **kwargs: Any,
-    ) -> List[List[types.ScoredPoint]]:
+    ) -> List[types.QueryResponse]:
         collection = self._get_collection(collection_name)
 
         return [

--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -374,7 +374,7 @@ class QdrantClient(QdrantFastembedMixin):
         consistency: Optional[types.ReadConsistency] = None,
         timeout: Optional[int] = None,
         **kwargs: Any,
-    ) -> List[List[types.ScoredPoint]]:
+    ) -> List[types.QueryResponse]:
         """Perform any search, recommend, discovery, context search operations in batch, and mitigate network overhead
 
         Args:
@@ -407,8 +407,7 @@ class QdrantClient(QdrantFastembedMixin):
         self,
         collection_name: str,
         query: Union[
-            int,
-            str,
+            types.PointId,
             List[float],
             List[List[float]],
             types.SparseVector,
@@ -431,7 +430,7 @@ class QdrantClient(QdrantFastembedMixin):
         shard_key_selector: Optional[types.ShardKeySelector] = None,
         timeout: Optional[int] = None,
         **kwargs: Any,
-    ) -> List[types.ScoredPoint]:
+    ) -> types.QueryResponse:
         """Universal endpoint to run any available operation, such as search, recommendation, discovery, context search.
 
         Args:
@@ -515,7 +514,7 @@ class QdrantClient(QdrantFastembedMixin):
             )
 
         Returns:
-            List of found close points with similarity scores.
+            QueryResponse structure containing list of found close points with similarity scores.
         """
 
         assert len(kwargs) == 0, f"Unknown arguments: {list(kwargs.keys())}"


### PR DESCRIPTION
Replace int and str type to PointId to improve readability
Return QueryResponse in query methods instead of scored points

This PR does not include implementation of result conversion for local mode, as #659 has not yet been merged