### PR TITLE
Removed invalid await from grpc async call

### DIFF
--- a/qdrant_client/async_qdrant_remote.py
+++ b/qdrant_client/async_qdrant_remote.py
@@ -2765,16 +2765,17 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         if self._prefer_grpc:
             if isinstance(shard_key, get_args_subscribed(models.ShardKey)):
                 shard_key = RestToGrpc.convert_shard_key(shard_key)
-            request = grpc.CreateShardKey(
-                shard_key=shard_key,
-                shards_number=shards_number,
-                replication_factor=replication_factor,
-                placement=placement or [],
-            )
             return (
                 await self.grpc_collections.CreateShardKey(
                     grpc.CreateShardKeyRequest(
-                        collection_name=collection_name, timeout=timeout, request=request
+                        collection_name=collection_name,
+                        timeout=timeout,
+                        request=grpc.CreateShardKey(
+                            shard_key=shard_key,
+                            shards_number=shards_number,
+                            replication_factor=replication_factor,
+                            placement=placement or [],
+                        ),
                     ),
                     timeout=self._timeout,
                 )

--- a/qdrant_client/async_qdrant_remote.py
+++ b/qdrant_client/async_qdrant_remote.py
@@ -2765,7 +2765,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         if self._prefer_grpc:
             if isinstance(shard_key, get_args_subscribed(models.ShardKey)):
                 shard_key = RestToGrpc.convert_shard_key(shard_key)
-            request = await grpc.CreateShardKey(
+            request = grpc.CreateShardKey(
                 shard_key=shard_key,
                 shards_number=shards_number,
                 replication_factor=replication_factor,

--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -3138,18 +3138,16 @@ class QdrantRemote(QdrantBase):
             if isinstance(shard_key, get_args_subscribed(models.ShardKey)):
                 shard_key = RestToGrpc.convert_shard_key(shard_key)
 
-            request = grpc.CreateShardKey(
-                shard_key=shard_key,
-                shards_number=shards_number,
-                replication_factor=replication_factor,
-                placement=placement or [],
-            )
-
             return self.grpc_collections.CreateShardKey(
                 grpc.CreateShardKeyRequest(
                     collection_name=collection_name,
                     timeout=timeout,
-                    request=request,
+                    request=grpc.CreateShardKey(
+                        shard_key=shard_key,
+                        shards_number=shards_number,
+                        replication_factor=replication_factor,
+                        placement=placement or [],
+                    ),
                 ),
                 timeout=self._timeout,
             ).result


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

This PR only removes invalid `await` clause from initialising grpc request. The existing `await` was causing folowing exception (on version 1.11.2): 

```python
   2597     if isinstance(shard_key, get_args_subscribed(models.ShardKey)):
   2598         shard_key = RestToGrpc.convert_shard_key(shard_key)
-> 2599     request = await grpc.CreateShardKey(
   2600         shard_key=shard_key,
   2601         shards_number=shards_number,
   2602         replication_factor=replication_factor,
   2603         placement=placement or [],
   2604     )
   2605     return (
   2606         await self.grpc_collections.CreateShardKey(
   2607             grpc.CreateShardKeyRequest(
   (...)
   2611         )
   2612     ).result
   2613 else:

TypeError: object CreateShardKey can't be used in 'await' expression
```

I've tested the local behaviour with a positive result.

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
