### PR TITLE
fix: use the same name for `check_compatibility` flag in args, warnings and tests

### DIFF
--- a/qdrant_client/async_qdrant_remote.py
+++ b/qdrant_client/async_qdrant_remote.py
@@ -179,7 +179,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                 )
                 if not server_version:
                     show_warning(
-                        message=f"Failed to obtain server version. Unable to check client-server compatibility. Set check_compatibility=False to skip version check.",
+                        message="Failed to obtain server version. Unable to check client-server compatibility. Set check_compatibility=False to skip version check.",
                         category=UserWarning,
                         stacklevel=4,
                     )

--- a/qdrant_client/async_qdrant_remote.py
+++ b/qdrant_client/async_qdrant_remote.py
@@ -179,13 +179,13 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                 )
                 if not server_version:
                     show_warning(
-                        message=f"Failed to obtain server version. Unable to check client-server compatibility. Set check_version=False to skip version check.",
+                        message=f"Failed to obtain server version. Unable to check client-server compatibility. Set check_compatibility=False to skip version check.",
                         category=UserWarning,
                         stacklevel=4,
                     )
                 elif not is_compatible(client_version, server_version):
                     show_warning(
-                        message=f"Qdrant client version {client_version} is incompatible with server version {server_version}. Major versions should match and minor version difference must not exceed 1. Set check_version=False to skip version check.",
+                        message=f"Qdrant client version {client_version} is incompatible with server version {server_version}. Major versions should match and minor version difference must not exceed 1. Set check_compatibility=False to skip version check.",
                         category=UserWarning,
                         stacklevel=4,
                     )

--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -216,13 +216,13 @@ class QdrantRemote(QdrantBase):
 
                 if not server_version:
                     show_warning(
-                        message=f"Failed to obtain server version. Unable to check client-server compatibility. Set check_version=False to skip version check.",
+                        message=f"Failed to obtain server version. Unable to check client-server compatibility. Set check_compatibility=False to skip version check.",
                         category=UserWarning,
                         stacklevel=4,
                     )
                 elif not is_compatible(client_version, server_version):
                     show_warning(
-                        message=f"Qdrant client version {client_version} is incompatible with server version {server_version}. Major versions should match and minor version difference must not exceed 1. Set check_version=False to skip version check.",
+                        message=f"Qdrant client version {client_version} is incompatible with server version {server_version}. Major versions should match and minor version difference must not exceed 1. Set check_compatibility=False to skip version check.",
                         category=UserWarning,
                         stacklevel=4,
                     )

--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -2,7 +2,6 @@ import importlib.metadata
 import logging
 import math
 import platform
-import warnings
 from multiprocessing import get_all_start_methods
 from typing import (
     Any,
@@ -216,19 +215,23 @@ class QdrantRemote(QdrantBase):
 
                 if not server_version:
                     show_warning(
-                        message=f"Failed to obtain server version. Unable to check client-server compatibility. Set check_compatibility=False to skip version check.",
+                        message="Failed to obtain server version. Unable to check client-server compatibility."
+                        " Set check_compatibility=False to skip version check.",
                         category=UserWarning,
                         stacklevel=4,
                     )
                 elif not is_compatible(client_version, server_version):
                     show_warning(
-                        message=f"Qdrant client version {client_version} is incompatible with server version {server_version}. Major versions should match and minor version difference must not exceed 1. Set check_compatibility=False to skip version check.",
+                        message=f"Qdrant client version {client_version} is incompatible with server "
+                        f"version {server_version}. Major versions should match and minor version difference "
+                        "must not exceed 1. Set check_compatibility=False to skip version check.",
                         category=UserWarning,
                         stacklevel=4,
                     )
             except Exception as er:
-                logging.debug(f"Unable to get server version: {er}, server version defaults to None")
-
+                logging.debug(
+                    f"Unable to get server version: {er}, server version defaults to None"
+                )
 
     @property
     def closed(self) -> bool:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -40,7 +40,7 @@ from qdrant_client.common.version_check import is_compatible, parse_version
         "Both versions are None, negative",
     ],
 )
-def test_check_versions(client_version, server_version, expected_result):
+def test_check_compatibility(client_version, server_version, expected_result):
     assert (
         is_compatible(client_version=client_version, server_version=server_version)
         is expected_result


### PR DESCRIPTION
Replace `check_version` with `check_compatibility` in warnings and tests to fit flag name

For example it fix this place:

https://github.com/qdrant/qdrant-client/blob/64311d3a19b644647f73f2ac143902f4203a3d77/qdrant_client/qdrant_remote.py#L210

https://github.com/qdrant/qdrant-client/blob/64311d3a19b644647f73f2ac143902f4203a3d77/qdrant_client/qdrant_remote.py#L219
