### PR TITLE
deprecate: mark async gRPC properties as deprecated in QdrantRemote

### DIFF
--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -189,6 +189,11 @@ class QdrantClient(QdrantFastembedMixin):
         Returns:
             An instance of raw gRPC client, generated from Protobuf
         """
+        warnings.warn(
+            "async_grpc_points is deprecated and will be removed in a future release. Use `AsyncQdrantRemote.grpc_points` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if isinstance(self._client, QdrantRemote):
             return self._client.async_grpc_points
 
@@ -201,6 +206,11 @@ class QdrantClient(QdrantFastembedMixin):
         Returns:
             An instance of raw gRPC client, generated from Protobuf
         """
+        warnings.warn(
+            "async_grpc_collections is deprecated and will be removed in a future release. Use `AsyncQdrantRemote.grpc_collections` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if isinstance(self._client, QdrantRemote):
             return self._client.async_grpc_collections
 

--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -299,6 +299,11 @@ class QdrantRemote(QdrantBase):
         Returns:
             An instance of raw gRPC client, generated from Protobuf
         """
+        warnings.warn(
+            "async_grpc_collections is deprecated and will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self._aio_grpc_collections_client is None:
             self._init_async_grpc_collections_client()
         return self._aio_grpc_collections_client
@@ -310,6 +315,11 @@ class QdrantRemote(QdrantBase):
         Returns:
             An instance of raw gRPC client, generated from Protobuf
         """
+        warnings.warn(
+            "async_grpc_points is deprecated and will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self._aio_grpc_points_client is None:
             self._init_async_grpc_points_client()
         return self._aio_grpc_points_client
@@ -321,6 +331,11 @@ class QdrantRemote(QdrantBase):
         Returns:
             An instance of raw gRPC client, generated from Protobuf
         """
+        warnings.warn(
+            "async_grpc_snapshots is deprecated and will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self._aio_grpc_snapshots_client is None:
             self._init_async_grpc_snapshots_client()
         return self._aio_grpc_snapshots_client
@@ -332,6 +347,11 @@ class QdrantRemote(QdrantBase):
         Returns:
             An instance of raw gRPC client, generated from Protobuf
         """
+        warnings.warn(
+            "async_grpc_root is deprecated and will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self._aio_grpc_root_client is None:
             self._init_async_grpc_root_client()
         return self._aio_grpc_root_client
@@ -754,34 +774,34 @@ class QdrantRemote(QdrantBase):
             return http_res
 
     def query_points_groups(
-            self,
-            collection_name: str,
-            group_by: str,
-            query: Union[
-                types.PointId,
-                List[float],
-                List[List[float]],
-                types.SparseVector,
-                types.Query,
-                types.NumpyArray,
-                types.Document,
-                None,
-            ] = None,
-            using: Optional[str] = None,
-            prefetch: Union[types.Prefetch, List[types.Prefetch], None] = None,
-            query_filter: Optional[types.Filter] = None,
-            search_params: Optional[types.SearchParams] = None,
-            limit: int = 10,
-            group_size: int = 3,
-            with_payload: Union[bool, Sequence[str], types.PayloadSelector] = True,
-            with_vectors: Union[bool, Sequence[str]] = False,
-            score_threshold: Optional[float] = None,
-            with_lookup: Optional[types.WithLookupInterface] = None,
-            lookup_from: Optional[types.LookupLocation] = None,
-            consistency: Optional[types.ReadConsistency] = None,
-            shard_key_selector: Optional[types.ShardKeySelector] = None,
-            timeout: Optional[int] = None,
-            **kwargs: Any,
+        self,
+        collection_name: str,
+        group_by: str,
+        query: Union[
+            types.PointId,
+            List[float],
+            List[List[float]],
+            types.SparseVector,
+            types.Query,
+            types.NumpyArray,
+            types.Document,
+            None,
+        ] = None,
+        using: Optional[str] = None,
+        prefetch: Union[types.Prefetch, List[types.Prefetch], None] = None,
+        query_filter: Optional[types.Filter] = None,
+        search_params: Optional[types.SearchParams] = None,
+        limit: int = 10,
+        group_size: int = 3,
+        with_payload: Union[bool, Sequence[str], types.PayloadSelector] = True,
+        with_vectors: Union[bool, Sequence[str]] = False,
+        score_threshold: Optional[float] = None,
+        with_lookup: Optional[types.WithLookupInterface] = None,
+        lookup_from: Optional[types.LookupLocation] = None,
+        consistency: Optional[types.ReadConsistency] = None,
+        shard_key_selector: Optional[types.ShardKeySelector] = None,
+        timeout: Optional[int] = None,
+        **kwargs: Any,
     ) -> types.GroupsResult:
         if self._prefer_grpc:
             if isinstance(query, get_args(models.Query)):

--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -299,11 +299,6 @@ class QdrantRemote(QdrantBase):
         Returns:
             An instance of raw gRPC client, generated from Protobuf
         """
-        warnings.warn(
-            "async_grpc_collections is deprecated and will be removed in a future release.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         if self._aio_grpc_collections_client is None:
             self._init_async_grpc_collections_client()
         return self._aio_grpc_collections_client
@@ -315,11 +310,6 @@ class QdrantRemote(QdrantBase):
         Returns:
             An instance of raw gRPC client, generated from Protobuf
         """
-        warnings.warn(
-            "async_grpc_points is deprecated and will be removed in a future release.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         if self._aio_grpc_points_client is None:
             self._init_async_grpc_points_client()
         return self._aio_grpc_points_client
@@ -332,7 +322,7 @@ class QdrantRemote(QdrantBase):
             An instance of raw gRPC client, generated from Protobuf
         """
         warnings.warn(
-            "async_grpc_snapshots is deprecated and will be removed in a future release.",
+            "async_grpc_snapshots is deprecated and will be removed in a future release. Use `AsyncQdrantRemote.grpc_snapshots` instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -348,7 +338,7 @@ class QdrantRemote(QdrantBase):
             An instance of raw gRPC client, generated from Protobuf
         """
         warnings.warn(
-            "async_grpc_root is deprecated and will be removed in a future release.",
+            "async_grpc_root is deprecated and will be removed in a future release. Use `AsyncQdrantRemote.grpc_root` instead.",
             DeprecationWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
- Deprecated multiple async gRPC methods in favor of AsyncQdrantClient and QdrantClient.
- Added deprecation warnings for each method.

refs: #592 

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you installed `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
