### PR TITLE
Fix for if a path is given for a remote client URL it is stored as the prefix and not discarded.

### DIFF
--- a/qdrant_client/async_qdrant_remote.py
+++ b/qdrant_client/async_qdrant_remote.py
@@ -78,7 +78,9 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         self._grpc_options = grpc_options or {}
         self._https = https if https is not None else api_key is not None
         self._scheme = "https" if self._https else "http"
-        self._prefix = self._format_prefix(prefix or "")
+        self._prefix = prefix or ""
+        if len(self._prefix) > 0 and self._prefix[0] != "/":
+            self._prefix = f"/{self._prefix}"
         if url is not None and host is not None:
             raise ValueError(f"Only one of (url, host) can be set. url is {url}, host is {host}")
         if host is not None and (host.startswith("http://") or host.startswith("https://")):
@@ -100,9 +102,6 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                 )
             elif parsed_url.path:
                 self._prefix = parsed_url.path
-            self._prefix = (
-                self._prefix if self._prefix else self._format_prefix(parsed_url.path or "")
-            )
             if self._scheme not in ("http", "https"):
                 raise ValueError(f"Unknown scheme: {self._scheme}")
         else:
@@ -208,12 +207,6 @@ class AsyncQdrantRemote(AsyncQdrantBase):
             parse_result.path,
         )
         return (scheme, host, port, prefix)
-
-    @staticmethod
-    def _format_prefix(prefix: str) -> str:
-        if len(prefix) > 0 and prefix[0] != "/":
-            return f"/{prefix}"
-        return prefix
 
     def _init_grpc_channel(self) -> None:
         if self._closed:

--- a/qdrant_client/async_qdrant_remote.py
+++ b/qdrant_client/async_qdrant_remote.py
@@ -78,9 +78,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         self._grpc_options = grpc_options or {}
         self._https = https if https is not None else api_key is not None
         self._scheme = "https" if self._https else "http"
-        self._prefix = prefix or ""
-        if len(self._prefix) > 0 and self._prefix[0] != "/":
-            self._prefix = f"/{self._prefix}"
+        self._prefix = self._format_prefix(prefix or "")
         if url is not None and host is not None:
             raise ValueError(f"Only one of (url, host) can be set. url is {url}, host is {host}")
         if host is not None and (host.startswith("http://") or host.startswith("https://")):
@@ -100,6 +98,9 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                 raise ValueError(
                     f"Prefix can be set either in `url` or in `prefix`. url is {url}, prefix is {parsed_url.path}"
                 )
+            self._prefix = (
+                self._prefix if self._prefix else self._format_prefix(parsed_url.path or "")
+            )
             if self._scheme not in ("http", "https"):
                 raise ValueError(f"Unknown scheme: {self._scheme}")
         else:
@@ -205,6 +206,12 @@ class AsyncQdrantRemote(AsyncQdrantBase):
             parse_result.path,
         )
         return (scheme, host, port, prefix)
+
+    @staticmethod
+    def _format_prefix(prefix: str) -> str:
+        if len(prefix) > 0 and prefix[0] != "/":
+            return f"/{prefix}"
+        return prefix
 
     def _init_grpc_channel(self) -> None:
         if self._closed:

--- a/qdrant_client/async_qdrant_remote.py
+++ b/qdrant_client/async_qdrant_remote.py
@@ -98,6 +98,8 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                 raise ValueError(
                     f"Prefix can be set either in `url` or in `prefix`. url is {url}, prefix is {parsed_url.path}"
                 )
+            elif parsed_url.path:
+                self._prefix = parsed_url.path
             self._prefix = (
                 self._prefix if self._prefix else self._format_prefix(parsed_url.path or "")
             )

--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -101,6 +101,8 @@ class QdrantRemote(QdrantBase):
                     "Prefix can be set either in `url` or in `prefix`. "
                     f"url is {url}, prefix is {parsed_url.path}"
                 )
