### PR TITLE
fix: model fields set and model config access

### DIFF
--- a/qdrant_client/_pydantic_compat.py
+++ b/qdrant_client/_pydantic_compat.py
@@ -53,3 +53,10 @@ def model_json_schema(model: Type[BaseModel], *args: Any, **kwargs: Any) -> dict
         return model.model_json_schema(*args, **kwargs)
     else:
         return json.loads(model.schema_json(*args, **kwargs))
+
+
+def model_config(model: Type[BaseModel]) -> dict[str, Any]:
+    if PYDANTIC_V2:
+        return model.model_config
+    else:
+        return dict(vars(model.__config__))

--- a/qdrant_client/embed/type_inspector.py
+++ b/qdrant_client/embed/type_inspector.py
@@ -2,6 +2,7 @@ from typing import Union, Optional, Iterable
 
 from pydantic import BaseModel
 
+from qdrant_client._pydantic_compat import model_fields_set
 from qdrant_client.embed.common import INFERENCE_OBJECT_TYPES
 from qdrant_client.embed.schema_parser import ModelSchemaParser
 from qdrant_client.embed.utils import FieldPath
@@ -62,7 +63,7 @@ class Inspector:
     ) -> bool:
         def inspect_recursive(member: BaseModel) -> bool:
             recursive_paths = []
-            for field_name in member.model_fields_set:
+            for field_name in model_fields_set(member):
                 if field_name in self.parser.name_recursive_ref_mapping:
                     mapped_model_name = self.parser.name_recursive_ref_mapping[field_name]
                     if mapped_model_name not in self.parser.path_cache:

--- a/tools/populate_inspection_cache.py
+++ b/tools/populate_inspection_cache.py
@@ -6,6 +6,7 @@ from typing import Union
 from pydantic import BaseModel
 
 from qdrant_client import models
+from qdrant_client._pydantic_compat import model_config
 from qdrant_client.embed.schema_parser import ModelSchemaParser
 from types import ModuleType
 
@@ -40,7 +41,8 @@ if __name__ == "__main__":
         if not issubclass(model, BaseModel) or model == BaseModel:
             continue
 
-        if "extra" not in model.model_config or model.model_config["extra"] != "forbid":  # type: ignore
+        config = model_config(model)
+        if "extra" not in config or config["extra"] != "forbid":  # type: ignore
             continue
 
         parser.parse_model(model)


### PR DESCRIPTION
due to incorrect access to `model_fields_set` the following upsert was failing in pydantic v1

```python
from qdrant_client import QdrantClient, models

if __name__ == '__main__':
    client = QdrantClient(":memory:")
    collection_name = "test"

    # Create collection with sparse vector support
    client.create_collection(
        collection_name=collection_name,
        sparse_vectors_config={
            "text": models.SparseVectorParams(),
        },
    )

    client.upsert(
        collection_name=collection_name,
        points=[
            models.PointStruct(
                id=1,
                vector={
                    "text": models.SparseVector(
                        indices=[1, 3, 5, 6],
                        values=[0.1, 0.2, 0.3, 0.4],
                    )
                },
            )
        ],
    )
```