### PR TITLE
Default inference batch size

### DIFF
--- a/qdrant_client/async_qdrant_fastembed.py
+++ b/qdrant_client/async_qdrant_fastembed.py
@@ -42,7 +42,7 @@ from qdrant_client.fastembed_common import (
 
 class AsyncQdrantFastembedMixin(AsyncQdrantBase):
     DEFAULT_EMBEDDING_MODEL = "BAAI/bge-small-en"
-    DEFAULT_BATCH_SIZE = 16
+    DEFAULT_BATCH_SIZE = 8
     _FASTEMBED_INSTALLED: bool
 
     def __init__(self, parser: ModelSchemaParser, **kwargs: Any):

--- a/qdrant_client/embed/embedder.py
+++ b/qdrant_client/embed/embedder.py
@@ -189,7 +189,7 @@ class Embedder:
         images: Optional[list[ImageInput]] = None,
         options: Optional[dict[str, Any]] = None,
         is_query: bool = False,
-        batch_size: int = 32,
+        batch_size: int = 8,
     ) -> NumericVector:
         if (texts is None) is (images is None):
             raise ValueError("Either documents or images should be provided")

--- a/qdrant_client/embed/model_embedder.py
+++ b/qdrant_client/embed/model_embedder.py
@@ -49,7 +49,7 @@ class ModelEmbedder:
         self,
         raw_models: Union[BaseModel, Iterable[BaseModel]],
         is_query: bool = False,
-        batch_size: int = 16,
+        batch_size: int = 8,
     ) -> Iterable[BaseModel]:
         """Embed raw data fields in models and return models with vectors
 
@@ -65,12 +65,14 @@ class ModelEmbedder:
         if isinstance(raw_models, BaseModel):
             raw_models = [raw_models]
         for raw_models_batch in iter_batch(raw_models, batch_size):
-            yield from self.embed_models_batch(raw_models_batch, is_query)
+            yield from self.embed_models_batch(
+                raw_models_batch, is_query, inference_batch_size=batch_size
+            )
 
     def embed_models_strict(
         self,
         raw_models: Iterable[Union[dict[str, BaseModel], BaseModel]],
-        batch_size: int = 16,
+        batch_size: int = 8,
         parallel: Optional[int] = None,
     ) -> Iterable[Union[dict[str, BaseModel], BaseModel]]:
         """Embed raw data fields in models and return models with vectors
@@ -94,7 +96,7 @@ class ModelEmbedder:
 
         if parallel is None or parallel == 1 or is_small:
             for batch in iter_batch(raw_models, batch_size):
-                yield from self.embed_models_batch(batch)
+                yield from self.embed_models_batch(batch, inference_batch_size=batch_size)
         else:
             raw_models_batches = iter_batch(
                 raw_models, size=1
@@ -119,6 +121,7 @@ class ModelEmbedder:
         self,
         raw_models: list[Union[dict[str, BaseModel], BaseModel]],
         is_query: bool = False,
+        inference_batch_size: int = 8,
     ) -> Iterable[BaseModel]:
         """Embed a batch of models with raw data fields and return models with vectors
 
@@ -127,6 +130,7 @@ class ModelEmbedder:
         Args:
             raw_models: list[Union[dict[str, BaseModel], BaseModel]] - models which can contain fields with raw data
             is_query: bool - flag to determine which embed method to use. Defaults to False.
+            inference_batch_size: int - batch size for inference
         Returns:
             Iterable[BaseModel]: models with embedded fields
         """
@@ -137,7 +141,12 @@ class ModelEmbedder:
             yield from raw_models
         else:
             yield from (
-                self._process_model(raw_model, is_query=is_query, accumulating=False)
+                self._process_model(
+                    raw_model,
+                    is_query=is_query,
+                    accumulating=False,
+                    inference_batch_size=inference_batch_size,
+                )
                 for raw_model in raw_models
             )
 
@@ -147,6 +156,7 @@ class ModelEmbedder:
         paths: Optional[list[FieldPath]] = None,
         is_query: bool = False,
         accumulating: bool = False,
