### PR TITLE
Optional vectors config

### DIFF
--- a/qdrant_client/async_qdrant_client.py
+++ b/qdrant_client/async_qdrant_client.py
@@ -2299,10 +2299,6 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
             Operation result
         """
         assert len(kwargs) == 0, f"Unknown arguments: {list(kwargs.keys())}"
-        if vectors_config is None and sparse_vectors_config is None:
-            raise ValueError(
-                "At least one of `vectors_config` or `sparse_vectors_config` should be provided."
-            )
         return await self._client.create_collection(
             collection_name=collection_name,
             vectors_config=vectors_config,

--- a/qdrant_client/async_qdrant_client.py
+++ b/qdrant_client/async_qdrant_client.py
@@ -2232,7 +2232,9 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
     async def create_collection(
         self,
         collection_name: str,
-        vectors_config: Union[types.VectorParams, Mapping[str, types.VectorParams]],
+        vectors_config: Optional[
+            Union[types.VectorParams, Mapping[str, types.VectorParams]]
+        ] = None,
         sparse_vectors_config: Optional[Mapping[str, types.SparseVectorParams]] = None,
         shard_number: Optional[int] = None,
         sharding_method: Optional[types.ShardingMethod] = None,
@@ -2297,6 +2299,10 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
             Operation result
         """
         assert len(kwargs) == 0, f"Unknown arguments: {list(kwargs.keys())}"
