### PR TITLE
Bug report: Publish pipeline

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,11 +15,19 @@ on:
     tags:
       - 'v*'           # Push events to every version tag
 
-
 jobs:
   deploy:
 
     runs-on: ubuntu-latest
+    environment:
+      name: publish
+    permissions:
+      # This permission is used for trusted publishing:
+      # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
+      #
+      # Trusted publishing has to also be configured on PyPI for each package:
+      # https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+      id-token: write
 
     steps:
     - uses: actions/checkout@v2
@@ -33,8 +41,8 @@ jobs:
         poetry install
     - name: Build package
       run: poetry build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        verbose: true
+        print-hash: true


### PR DESCRIPTION
Benefit: If someone submits a PR, they cannot steal the `PYPI_API_TOKEN`. This could potentially be any current contributor.

Adapted from:
https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#trusted-publishing

There are some steps that the admin of this repo need to do. Both are UI actions.
## TODO:
1.  Pypi.org Follow pypi guide https://docs.pypi.org/trusted-publishers/adding-a-publisher/

This should roughly do it
```
- owner "qdrant"
- repository name "fastembed"
- workflow "publish.yml"
- environment name "publish" # The name of environment in the yaml needs to match the name of the github UI and what you put on pypi
```

2. Github.com Create a environment named "publish" in github UI under environments.
Below a screenshot of project github.com/michaelfeil/infinity and added e.g. me as Required Reviewer (e.g. if someone else pushes a tag to my repo, this stalls the github CI, and I get a notification to approve the publish.yml workflow)
![image](https://github.com/sarugaku/shellingham/assets/63565275/5f1155f5-ba81-462a-a54b-6160daf87a7b)
