### PR TITLE
docs: Removed recreate_collection quickstart.ipynb

### DIFF
--- a/docs/source/quickstart.ipynb
+++ b/docs/source/quickstart.ipynb
@@ -187,7 +187,7 @@
     "\n",
     "### Collection\n",
     "\n",
-    "A collection is a set of points with the same dimensionality and a similarity metric (e.g. Dot, Cosine) defined on it. We can create a collection with the `recreate_collection` API:"
+    "A collection is a set of points with the same dimensionality and a similarity metric (e.g. Dot, Cosine) defined on it. We can create a collection with the `create_collection` method:"
    ]
   },
   {
@@ -209,7 +209,7 @@
    "source": [
     "from qdrant_client.http.models import Distance, VectorParams\n",
     "\n",
-    "client.recreate_collection(\n",
+    "client.create_collection(\n",
     "    collection_name=\"test_collection\",\n",
     "    vectors_config=VectorParams(size=4, distance=Distance.DOT),\n",
     ")"


### PR DESCRIPTION
## Description

Since `recreate_collection` is deprecated.

Thanks to https://discord.com/channels/907569970500743200/1149327864936808529/threads/1263871151990374410