+        if vectors_config is None and sparse_vectors_config is None:
+            raise ValueError(
+                "At least one of `vectors_config` or `sparse_vectors_config` should be provided."
+            )
         return await self._client.create_collection(
             collection_name=collection_name,
             vectors_config=vectors_config,

--- a/qdrant_client/async_qdrant_remote.py
+++ b/qdrant_client/async_qdrant_remote.py
@@ -2446,7 +2446,9 @@ class AsyncQdrantRemote(AsyncQdrantBase):
     async def create_collection(
         self,
         collection_name: str,
-        vectors_config: Union[types.VectorParams, Mapping[str, types.VectorParams]],
+        vectors_config: Optional[
+            Union[types.VectorParams, Mapping[str, types.VectorParams]]
+        ] = None,
         shard_number: Optional[int] = None,
         replication_factor: Optional[int] = None,
         write_consistency_factor: Optional[int] = None,

--- a/qdrant_client/common/version_check.py
+++ b/qdrant_client/common/version_check.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 from typing import Any, Optional
 from collections import namedtuple
 

--- a/qdrant_client/local/async_qdrant_local.py
+++ b/qdrant_client/local/async_qdrant_local.py
@@ -921,7 +921,9 @@ class AsyncQdrantLocal(AsyncQdrantBase):
     async def create_collection(
         self,
         collection_name: str,
-        vectors_config: Union[types.VectorParams, Mapping[str, types.VectorParams]],
+        vectors_config: Optional[
+            Union[types.VectorParams, Mapping[str, types.VectorParams]]
+        ] = None,
         init_from: Optional[types.InitFrom] = None,
         sparse_vectors_config: Optional[Mapping[str, types.SparseVectorParams]] = None,
         **kwargs: Any,
@@ -942,7 +944,7 @@ class AsyncQdrantLocal(AsyncQdrantBase):
             os.makedirs(collection_path, exist_ok=True)
         collection = LocalCollection(
             rest_models.CreateCollection(
-                vectors=vectors_config, sparse_vectors=sparse_vectors_config
+                vectors=vectors_config or {}, sparse_vectors=sparse_vectors_config
             ),
             location=collection_path,
             force_disable_check_same_thread=self.force_disable_check_same_thread,

--- a/qdrant_client/local/qdrant_local.py
+++ b/qdrant_client/local/qdrant_local.py
@@ -1,7 +1,6 @@
 import importlib.metadata
 import itertools
 import json
-import logging
 import os
 import shutil
 from copy import deepcopy
@@ -995,7 +994,9 @@ class QdrantLocal(QdrantBase):
     def create_collection(
         self,
         collection_name: str,
-        vectors_config: Union[types.VectorParams, Mapping[str, types.VectorParams]],
+        vectors_config: Optional[
+            Union[types.VectorParams, Mapping[str, types.VectorParams]]
+        ] = None,
         init_from: Optional[types.InitFrom] = None,
         sparse_vectors_config: Optional[Mapping[str, types.SparseVectorParams]] = None,
         **kwargs: Any,
@@ -1019,7 +1020,7 @@ class QdrantLocal(QdrantBase):
 
         collection = LocalCollection(
             rest_models.CreateCollection(
-                vectors=vectors_config,
+                vectors=vectors_config or {},
                 sparse_vectors=sparse_vectors_config,
             ),
             location=collection_path,

--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -2379,11 +2379,6 @@ class QdrantClient(QdrantFastembedMixin):
         """
         assert len(kwargs) == 0, f"Unknown arguments: {list(kwargs.keys())}"
 
-        if vectors_config is None and sparse_vectors_config is None:
-            raise ValueError(
-                "At least one of `vectors_config` or `sparse_vectors_config` should be provided."
-            )
-
         return self._client.create_collection(
             collection_name=collection_name,
             vectors_config=vectors_config,

--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -2311,7 +2311,9 @@ class QdrantClient(QdrantFastembedMixin):
     def create_collection(
         self,
         collection_name: str,
-        vectors_config: Union[types.VectorParams, Mapping[str, types.VectorParams]],
+        vectors_config: Optional[
+            Union[types.VectorParams, Mapping[str, types.VectorParams]]
+        ] = None,
         sparse_vectors_config: Optional[Mapping[str, types.SparseVectorParams]] = None,
         shard_number: Optional[int] = None,
         sharding_method: Optional[types.ShardingMethod] = None,
@@ -2376,6 +2378,11 @@ class QdrantClient(QdrantFastembedMixin):
             Operation result
         """
         assert len(kwargs) == 0, f"Unknown arguments: {list(kwargs.keys())}"
+
+        if vectors_config is None and sparse_vectors_config is None:
+            raise ValueError(
+                "At least one of `vectors_config` or `sparse_vectors_config` should be provided."
+            )
 
         return self._client.create_collection(
             collection_name=collection_name,

--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -2703,7 +2703,9 @@ class QdrantRemote(QdrantBase):
     def create_collection(
         self,
         collection_name: str,
-        vectors_config: Union[types.VectorParams, Mapping[str, types.VectorParams]],
+        vectors_config: Optional[
+            Union[types.VectorParams, Mapping[str, types.VectorParams]]
+        ] = None,
         shard_number: Optional[int] = None,
         replication_factor: Optional[int] = None,
         write_consistency_factor: Optional[int] = None,

--- a/tests/congruence_tests/test_collections.py
+++ b/tests/congruence_tests/test_collections.py
@@ -220,9 +220,7 @@ def test_config_variations():
     check_variation(None, sparse_vectors_config)
     check_variation({"text": vectors_config}, sparse_vectors_config)
     check_variation({"text": vectors_config}, None)
-
-    with pytest.raises(ValueError, match="At least"):
-        check_variation(None, None)
+    check_variation(None, None)
 
 
 def wait_for(condition: Callable, *args, **kwargs):


### PR DESCRIPTION
it is no longer requested to specify vectors_config when creating a collection with sparse vectors only

```python
from qdrant_client import QdrantClient, models

cl = QdrantClient()
cl.create_collection(
    'test', 
    vectors_config={}, 
    sparse_vectors_config={"sparse": models.SparseVectorParams()}
)
```

->
```python
from qdrant_client import QdrantClient, models

cl = QdrantClient()
cl.create_collection(
    'test', 
    sparse_vectors_config={"sparse": models.SparseVectorParams()}
)
```