+            elif parsed_url.path:
+                self._prefix = parsed_url.path
 
             self._prefix = (
                 self._prefix if self._prefix else self._format_prefix(parsed_url.path or "")

--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -70,7 +70,9 @@ class QdrantRemote(QdrantBase):
         self._https = https if https is not None else api_key is not None
         self._scheme = "https" if self._https else "http"
 
-        self._prefix = self._format_prefix(prefix or "")
+        self._prefix = prefix or ""
+        if len(self._prefix) > 0 and self._prefix[0] != "/":
+            self._prefix = f"/{self._prefix}"
 
         if url is not None and host is not None:
             raise ValueError(f"Only one of (url, host) can be set. url is {url}, host is {host}")
@@ -103,10 +105,6 @@ class QdrantRemote(QdrantBase):
                 )
             elif parsed_url.path:
                 self._prefix = parsed_url.path
-
-            self._prefix = (
-                self._prefix if self._prefix else self._format_prefix(parsed_url.path or "")
-            )
 
             if self._scheme not in ("http", "https"):
                 raise ValueError(f"Unknown scheme: {self._scheme}")
@@ -244,12 +242,6 @@ class QdrantRemote(QdrantBase):
             parse_result.path,
         )
         return scheme, host, port, prefix
-
-    @staticmethod
-    def _format_prefix(prefix: str) -> str:
-        if len(prefix) > 0 and prefix[0] != "/":
-            return f"/{prefix}"
-        return prefix
 
     def _init_grpc_channel(self) -> None:
         if self._closed:

--- a/tests/test_async_qdrant_client.py
+++ b/tests/test_async_qdrant_client.py
@@ -9,61 +9,12 @@ import pytest
 import qdrant_client.http.exceptions
 from qdrant_client import models
 from qdrant_client.async_qdrant_client import AsyncQdrantClient
-from qdrant_client.async_qdrant_remote import AsyncQdrantRemote
 from tests.utils import read_version
 
 NUM_VECTORS = 100
 NUM_QUERIES = 100
 DIM = 32
 COLLECTION_NAME = "async_test_collection"
-
-
-def test_client_init():
-    client = AsyncQdrantClient()
-    assert isinstance(client._client, AsyncQdrantRemote)
-    assert client._client.rest_uri == "http://localhost:6333"
-
-    client = AsyncQdrantClient(https=True)
-    assert isinstance(client._client, AsyncQdrantRemote)
-    assert client._client.rest_uri == "https://localhost:6333"
-
-    client = AsyncQdrantClient(https=True, port=7333)
-    assert isinstance(client._client, AsyncQdrantRemote)
-    assert client._client.rest_uri == "https://localhost:7333"
-
-    client = AsyncQdrantClient(host="hidden_port_addr.com", prefix="custom")
-    assert isinstance(client._client, AsyncQdrantRemote)
-    assert client._client.rest_uri == "http://hidden_port_addr.com:6333/custom"
-
-    client = AsyncQdrantClient(host="hidden_port_addr.com", port=None)
-    assert isinstance(client._client, AsyncQdrantRemote)
-    assert client._client.rest_uri == "http://hidden_port_addr.com"
-
-    client = AsyncQdrantClient(
-        host="hidden_port_addr.com",
-        port=None,
-        prefix="custom",
-    )
-    assert isinstance(client._client, AsyncQdrantRemote)
-    assert client._client.rest_uri == "http://hidden_port_addr.com/custom"
-
-    client = AsyncQdrantClient("http://hidden_port_addr.com", port=None)
-    assert isinstance(client._client, AsyncQdrantRemote)
-    assert client._client.rest_uri == "http://hidden_port_addr.com"
-
-    # url takes precedence over port, which has default value for a backward compatibility
-    client = AsyncQdrantClient(url="http://localhost:6333", port=7333)
-    assert isinstance(client._client, AsyncQdrantRemote)
-    assert client._client.rest_uri == "http://localhost:6333"
-
-    client = AsyncQdrantClient(url="http://localhost:6333", prefix="custom")
-    assert isinstance(client._client, AsyncQdrantRemote)
-    assert client._client.rest_uri == "http://localhost:6333/custom"
-
-    client = AsyncQdrantClient(url="http://localhost:6333/custom")
-    assert isinstance(client._client, AsyncQdrantRemote)
-    assert client._client.rest_uri == "http://localhost:6333/custom"
-    assert client._client._prefix == "/custom"
 
 
 @pytest.mark.asyncio

