### PR TITLE
Fix nested prefetches in qdrant_local.py

### DIFF
--- a/qdrant_client/local/async_qdrant_local.py
+++ b/qdrant_client/local/async_qdrant_local.py
@@ -349,7 +349,11 @@ class AsyncQdrantLocal(AsyncQdrantBase):
             )
         elif isinstance(prefetch, Sequence):
             prefetches = list(prefetch)
-        return [self._resolve_prefetch_input(prefetch, collection_name) for prefetch in prefetches if prefetch is not None]
+        return [
+            self._resolve_prefetch_input(prefetch, collection_name)
+            for prefetch in prefetches
+            if prefetch is not None
+        ]
 
     def _resolve_prefetch_input(
         self, prefetch: types.Prefetch, collection_name: str

--- a/qdrant_client/local/async_qdrant_local.py
+++ b/qdrant_client/local/async_qdrant_local.py
@@ -349,7 +349,7 @@ class AsyncQdrantLocal(AsyncQdrantBase):
             )
         elif isinstance(prefetch, Sequence):
             prefetches = list(prefetch)
-        return [self._resolve_prefetch_input(prefetch, collection_name) for prefetch in prefetches]
+        return [self._resolve_prefetch_input(prefetch, collection_name) for prefetch in prefetches if prefetch is not None]
 
     def _resolve_prefetch_input(
         self, prefetch: types.Prefetch, collection_name: str

--- a/qdrant_client/local/qdrant_local.py
+++ b/qdrant_client/local/qdrant_local.py
@@ -370,7 +370,7 @@ class QdrantLocal(QdrantBase):
         elif isinstance(prefetch, Sequence):
             prefetches = list(prefetch)
 
-        return [self._resolve_prefetch_input(prefetch, collection_name) for prefetch in prefetches]
+        return [self._resolve_prefetch_input(prefetch, collection_name) for prefetch in prefetches if prefetch is not None]
 
     def _resolve_prefetch_input(
         self, prefetch: types.Prefetch, collection_name: str

--- a/tests/congruence_tests/test_query.py
+++ b/tests/congruence_tests/test_query.py
@@ -583,6 +583,23 @@ class TestSimpleSearcher:
             limit=10,
         )
 
+    def dense_query_text_nested_prefetch(self, client: QdrantBase) -> models.QueryResponse:
+        return client.query_points(
+            collection_name=COLLECTION_NAME,
+            prefetch=[
+                models.Prefetch(
+                    prefetch=models.Prefetch(
+                        query=self.dense_vector_query_text,
+                        using="text"
+                    ),
+                    query=self.dense_vector_query_text,
+                    using="text"
+                ),
+            ],
+            query=self.dense_vector_query_text,
+            using="text"
+        )
+
     @classmethod
     def dense_recommend_image(cls, client: QdrantBase) -> models.QueryResponse:
         return client.query_points(
@@ -812,6 +829,20 @@ def test_no_query_no_prefetch():
 
     compare_clients_results(local_client, http_client, grpc_client, searcher.query_scroll_offset)
     compare_clients_results(http_client, grpc_client, grpc_client, searcher.query_scroll_offset)
+
+
+def test_dense_query_nested_prefetch():
+    major, minor, patch, dev = read_version()
+    if not dev and None not in (major, minor, patch) and (major, minor, patch) < (1, 10, 0):
+        pytest.skip("Works as of version 1.10.0")
+
+    fixture_points = generate_fixtures()
+
+    searcher = TestSimpleSearcher()
+
+    local_client, http_client, grpc_client = init_clients(fixture_points)
+
+    compare_clients_results(local_client, http_client, grpc_client, searcher.dense_query_text_nested_prefetch)
 
 
 def test_dense_query_filtered_prefetch():

--- a/tests/congruence_tests/test_query.py
+++ b/tests/congruence_tests/test_query.py
@@ -832,9 +832,6 @@ def test_no_query_no_prefetch():
 
 
 def test_dense_query_nested_prefetch():
-    major, minor, patch, dev = read_version()
-    if not dev and None not in (major, minor, patch) and (major, minor, patch) < (1, 10, 0):
-        pytest.skip("Works as of version 1.10.0")
 
     fixture_points = generate_fixtures()
 


### PR DESCRIPTION
Having multiple nested prefetches does not seem to work with qdrant in local mode. The last prefetch in the chain is none which then raises an exception in the _resolve_prefetch_input method:
`if prefetch.query`
raises an exception since prefetch is none)

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you installed `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