+        inference_batch_size: Optional[int] = None,
     ) -> Union[dict[str, BaseModel], dict[str, NumericVector], BaseModel, NumericVector]:
         """Embed model's fields requiring inference
 
@@ -155,6 +165,7 @@ class ModelEmbedder:
             paths: Path to fields to embed. E.g. [FieldPath(current="recommend", tail=[FieldPath(current="negative", tail=None)])]
             is_query: Flag to determine which embed method to use. Defaults to False.
             accumulating: Flag to determine if we are accumulating models for batch embedding. Defaults to False.
+            inference_batch_size: Optional[int] - batch size for inference
 
         Returns:
             A deepcopy of the method with embedded fields
@@ -164,7 +175,9 @@ class ModelEmbedder:
             if accumulating:
                 self._accumulate(model)  # type: ignore
             else:
-                return self._drain_accumulator(model, is_query=is_query)  # type: ignore
+                return self._drain_accumulator(
+                    model, is_query=is_query, inference_batch_size=inference_batch_size
+                )  # type: ignore
 
         if paths is None:
             model = deepcopy(model) if not accumulating else model
@@ -197,7 +210,9 @@ class ModelEmbedder:
 
                     if not accumulating:
                         embeddings = [
-                            self._drain_accumulator(data, is_query=is_query)
+                            self._drain_accumulator(
+                                data, is_query=is_query, inference_batch_size=inference_batch_size
+                            )
                             for data in current_model
                         ]
                         if was_list:
@@ -238,7 +253,9 @@ class ModelEmbedder:
             self._batch_accumulator[data.model] = []
         self._batch_accumulator[data.model].append(data)
 
-    def _drain_accumulator(self, data: models.VectorStruct, is_query: bool) -> models.VectorStruct:
+    def _drain_accumulator(
+        self, data: models.VectorStruct, is_query: bool, inference_batch_size: int = 8
+    ) -> models.VectorStruct:
         """Drain accumulator and replaces inference objects with computed embeddings
             It is assumed objects are traversed in the same order as they were added to the accumulator
 
@@ -246,13 +263,16 @@ class ModelEmbedder:
             data: models.VectorStruct - any vector struct data, if inference object types instances in `data` - replace
                 them with computed embeddings. If embeddings haven't yet been computed - compute them and then replace
                 inference objects.
+            inference_batch_size: int - batch size for inference
 
         Returns:
             models.VectorStruct: data with replaced inference objects
         """
         if isinstance(data, dict):
             for key, value in data.items():
-                data[key] = self._drain_accumulator(value, is_query=is_query)
+                data[key] = self._drain_accumulator(
+                    value, is_query=is_query, inference_batch_size=inference_batch_size
+                )
             return data
 
         if isinstance(data, list):
@@ -260,29 +280,31 @@ class ModelEmbedder:
                 if not isinstance(value, get_args(INFERENCE_OBJECT_TYPES)):  # if value is vector
                     return data
 
-                data[i] = self._drain_accumulator(value, is_query=is_query)
+                data[i] = self._drain_accumulator(
+                    value, is_query=is_query, inference_batch_size=inference_batch_size
+                )
             return data
 
         if not isinstance(data, get_args(INFERENCE_OBJECT_TYPES)):
             return data
 
         if not self._embed_storage or not self._embed_storage.get(data.model, None):
-            self._embed_accumulator(is_query=is_query)
+            self._embed_accumulator(is_query=is_query, inference_batch_size=inference_batch_size)
 
         return self._next_embed(data.model)
 
-    def _embed_accumulator(self, is_query: bool = False) -> None:
+    def _embed_accumulator(self, is_query: bool = False, inference_batch_size: int = 8) -> None:
         """Embed all accumulated objects for all models
 
         Args:
             is_query: bool - flag to determine which embed method to use. Defaults to False.