--- a/tests/test_async_qdrant_client.py
+++ b/tests/test_async_qdrant_client.py
@@ -9,12 +9,61 @@ import pytest
 import qdrant_client.http.exceptions
 from qdrant_client import models
 from qdrant_client.async_qdrant_client import AsyncQdrantClient
+from qdrant_client.async_qdrant_remote import AsyncQdrantRemote
 from tests.utils import read_version
 
 NUM_VECTORS = 100
 NUM_QUERIES = 100
 DIM = 32
 COLLECTION_NAME = "async_test_collection"
+
+
+def test_client_init():
+    client = AsyncQdrantClient()
+    assert isinstance(client._client, AsyncQdrantRemote)
+    assert client._client.rest_uri == "http://localhost:6333"
+
+    client = AsyncQdrantClient(https=True)
+    assert isinstance(client._client, AsyncQdrantRemote)
+    assert client._client.rest_uri == "https://localhost:6333"
+
+    client = AsyncQdrantClient(https=True, port=7333)
+    assert isinstance(client._client, AsyncQdrantRemote)
+    assert client._client.rest_uri == "https://localhost:7333"
+
+    client = AsyncQdrantClient(host="hidden_port_addr.com", prefix="custom")
+    assert isinstance(client._client, AsyncQdrantRemote)
+    assert client._client.rest_uri == "http://hidden_port_addr.com:6333/custom"
+
+    client = AsyncQdrantClient(host="hidden_port_addr.com", port=None)
+    assert isinstance(client._client, AsyncQdrantRemote)
+    assert client._client.rest_uri == "http://hidden_port_addr.com"
+
+    client = AsyncQdrantClient(
+        host="hidden_port_addr.com",
+        port=None,
+        prefix="custom",
+    )
+    assert isinstance(client._client, AsyncQdrantRemote)
+    assert client._client.rest_uri == "http://hidden_port_addr.com/custom"
+
+    client = AsyncQdrantClient("http://hidden_port_addr.com", port=None)
+    assert isinstance(client._client, AsyncQdrantRemote)
+    assert client._client.rest_uri == "http://hidden_port_addr.com"
+
+    # url takes precedence over port, which has default value for a backward compatibility
+    client = AsyncQdrantClient(url="http://localhost:6333", port=7333)
+    assert isinstance(client._client, AsyncQdrantRemote)
+    assert client._client.rest_uri == "http://localhost:6333"
+
+    client = AsyncQdrantClient(url="http://localhost:6333", prefix="custom")
+    assert isinstance(client._client, AsyncQdrantRemote)
+    assert client._client.rest_uri == "http://localhost:6333/custom"
+
+    client = AsyncQdrantClient(url="http://localhost:6333/custom")
+    assert isinstance(client._client, AsyncQdrantRemote)
+    assert client._client.rest_uri == "http://localhost:6333/custom"
+    assert client._client._prefix == "/custom"
 
 
 @pytest.mark.asyncio

--- a/tests/test_qdrant_client.py
+++ b/tests/test_qdrant_client.py
@@ -146,6 +146,11 @@ def test_client_init():
     assert isinstance(client._client, QdrantRemote)
     assert client._client.rest_uri == "http://localhost:6333/custom"
 
+    client = QdrantClient(url="http://localhost:6333/custom")
+    assert isinstance(client._client, QdrantRemote)
+    assert client._client.rest_uri == "http://localhost:6333/custom"
+    assert client._client._prefix == "/custom"
+
     client = QdrantClient("my-domain.com")
     assert isinstance(client._client, QdrantRemote)
     assert client._client.rest_uri == "http://my-domain.com:6333"
@@ -2079,6 +2084,7 @@ def test_async_auth_token_provider():
         client.get_collections()
 
     assert token == ""
+
 
 @pytest.mark.parametrize("prefer_grpc", [True, False])
 def test_read_consistency(prefer_grpc):


### PR DESCRIPTION
Added coverage to both the async and regular client to ensure this bug doesn't come back up again.

### All Submissions:

* [X] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests? (https://github.com/rovermicrover/qdrant-client/actions/runs/12604938662/job/35132830550)
2. [X] Have you installed `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
