### PR TITLE
new: decrease number of vectors where possible

### DIFF
--- a/tests/congruence_tests/test_collections.py
+++ b/tests/congruence_tests/test_collections.py
@@ -18,7 +18,7 @@ COLLECTION_NAME = "test_collection"
 
 
 def test_get_collection():
-    fixture_points = generate_fixtures()
+    fixture_points = generate_fixtures(100)
 
     remote_client = init_remote()
 
@@ -106,7 +106,7 @@ def test_init_from():
     remote_client = init_remote()
     local_client = init_local()
 
-    points = generate_fixtures(vectors_sizes=vector_size)
+    points = generate_fixtures(100, vectors_sizes=vector_size)
     vector_params = models.VectorParams(size=vector_size, distance=models.Distance.COSINE)
 
     if remote_client.collection_exists(COLLECTION_NAME):

--- a/tests/congruence_tests/test_discovery.py
+++ b/tests/congruence_tests/test_discovery.py
@@ -373,7 +373,7 @@ def test_context_with_filters(local_client, http_client, grpc_client, filter: mo
 
 
 def test_query_with_nan():
-    fixture_points = generate_fixtures()
+    fixture_points = generate_fixtures(100)
     vector = np.random.random(image_vector_size)
     vector[0] = np.nan
     vector = vector.tolist()

--- a/tests/congruence_tests/test_group_search.py
+++ b/tests/congruence_tests/test_group_search.py
@@ -217,7 +217,7 @@ def group_by_keys():
 
 
 def test_group_search_types():
-    fixture_points = generate_fixtures(vectors_sizes=50)
+    fixture_points = generate_fixtures(100, vectors_sizes=50)
     vectors_config = models.VectorParams(size=50, distance=models.Distance.EUCLID)
 
     searcher = TestGroupSearcher()
@@ -244,7 +244,7 @@ def test_group_search_types():
     delete_fixture_collection(local_client)
     delete_fixture_collection(remote_client)
 
-    fixture_points = generate_fixtures()
+    fixture_points = generate_fixtures(100)
     init_client(local_client, fixture_points)
     init_client(remote_client, fixture_points)
 

--- a/tests/congruence_tests/test_optional_vectors.py
+++ b/tests/congruence_tests/test_optional_vectors.py
@@ -3,7 +3,6 @@ import numpy as np
 from qdrant_client.http.models import models
 from tests.congruence_tests.test_common import (
     COLLECTION_NAME,
-    NUM_VECTORS,
     compare_client_results,
     generate_fixtures,
     generate_sparse_fixtures,
@@ -18,7 +17,8 @@ from tests.fixtures.points import random_sparse_vectors
 
 
 def test_simple_opt_vectors_search():
-    fixture_points = generate_fixtures()
+    num_vectors = 100
+    fixture_points = generate_fixtures(num=num_vectors)
 
     local_client = init_local()
     init_client(local_client, fixture_points)
@@ -26,7 +26,7 @@ def test_simple_opt_vectors_search():
     remote_client = init_remote()
     init_client(remote_client, fixture_points)
 
-    ids_to_delete = [x for x in range(NUM_VECTORS) if x % 5 == 0]
+    ids_to_delete = [x for x in range(num_vectors) if x % 5 == 0]
 
     vectors_to_retrieve = [x for x in range(20)]
 
@@ -90,7 +90,8 @@ def test_simple_opt_vectors_search():
 
 
 def test_simple_opt_sparse_vectors_search():
-    fixture_points = generate_sparse_fixtures()
+    num_vectors = 100
+    fixture_points = generate_sparse_fixtures(num=num_vectors)
 
     local_client = init_local()
     init_client(
@@ -108,7 +109,7 @@ def test_simple_opt_sparse_vectors_search():
         sparse_vectors_config=sparse_vectors_config,
     )
 
-    ids_to_delete = [x for x in range(NUM_VECTORS) if x % 5 == 0]
+    ids_to_delete = [x for x in range(num_vectors) if x % 5 == 0]
 
     vectors_to_retrieve = [x for x in range(20)]
 

--- a/tests/congruence_tests/test_query.py
+++ b/tests/congruence_tests/test_query.py
@@ -763,7 +763,7 @@ def test_dense_query_lookup_from_another_collection():
 
 
 def test_dense_query_lookup_from_negative():
-    fixture_points = generate_fixtures()
+    fixture_points = generate_fixtures(100)
 
     secondary_collection_points = generate_fixtures(10)
 
@@ -827,7 +827,7 @@ def test_no_query_no_prefetch():
     if not dev and None not in (major, minor, patch) and (major, minor, patch) < (1, 10, 1):
         pytest.skip("Works as of version 1.10.1")
 
-    fixture_points = generate_fixtures()
+    fixture_points = generate_fixtures(100)
 
     searcher = TestSimpleSearcher()
 
@@ -841,7 +841,7 @@ def test_no_query_no_prefetch():
 
 
 def test_dense_query_nested_prefetch():
-    fixture_points = generate_fixtures()
+    fixture_points = generate_fixtures(100)
 
     searcher = TestSimpleSearcher()
 
@@ -875,7 +875,7 @@ def test_dense_query_filtered_prefetch():
 
 
 def test_dense_query_prefetch_score_threshold():
-    fixture_points = generate_fixtures()
+    fixture_points = generate_fixtures(100)
 
     searcher = TestSimpleSearcher()
 
@@ -887,7 +887,7 @@ def test_dense_query_prefetch_score_threshold():
 
 
 def test_dense_query_prefetch_parametrized():
-    fixture_points = generate_fixtures()
+    fixture_points = generate_fixtures(100)
 
     searcher = TestSimpleSearcher()
 
@@ -924,7 +924,7 @@ def test_dense_query_prefetch_parametrized():
 
 
 def test_dense_query_parametrized():
-    fixture_points = generate_fixtures()
+    fixture_points = generate_fixtures(100)
 
     searcher = TestSimpleSearcher()
 
@@ -951,7 +951,7 @@ def test_dense_query_parametrized():
 
 
 def test_sparse_query():
-    fixture_points = generate_sparse_fixtures()
+    fixture_points = generate_sparse_fixtures(100)
 
     searcher = TestSimpleSearcher()
 
@@ -963,7 +963,7 @@ def test_sparse_query():
 
 
 def test_multivec_query():
-    fixture_points = generate_multivector_fixtures()
+    fixture_points = generate_multivector_fixtures(100)
 
     searcher = TestSimpleSearcher()
 
@@ -1024,7 +1024,7 @@ def test_dense_query():
 
 
 def test_dense_query_orderby():
-    fixture_points = generate_fixtures(200)
+    fixture_points = generate_fixtures(100)
 
     searcher = TestSimpleSearcher()
 
@@ -1041,7 +1041,7 @@ def test_dense_query_orderby():
 
 
 def test_dense_query_recommend():
-    fixture_points = generate_fixtures()
+    fixture_points = generate_fixtures(100)
 
     searcher = TestSimpleSearcher()
 
@@ -1052,7 +1052,7 @@ def test_dense_query_recommend():
 
 
 def test_dense_query_rescore():
-    fixture_points = generate_fixtures()
+    fixture_points = generate_fixtures(100)
 
     searcher = TestSimpleSearcher()
 
@@ -1065,7 +1065,7 @@ def test_dense_query_rescore():
 
 
 def test_dense_query_fusion():
-    fixture_points = generate_fixtures()
+    fixture_points = generate_fixtures(100)
 
     searcher = TestSimpleSearcher()
 
@@ -1270,7 +1270,7 @@ def test_search_with_persistence_and_skipped_vectors():
 def test_query_invalid_vector_type():
     import grpc
 
-    fixture_points = generate_fixtures()
+    fixture_points = generate_fixtures(10)
 
     local_client, http_client, grpc_client = init_clients(fixture_points)
 
@@ -1292,7 +1292,7 @@ def test_query_invalid_vector_type():
 
 
 def test_query_with_nan():
-    fixture_points = generate_fixtures()
+    fixture_points = generate_fixtures(10)
 
     local_client, http_client, grpc_client = init_clients(fixture_points)
 
@@ -1335,7 +1335,7 @@ def test_query_with_nan():
 
 
 def test_flat_query_dense_interface():
-    fixture_points = generate_fixtures()
+    fixture_points = generate_fixtures(100)
 
     searcher = TestSimpleSearcher()
 
@@ -1351,7 +1351,7 @@ def test_flat_query_dense_interface():
 
 
 def test_flat_query_sparse_interface():
-    fixture_points = generate_sparse_fixtures()
+    fixture_points = generate_sparse_fixtures(100)
 
     searcher = TestSimpleSearcher()
 
@@ -1363,7 +1363,7 @@ def test_flat_query_sparse_interface():
 
 
 def test_flat_query_multivector_interface():
-    fixture_points = generate_multivector_fixtures()
+    fixture_points = generate_multivector_fixtures(100)
 
     searcher = TestSimpleSearcher()
 

--- a/tests/congruence_tests/test_query_batch.py
+++ b/tests/congruence_tests/test_query_batch.py
@@ -135,7 +135,7 @@ class TestQueryBatchSearcher:
 
 
 def test_sparse_query_batch():
-    fixture_points = generate_sparse_fixtures()
+    fixture_points = generate_sparse_fixtures(100)
 
     searcher = TestQueryBatchSearcher()
 
@@ -149,7 +149,7 @@ def test_sparse_query_batch():
 
 
 def test_multivec_query_batch():
-    fixture_points = generate_multivector_fixtures()
+    fixture_points = generate_multivector_fixtures(100)
 
     searcher = TestQueryBatchSearcher()
 
@@ -164,7 +164,7 @@ def test_multivec_query_batch():
 
 @pytest.mark.parametrize("prefer_grpc", (False, True))
 def test_dense_query_batch(prefer_grpc):
-    fixture_points = generate_fixtures()
+    fixture_points = generate_fixtures(100)
 
     searcher = TestQueryBatchSearcher()
 

--- a/tests/congruence_tests/test_recommendation.py
+++ b/tests/congruence_tests/test_recommendation.py
@@ -275,7 +275,7 @@ def test_simple_recommend() -> None:
 
 
 def test_query_with_nan():
-    fixture_points = generate_fixtures()
+    fixture_points = generate_fixtures(100)
     vector = np.random.random(image_vector_size)
     vector[0] = np.nan
     vector = vector.tolist()

--- a/tests/congruence_tests/test_retrieve.py
+++ b/tests/congruence_tests/test_retrieve.py
@@ -14,7 +14,7 @@ from tests.congruence_tests.test_common import (
 
 
 def test_retrieve(local_client, remote_client) -> None:
-    num_vectors = 1000
+    num_vectors = 100
     fixture_points = generate_fixtures(num_vectors)
     keys = list(fixture_points[0].payload.keys())
 
@@ -74,7 +74,7 @@ def test_retrieve(local_client, remote_client) -> None:
 
 
 def test_sparse_retrieve() -> None:
-    num_vectors = 1000
+    num_vectors = 100
     fixture_points = generate_sparse_fixtures(num_vectors)
 
     local_client = init_local()

--- a/tests/congruence_tests/test_search.py
+++ b/tests/congruence_tests/test_search.py
@@ -321,7 +321,7 @@ def test_search_with_persistence_and_skipped_vectors():
 
 
 def test_search_invalid_vector_type():
-    fixture_points = generate_fixtures()
+    fixture_points = generate_fixtures(10)
 
     local_client = init_local()
     init_client(local_client, fixture_points)
@@ -338,7 +338,7 @@ def test_search_invalid_vector_type():
 
 
 def test_query_with_nan():
-    fixture_points = generate_fixtures()
+    fixture_points = generate_fixtures(10)
 
     local_client = init_local()
     init_client(local_client, fixture_points)

--- a/tests/congruence_tests/test_sparse_idf_search.py
+++ b/tests/congruence_tests/test_sparse_idf_search.py
@@ -37,6 +37,7 @@ class TestSimpleSparseSearcher:
 
 def test_simple_search():
     fixture_points = generate_sparse_fixtures(
+        100,
         vectors_sizes={"sparse-text": sparse_text_vector_size},
         even_sparse=False,
         with_payload=False,
@@ -90,6 +91,7 @@ def test_search_with_persistence():
     import tempfile
 
     fixture_points = generate_sparse_fixtures(
+        100,
         vectors_sizes={"sparse-text": sparse_text_vector_size},
         even_sparse=False,
         with_payload=False,

--- a/tests/congruence_tests/test_sparse_recommend.py
+++ b/tests/congruence_tests/test_sparse_recommend.py
@@ -204,9 +204,9 @@ class TestSimpleRecommendation:
 
 
 def test_simple_recommend() -> None:
-    fixture_points = generate_sparse_fixtures()
+    fixture_points = generate_sparse_fixtures(100)
 
-    secondary_collection_points = generate_sparse_fixtures(100)
+    secondary_collection_points = generate_sparse_fixtures(50)
 
     searcher = TestSimpleRecommendation()
 
@@ -256,6 +256,28 @@ def test_simple_recommend() -> None:
     )
     compare_client_results(local_client, remote_client, searcher.recommend_batch)
 
+
+def test_simple_recommend_filters():
+    fixture_points = generate_sparse_fixtures()
+
+    searcher = TestSimpleRecommendation()
+
+    local_client = init_local()
+    init_client(
+        local_client,
+        fixture_points,
+        vectors_config={},
+        sparse_vectors_config=sparse_vectors_config,
+    )
+
+    remote_client = init_remote()
+    init_client(
+        remote_client,
+        fixture_points,
+        vectors_config={},
+        sparse_vectors_config=sparse_vectors_config,
+    )
+
     for _ in range(10):
         query_filter = one_random_filter_please()
         try:
@@ -271,7 +293,7 @@ def test_simple_recommend() -> None:
 
 
 def test_query_with_nan():
-    fixture_points = generate_sparse_fixtures()
+    fixture_points = generate_sparse_fixtures(10)
     sparse_vector_dict = random_sparse_vectors({"sparse-image": sparse_image_vector_size})
     sparse_vector = sparse_vector_dict["sparse-image"]
     sparse_vector.values[0] = np.nan

--- a/tests/congruence_tests/test_sparse_search.py
+++ b/tests/congruence_tests/test_sparse_search.py
@@ -288,7 +288,7 @@ def test_query_with_nan():
     local_client = init_local()
     remote_client = init_remote()
 
-    fixture_points = generate_sparse_fixtures()
+    fixture_points = generate_sparse_fixtures(100)
     sparse_vector = random_sparse_vectors({"sparse-text": sparse_text_vector_size})
     named_sparse_vector = models.NamedSparseVector(
         name="sparse-text", vector=sparse_vector["sparse-text"]

--- a/tests/integration-tests.sh
+++ b/tests/integration-tests.sh
@@ -39,9 +39,9 @@ done
 # Backwards compatibility tests are enabled by setting QDRANT_VERSION to a version that is not the latest
 # OR by setting IGNORE_CONGRUENCE_TESTS to true
 if [[ "$QDRANT_VERSION" != "$QDRANT_LATEST" ]] || [[ "$IGNORE_CONGRUENCE_TESTS" == "true" ]]; then
-  QDRANT_VERSION=$QDRANT_VERSION pytest --ignore=tests/congruence_tests
+  QDRANT_VERSION=$QDRANT_VERSION pytest -x --ignore=tests/congruence_tests
 else
-  QDRANT_VERSION=$QDRANT_VERSION pytest
+  QDRANT_VERSION=$QDRANT_VERSION pytest -x
 fi
 
 


### PR DESCRIPTION
this pr contains all the places where we can decrease the number of vectors in congruence tests without sacrificing payload filters