### PR TITLE
fix: fix conversion in create_payload_index, add tests

### DIFF
--- a/qdrant_client/async_qdrant_remote.py
+++ b/qdrant_client/async_qdrant_remote.py
@@ -2487,14 +2487,28 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                 field_schema = RestToGrpc.convert_payload_schema_type(field_schema)
             if isinstance(field_schema, int):
                 field_schema = grpc_payload_schema_to_field_type(field_schema)
-            if isinstance(field_schema, models.TextIndexParams):
-                field_index_params = grpc.PayloadIndexParams(
-                    text_index_params=RestToGrpc.convert_text_index_params(field_schema)
-                )
-                field_schema = grpc.FieldType.FieldTypeText
+            if isinstance(field_schema, get_args(models.PayloadSchemaParams)):
+                field_schema = RestToGrpc.convert_payload_schema_params(field_schema)
             if isinstance(field_schema, grpc.PayloadIndexParams):
                 field_index_params = field_schema
-                field_schema = grpc.FieldType.FieldTypeText
+                name = field_index_params.WhichOneof("index_params")
+                index_params = getattr(field_index_params, name)
+                if isinstance(index_params, grpc.TextIndexParams):
+                    field_schema = grpc.FieldType.FieldTypeText
+                if isinstance(index_params, grpc.IntegerIndexParams):
+                    field_schema = grpc.FieldType.FieldTypeInteger
+                if isinstance(index_params, grpc.KeywordIndexParams):
+                    field_schema = grpc.FieldType.FieldTypeKeyword
+                if isinstance(index_params, grpc.FloatIndexParams):
+                    field_schema = grpc.FieldType.FieldTypeFloat
+                if isinstance(index_params, grpc.GeoIndexParams):
+                    field_schema = grpc.FieldType.FieldTypeGeo
+                if isinstance(index_params, grpc.BoolIndexParams):
+                    field_schema = grpc.FieldType.FieldTypeBool
+                if isinstance(index_params, grpc.DatetimeIndexParams):
+                    field_schema = grpc.FieldType.FieldTypeDatetime
+                if isinstance(index_params, grpc.UuidIndexParams):
+                    field_schema = grpc.FieldType.FieldTypeUuid
             request = grpc.CreateFieldIndexCollection(
                 collection_name=collection_name,
                 field_name=field_name,

--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -2857,15 +2857,36 @@ class QdrantRemote(QdrantBase):
                 # otherwise the value will be corrupted
                 field_schema = grpc_payload_schema_to_field_type(field_schema)
 
-            if isinstance(field_schema, models.TextIndexParams):
-                field_index_params = grpc.PayloadIndexParams(
-                    text_index_params=RestToGrpc.convert_text_index_params(field_schema)
-                )
-                field_schema = grpc.FieldType.FieldTypeText
+            if isinstance(field_schema, get_args(models.PayloadSchemaParams)):
+                field_schema = RestToGrpc.convert_payload_schema_params(field_schema)
 
             if isinstance(field_schema, grpc.PayloadIndexParams):
                 field_index_params = field_schema
-                field_schema = grpc.FieldType.FieldTypeText
+                name = field_index_params.WhichOneof("index_params")
+                index_params = getattr(field_index_params, name)
+                if isinstance(index_params, grpc.TextIndexParams):
+                    field_schema = grpc.FieldType.FieldTypeText
+
+                if isinstance(index_params, grpc.IntegerIndexParams):
+                    field_schema = grpc.FieldType.FieldTypeInteger
+
+                if isinstance(index_params, grpc.KeywordIndexParams):
+                    field_schema = grpc.FieldType.FieldTypeKeyword
+
+                if isinstance(index_params, grpc.FloatIndexParams):
+                    field_schema = grpc.FieldType.FieldTypeFloat
+
+                if isinstance(index_params, grpc.GeoIndexParams):
+                    field_schema = grpc.FieldType.FieldTypeGeo
+
+                if isinstance(index_params, grpc.BoolIndexParams):
+                    field_schema = grpc.FieldType.FieldTypeBool
+
+                if isinstance(index_params, grpc.DatetimeIndexParams):
+                    field_schema = grpc.FieldType.FieldTypeDatetime
+
+                if isinstance(index_params, grpc.UuidIndexParams):
+                    field_schema = grpc.FieldType.FieldTypeUuid
 
             request = grpc.CreateFieldIndexCollection(
                 collection_name=collection_name,

--- a/tests/test_qdrant_client.py
+++ b/tests/test_qdrant_client.py
@@ -56,6 +56,7 @@ from tests.congruence_tests.test_common import (
     generate_fixtures,
     init_client,
     init_remote,
+    initialize_fixture_collection,
 )
 from tests.fixtures.payload import (
     one_random_payload_please,
@@ -2131,8 +2132,84 @@ def test_read_consistency(prefer_grpc):
     )
 
 
+@pytest.mark.parametrize("prefer_grpc", (False, True))
+def test_create_payload_index(prefer_grpc):
+    client = init_remote(prefer_grpc=prefer_grpc)
+    initialize_fixture_collection(client, COLLECTION_NAME, vectors_config={})
+
+    client.create_payload_index(COLLECTION_NAME, "keyword", models.PayloadSchemaType.KEYWORD)
+    client.create_payload_index(COLLECTION_NAME, "integer", models.PayloadSchemaType.INTEGER)
+    client.create_payload_index(COLLECTION_NAME, "float", models.PayloadSchemaType.FLOAT)
+    client.create_payload_index(COLLECTION_NAME, "geo", models.PayloadSchemaType.GEO)
+    client.create_payload_index(COLLECTION_NAME, "text", models.PayloadSchemaType.TEXT)
+    client.create_payload_index(COLLECTION_NAME, "bool", models.PayloadSchemaType.BOOL)
+    client.create_payload_index(COLLECTION_NAME, "datetime", models.PayloadSchemaType.DATETIME)
+    client.create_payload_index(COLLECTION_NAME, "uuid", models.PayloadSchemaType.UUID)
+
+    client.create_payload_index(
+        COLLECTION_NAME,
+        "keyword_parametrized",
+        models.KeywordIndexParams(
+            type=models.KeywordIndexType.KEYWORD, is_tenant=False, on_disk=True
+        ),
+    )
+    client.create_payload_index(
+        COLLECTION_NAME,
+        "integer_parametrized",
+        models.IntegerIndexParams(
+            type=models.IntegerIndexType.INTEGER,
+            lookup=True,
+            range=True,
+            is_principal=False,
+            on_disk=True,
+        ),
+    )
+    client.create_payload_index(
+        COLLECTION_NAME,
+        "float_parametrized",
+        models.FloatIndexParams(
+            type=models.FloatIndexType.FLOAT, is_principal=False, on_disk=True
+        ),
+    )
+
+    client.create_payload_index(
+        COLLECTION_NAME,
+        "text_parametrized",
+        models.TextIndexParams(
+            type=models.TextIndexType.TEXT,
+            tokenizer=models.TokenizerType.PREFIX,
+            min_token_len=3,
+            max_token_len=7,
+            lowercase=True,
+        ),
+    )
+
+    client.create_payload_index(
+        COLLECTION_NAME,
+        "datetime_parametrized",
+        models.DatetimeIndexParams(
+            type=models.DatetimeIndexType.DATETIME, is_principal=False, on_disk=True
+        ),
+    )
+    client.create_payload_index(
+        COLLECTION_NAME,
+        "uuid_parametrized",
+        models.UuidIndexParams(type=models.UuidIndexType.UUID, is_tenant=False, on_disk=True),
+    )
+
+    client.create_payload_index(
+        COLLECTION_NAME, "geo_parametrized", models.GeoIndexParams(type=models.GeoIndexType.GEO)
+    )
+    client.create_payload_index(
+        COLLECTION_NAME,
+        "bool_parametrized",
+        models.BoolIndexParams(type=models.BoolIndexType.BOOL),
+    )
+
+
 if __name__ == "__main__":
     test_qdrant_client_integration()
     test_points_crud()
     test_has_id_condition()
     test_insert_float()
+    test_create_payload_index()

--- a/tests/test_qdrant_client.py
+++ b/tests/test_qdrant_client.py
@@ -2144,33 +2144,6 @@ def test_create_payload_index(prefer_grpc):
     client.create_payload_index(COLLECTION_NAME, "text", models.PayloadSchemaType.TEXT)
     client.create_payload_index(COLLECTION_NAME, "bool", models.PayloadSchemaType.BOOL)
     client.create_payload_index(COLLECTION_NAME, "datetime", models.PayloadSchemaType.DATETIME)
-    client.create_payload_index(COLLECTION_NAME, "uuid", models.PayloadSchemaType.UUID)
-
-    client.create_payload_index(
-        COLLECTION_NAME,
-        "keyword_parametrized",
-        models.KeywordIndexParams(
-            type=models.KeywordIndexType.KEYWORD, is_tenant=False, on_disk=True
-        ),
-    )
-    client.create_payload_index(
-        COLLECTION_NAME,
-        "integer_parametrized",
-        models.IntegerIndexParams(
-            type=models.IntegerIndexType.INTEGER,
-            lookup=True,
-            range=True,
-            is_principal=False,
-            on_disk=True,
-        ),
-    )
-    client.create_payload_index(
-        COLLECTION_NAME,
-        "float_parametrized",
-        models.FloatIndexParams(
-            type=models.FloatIndexType.FLOAT, is_principal=False, on_disk=True
-        ),
-    )
 
     client.create_payload_index(
         COLLECTION_NAME,
@@ -2184,27 +2157,60 @@ def test_create_payload_index(prefer_grpc):
         ),
     )
 
-    client.create_payload_index(
-        COLLECTION_NAME,
-        "datetime_parametrized",
-        models.DatetimeIndexParams(
-            type=models.DatetimeIndexType.DATETIME, is_principal=False, on_disk=True
-        ),
-    )
-    client.create_payload_index(
-        COLLECTION_NAME,
-        "uuid_parametrized",
-        models.UuidIndexParams(type=models.UuidIndexType.UUID, is_tenant=False, on_disk=True),
-    )
+    major, minor, patch, dev = read_version()
+    if major is None or dev or (major, minor, patch) >= (1, 11, 0):
+        client.create_payload_index(COLLECTION_NAME, "uuid", models.PayloadSchemaType.UUID)
 
-    client.create_payload_index(
-        COLLECTION_NAME, "geo_parametrized", models.GeoIndexParams(type=models.GeoIndexType.GEO)
-    )
-    client.create_payload_index(
-        COLLECTION_NAME,
-        "bool_parametrized",
-        models.BoolIndexParams(type=models.BoolIndexType.BOOL),
-    )
+        client.create_payload_index(
+            COLLECTION_NAME,
+            "keyword_parametrized",
+            models.KeywordIndexParams(
+                type=models.KeywordIndexType.KEYWORD, is_tenant=False, on_disk=True
+            ),
+        )
+        client.create_payload_index(
+            COLLECTION_NAME,
+            "integer_parametrized",
+            models.IntegerIndexParams(
+                type=models.IntegerIndexType.INTEGER,
+                lookup=True,
+                range=True,
+                is_principal=False,
+                on_disk=True,
+            ),
+        )
+        client.create_payload_index(
+            COLLECTION_NAME,
+            "float_parametrized",
+            models.FloatIndexParams(
+                type=models.FloatIndexType.FLOAT, is_principal=False, on_disk=True
+            ),
+        )
+
+        client.create_payload_index(
+            COLLECTION_NAME,
+            "datetime_parametrized",
+            models.DatetimeIndexParams(
+                type=models.DatetimeIndexType.DATETIME, is_principal=False, on_disk=True
+            ),
+        )
+        client.create_payload_index(
+            COLLECTION_NAME,
+            "uuid_parametrized",
+            models.UuidIndexParams(type=models.UuidIndexType.UUID, is_tenant=False, on_disk=True),
+        )
+
+    if major is None or dev or (major, minor, patch) >= (1, 11, 1):
+        client.create_payload_index(
+            COLLECTION_NAME,
+            "geo_parametrized",
+            models.GeoIndexParams(type=models.GeoIndexType.GEO),
+        )
+        client.create_payload_index(
+            COLLECTION_NAME,
+            "bool_parametrized",
+            models.BoolIndexParams(type=models.BoolIndexType.BOOL),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
we forgot to use conversion for parametrized payload indices in `create_payload_index`

this PR adds the necessary invocations

a bug in core was found related to the creation of parametrized geo and bool indices

```
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.INVALID_ARGUMENT
	details = "field_type (Geo) and field_index_params do not match"
	debug_error_string = "UNKNOWN:Error received from peer  {grpc_message:"field_type (Geo) and field_index_params do not match", grpc_status:3, created_time:"2024-08-20T21:42:22.125081+02:00"}"
```

There are new tests, which can reproduce this error (`tests/test_qdrant_client.py::test_create_payload_index`)

grpc code snippet to reproduce the issue:

```python
from qdrant_client import grpc
from qdrant_client import QdrantClient, models

collection_name = "checkgeo"
cl = QdrantClient(prefer_grpc=True)
if cl.collection_exists(collection_name):
    cl.delete_collection(collection_name)
cl.create_collection(
    collection_name, vectors_config=models.VectorParams(size=2, distance=models.Distance.COSINE)
)
field_name = "testfield"
field_schema = grpc.FieldType.FieldTypeGeo
field_index_params = grpc.PayloadIndexParams(geo_index_params=grpc.GeoIndexParams())
request = grpc.CreateFieldIndexCollection(
    collection_name=collection_name,
    field_name=field_name,
    field_type=field_schema,
    field_index_params=field_index_params,
    wait=True,
)

print(cl._client.grpc_points.CreateFieldIndex(request).result)
```

cc: @coszio 