-
+            inference_batch_size: int - batch size for inference
         Returns:
             None
         """
 
         def embed(
-            objects: list[INFERENCE_OBJECT_TYPES], model_name: str, is_text: bool
+            objects: list[INFERENCE_OBJECT_TYPES], model_name: str, is_text: bool, batch_size: int
         ) -> list[NumericVector]:
             """Assemble batches by groups, embeds and return embeddings in the original order"""
             unique_options: list[dict[str, Any]] = []
@@ -311,6 +333,7 @@ class ModelEmbedder:
                             images=batches[i] if not is_text else None,
                             is_query=is_query,
                             options=options or {},
+                            batch_size=batch_size,
                         )
                     ]
                 )
@@ -337,9 +360,13 @@ class ModelEmbedder:
                 *SUPPORTED_SPARSE_EMBEDDING_MODELS,
                 *_LATE_INTERACTION_EMBEDDING_MODELS,
             ]:
-                embeddings = embed(objects=data, model_name=model, is_text=True)
+                embeddings = embed(
+                    objects=data, model_name=model, is_text=True, batch_size=inference_batch_size
+                )
             else:
-                embeddings = embed(objects=data, model_name=model, is_text=False)
+                embeddings = embed(
+                    objects=data, model_name=model, is_text=False, batch_size=inference_batch_size
+                )
 
             self._embed_storage[model] = embeddings
         self._batch_accumulator.clear()

--- a/qdrant_client/embed/model_embedder.py
+++ b/qdrant_client/embed/model_embedder.py
@@ -202,7 +202,11 @@ class ModelEmbedder:
                     self._process_model(value, paths, accumulating=True)
                 else:
                     model[key] = self._process_model(
-                        value, paths, is_query=is_query, accumulating=False
+                        value,
+                        paths,
+                        is_query=is_query,
+                        accumulating=False,
+                        inference_batch_size=inference_batch_size,
                     )
             return model
 
@@ -216,7 +220,11 @@ class ModelEmbedder:
                     continue
                 if path.tail:
                     self._process_model(
-                        current_model, path.tail, is_query=is_query, accumulating=accumulating
+                        current_model,
+                        path.tail,
+                        is_query=is_query,
+                        accumulating=accumulating,
+                        inference_batch_size=inference_batch_size,
                     )
                 else:
                     was_list = isinstance(current_model, list)

--- a/qdrant_client/embed/model_embedder.py
+++ b/qdrant_client/embed/model_embedder.py
@@ -122,7 +122,7 @@ class ModelEmbedder:
             )
 
             for batch in pool.ordered_map(
-                raw_models_batches,
+                raw_models_batches, batch_size=multiprocessing_batch_size
             ):
                 yield from batch
 

--- a/qdrant_client/embed/model_embedder.py
+++ b/qdrant_client/embed/model_embedder.py
@@ -188,9 +188,9 @@ class ModelEmbedder:
                     inference_batch_size is not None
                 ), "inference_batch_size should be passed for inference"
                 return self._drain_accumulator(
-                    model,
+                    model,  # type: ignore
                     is_query=is_query,
-                    inference_batch_size=inference_batch_size,  # type: ignore
+                    inference_batch_size=inference_batch_size,
                 )
 
         if paths is None:

--- a/qdrant_client/qdrant_fastembed.py
+++ b/qdrant_client/qdrant_fastembed.py
@@ -33,7 +33,7 @@ from qdrant_client.fastembed_common import (
 
 class QdrantFastembedMixin(QdrantBase):
     DEFAULT_EMBEDDING_MODEL = "BAAI/bge-small-en"
-    DEFAULT_BATCH_SIZE = 16
+    DEFAULT_BATCH_SIZE = 8
     _FASTEMBED_INSTALLED: bool
 
     def __init__(self, parser: ModelSchemaParser, **kwargs: Any):

--- a/tests/embed_tests/test_local_inference.py
+++ b/tests/embed_tests/test_local_inference.py
@@ -1672,10 +1672,9 @@ def test_batch_size_propagation():
     local_client = QdrantClient(":memory:", local_inference_batch_size=inference_batch_size)
     if not local_client._FASTEMBED_INSTALLED:
         pytest.skip("FastEmbed is not installed, skipping")
-    # local_client._model_embedder.embedder.embed = mock(
-    #     local_client._model_embedder.embedder.embed, param_storage
-    # )
-    Embedder.embed = mock(Embedder.embed, param_storage)
+    local_client._model_embedder.embedder.embed = mock(
+        local_client._model_embedder.embedder.embed, param_storage
+    )
 
     if not local_client._FASTEMBED_INSTALLED:
         pytest.skip("FastEmbed is not installed, skipping")

--- a/tests/embed_tests/test_local_inference.py
+++ b/tests/embed_tests/test_local_inference.py
@@ -1672,9 +1672,10 @@ def test_batch_size_propagation():
     local_client = QdrantClient(":memory:", local_inference_batch_size=inference_batch_size)
     if not local_client._FASTEMBED_INSTALLED:
         pytest.skip("FastEmbed is not installed, skipping")
-    local_client._model_embedder.embedder.embed = mock(
-        local_client._model_embedder.embedder.embed, param_storage
-    )
+    # local_client._model_embedder.embedder.embed = mock(
+    #     local_client._model_embedder.embedder.embed, param_storage
+    # )
+    Embedder.embed = mock(Embedder.embed, param_storage)
 
     if not local_client._FASTEMBED_INSTALLED:
         pytest.skip("FastEmbed is not installed, skipping")
@@ -1714,3 +1715,4 @@ def test_batch_size_propagation():
         COLLECTION_NAME, points=points, batch_size=3
     )  # uses _embed_models_strict
     assert param_storage["batch_size"] == inference_batch_size
+    param_storage.clear()

--- a/tests/embed_tests/test_local_inference.py
+++ b/tests/embed_tests/test_local_inference.py
@@ -10,6 +10,7 @@ from tests.congruence_tests.test_common import (
     compare_collections,
 )
 from qdrant_client.qdrant_fastembed import IDF_EMBEDDING_MODELS
+from qdrant_client.embed.embedder import Embedder
 
 
 COLLECTION_NAME = "inference_collection"
@@ -1653,3 +1654,63 @@ def test_upsert_batch_with_different_options(prefer_grpc):
         num_vectors=10,
         collection_name=COLLECTION_NAME,
     )
+
+
+def test_batch_size_propagation():
+    def mock(func, kw_param_storage):
+        def decorated(*args, **kwargs):
+            for k in kwargs:
+                kw_param_storage[k] = kwargs[k]
+            return func(*args, **kwargs)
+
+        return decorated
+
+    param_storage = {}
+
+    bm25_name = "Qdrant/bm25"
+    inference_batch_size = 2
+    local_client = QdrantClient(":memory:", local_inference_batch_size=inference_batch_size)
+    if not local_client._FASTEMBED_INSTALLED:
+        pytest.skip("FastEmbed is not installed, skipping")
+    local_client._model_embedder.embedder.embed = mock(
+        local_client._model_embedder.embedder.embed, param_storage
+    )
+
+    if not local_client._FASTEMBED_INSTALLED:
+        pytest.skip("FastEmbed is not installed, skipping")
+
+    sparse_doc_1 = models.Document(
+        text="a quick",
+        model=bm25_name,
+    )
+    sparse_doc_2 = models.Document(
+        text="brown fox",
+        model=bm25_name,
+    )
+    sparse_doc_3 = models.Document(
+        text="jumps over",
+        model=bm25_name,
+    )
+    sparse_doc_4 = models.Document(
+        text="a lazy dog",
+        model=bm25_name,
+    )
+    local_client.create_collection(
+        COLLECTION_NAME, sparse_vectors_config={"sparse": models.SparseVectorParams()}
+    )
+    points = [
+        models.PointStruct(id=0, vector={"sparse": sparse_doc_1}),
+        models.PointStruct(id=1, vector={"sparse": sparse_doc_2}),
+        models.PointStruct(id=2, vector={"sparse": sparse_doc_3}),
+        models.PointStruct(id=3, vector={"sparse": sparse_doc_4}),
+    ]
+    local_client.upsert(  # uses _embed_models
+        COLLECTION_NAME, points
+    )
+    assert param_storage["batch_size"] == inference_batch_size
+    param_storage.clear()
+
+    local_client.upload_points(
+        COLLECTION_NAME, points=points, batch_size=3
+    )  # uses _embed_models_strict
+    assert param_storage["batch_size"] == inference_batch_size


### PR DESCRIPTION
According to the benchmarks we ran, a large inference batch size on cpu usually leads to a worse performance for both text and image objects, thus we're decreasing the default value to 8 (might be machine dependant)