### PR TITLE
fix(api_client): update path handling for hosts with subpaths

### DIFF
--- a/qdrant_client/http/api_client.py
+++ b/qdrant_client/http/api_client.py
@@ -82,7 +82,7 @@ class ApiClient:
     ) -> Any:
         if path_params is None:
             path_params = {}
-        url = urljoin((self.host or ""), url.format(**path_params))
+        url = urljoin((self.host or "").lstrip("/") + "/", url.format(**path_params).lstrip("/"))
         if "params" in kwargs and "timeout" in kwargs["params"]:
             kwargs["timeout"] = int(kwargs["params"]["timeout"])
         request = self._client.build_request(method, url, **kwargs)


### PR DESCRIPTION
Fix URL joining logic to ensure correct path resolution for API requests.

Previously, using urljoin could result in incorrect URLs if the host ended with a path and the formatted url started with a leading slash. For example, a host like `https://abc.com/api/qdrant` combined with `url.format(**path_params)` producing `"/collections"` would incorrectly resolve to `"https://abc.com/collections"`.

To address this, the `host` is now stripped of any leading slashes and ensured to end with a single /, while the `url` is stripped of leading slashes. This ensures the resulting URL maintains the expected path hierarchy:
Example fix:
`"https://abc.com/api/qdrant" + "/collections"` -> `"https://abc.com/api/qdrant/collections"`