### PR TITLE
fix: fix model json schema compat, fix fields inspected for inference

### DIFF
--- a/qdrant_client/_pydantic_compat.py
+++ b/qdrant_client/_pydantic_compat.py
@@ -1,3 +1,5 @@
+import json
+
 from typing import Any, Dict, Type, TypeVar
 
 from pydantic import BaseModel
@@ -44,3 +46,10 @@ def model_fields_set(model: BaseModel) -> set:
         return model.model_fields_set
     else:
         return model.__fields_set__
+
+
+def model_json_schema(model: BaseModel, *args: Any, **kwargs: Any) -> dict[str, Any]:
+    if PYDANTIC_V2:
+        return model.model_json_schema(*args, **kwargs)
+    else:
+        return json.loads(model.schema_json(*args, **kwargs))

--- a/qdrant_client/_pydantic_compat.py
+++ b/qdrant_client/_pydantic_compat.py
@@ -48,7 +48,7 @@ def model_fields_set(model: BaseModel) -> set:
         return model.__fields_set__
 
 
-def model_json_schema(model: BaseModel, *args: Any, **kwargs: Any) -> dict[str, Any]:
+def model_json_schema(model: BaseModel, *args: Any, **kwargs: Any) -> Dict[str, Any]:
     if PYDANTIC_V2:
         return model.model_json_schema(*args, **kwargs)
     else:

--- a/qdrant_client/embed/schema_parser.py
+++ b/qdrant_client/embed/schema_parser.py
@@ -2,6 +2,7 @@ from copy import copy, deepcopy
 from typing import List, Type, Dict, Union, Any, Set, Optional
 
 from pydantic import BaseModel
+from pydantic.json_schema import model_json_schema
 
 from qdrant_client.embed.utils import FieldPath, convert_paths
 
@@ -67,7 +68,7 @@ class ModelSchemaParser:
     """
 
     CACHE_PATH = "_inspection_cache.py"
-    INFERENCE_OBJECT_NAMES = {"Document", "Image"}
+    INFERENCE_OBJECT_NAMES = {"Document", "Image", "InferenceObject"}
 
     def __init__(self) -> None:
         self._defs: Dict[str, Union[Dict[str, Any], List[Dict[str, Any]]]] = deepcopy(DEFS)  # type: ignore[arg-type]
@@ -223,7 +224,7 @@ class ModelSchemaParser:
         if model_name in self._cache:
             return None
 
-        schema = model.model_json_schema()
+        schema = model_json_schema(model)
         self._defs.update(schema.get("$defs", {}))
 
         defs = self._replace_refs(schema)


### PR DESCRIPTION
We're still supporting pydantic v1, it has some discrepancies in methods with pydantic v2, this pr addresses model_json_schema discrepancy