### PR TITLE
fix: skip no prefetch query test if version is low

### DIFF
--- a/tests/congruence_tests/test_query.py
+++ b/tests/congruence_tests/test_query.py
@@ -26,7 +26,7 @@ from tests.congruence_tests.test_common import (
 )
 from tests.fixtures.filters import one_random_filter_please
 from tests.fixtures.points import generate_random_sparse_vector, generate_random_multivector
-
+from tests.utils import read_version
 
 SECONDARY_COLLECTION_NAME = "congruence_secondary_collection"
 
@@ -614,6 +614,12 @@ def test_dense_query_lookup_from_negative():
 
 
 def test_no_query_no_prefetch():
+    major, minor, patch, dev = read_version()
+    version_set = major is not None or dev
+    if version_set and not dev:
+        if major == 0 or (major == 1 and (minor < 10 or (minor == 10 and patch == 0))):
+            pytest.skip("Works as of version 1.10.1")
+
     fixture_points = generate_fixtures()
 
     searcher = TestSimpleSearcher()

--- a/tests/integration-tests.sh
+++ b/tests/integration-tests.sh
@@ -39,9 +39,9 @@ done
 # Backwards compatibility tests are enabled by setting QDRANT_VERSION to a version that is not the latest
 # OR by setting IGNORE_CONGRUENCE_TESTS to true
 if [[ "$QDRANT_VERSION" != "$QDRANT_LATEST" ]] || [[ "$IGNORE_CONGRUENCE_TESTS" == "true" ]]; then
-  pytest --ignore=tests/congruence_tests
+  QDRANT_VERSION=$QDRANT_VERSION pytest --ignore=tests/congruence_tests
 else
-  pytest
+  QDRANT_VERSION=$QDRANT_VERSION pytest
 fi
 
 


### PR DESCRIPTION
I've accidentally merged a test #676 into master, requiring a fix in the core which has not yet been released, adding a version check to avoid launching on versions below 1.10.1 