### PR TITLE
Rest & grpc client generation fix

### DIFF
--- a/tools/generate_grpc_client.sh
+++ b/tools/generate_grpc_client.sh
@@ -1,48 +1,62 @@
 #!/usr/bin/env bash
-
 set -e
 
 PROJECT_ROOT="$(pwd)/$(dirname "$0")/../"
 
-pip install grpcio==1.48.2
-pip install grpcio-tools==1.48.2 # the expected python version to use is 3.10.10
+TMP_QDRANT=$(mktemp -d)
+TMP_POETRY=$(mktemp -d)
+TMP_POETRY_PROJECT=$(mktemp -d)
 
-cd $(mktemp -d)
+cleanup() {
+  echo "Cleaning up temporary directories..."
+  rm -rf "$TMP_QDRANT" "$TMP_POETRY" "$TMP_POETRY_PROJECT"
+}
+trap cleanup EXIT
 
+export POETRY_VIRTUALENVS_PATH="$TMP_POETRY"
+cd "$TMP_POETRY_PROJECT"
+poetry init --no-interaction --name temp-proj
+# Force Poetry to use Python 3.10, won't work if python3.10 is not available at PATH
+poetry env use python3.10
+
+PYTHON_VERSION=$(poetry run python --version)
+echo "Using Python version: $PYTHON_VERSION"
+
+poetry run pip install grpcio==1.48.2 grpcio-tools==1.48.2
+
+cd "$TMP_QDRANT"
 git clone --sparse --filter=blob:none --depth=1 -b dev git@github.com:qdrant/qdrant.git
 cd qdrant
 git sparse-checkout add lib/api/src/grpc/proto
 
 PROTO_DIR="$(pwd)/lib/api/src/grpc/proto"
 
-# Ensure current path is project root
-cd $PROJECT_ROOT
+cd "$PROJECT_ROOT"
 
 CLIENT_DIR="qdrant_client/proto"
 
-cp $PROTO_DIR/*.proto $CLIENT_DIR/
+cp "$PROTO_DIR"/*.proto "$CLIENT_DIR/"
 
-# Remove internal services *.proto
-rm $CLIENT_DIR/collections_internal_service.proto
-rm $CLIENT_DIR/points_internal_service.proto
-rm $CLIENT_DIR/qdrant_internal_service.proto
-rm $CLIENT_DIR/shard_snapshots_service.proto
-rm $CLIENT_DIR/raft_service.proto
-rm $CLIENT_DIR/health_check.proto
+rm "$CLIENT_DIR"/collections_internal_service.proto \
+   "$CLIENT_DIR"/points_internal_service.proto \
+   "$CLIENT_DIR"/qdrant_internal_service.proto \
+   "$CLIENT_DIR"/shard_snapshots_service.proto \
+   "$CLIENT_DIR"/raft_service.proto \
+   "$CLIENT_DIR"/health_check.proto
 
-cat $CLIENT_DIR/qdrant.proto \
- | grep -v 'collections_internal_service.proto' \
- | grep -v 'points_internal_service.proto' \
- | grep -v 'qdrant_internal_service.proto' \
- | grep -v 'shard_snapshots_service.proto' \
- | grep -v 'raft_service.proto' \
- | grep -v 'health_check.proto' \
-  > $CLIENT_DIR/qdrant_tmp.proto
-mv $CLIENT_DIR/qdrant_tmp.proto $CLIENT_DIR/qdrant.proto
+grep -v 'collections_internal_service.proto' "$CLIENT_DIR/qdrant.proto" \
+  | grep -v 'points_internal_service.proto' \
+  | grep -v 'qdrant_internal_service.proto' \
+  | grep -v 'shard_snapshots_service.proto' \
+  | grep -v 'raft_service.proto' \
+  | grep -v 'health_check.proto' \
+  > "$CLIENT_DIR/qdrant_tmp.proto"
+mv "$CLIENT_DIR/qdrant_tmp.proto" "$CLIENT_DIR/qdrant.proto"
 
-python -m grpc_tools.protoc --proto_path=qdrant_client/proto/ -I ./qdrant_client/grpc ./qdrant_client/proto/*.proto --python_out=./qdrant_client/grpc --grpc_python_out=./qdrant_client/grpc
-
-# maybe I'll remove this crutch when google makes normal imports for issue from 2016
-# https://github.com/protocolbuffers/protobuf/issues/1491
+poetry run python -m grpc_tools.protoc --proto_path=qdrant_client/proto/ \
+  -I ./qdrant_client/grpc \
+  ./qdrant_client/proto/*.proto \
+  --python_out=./qdrant_client/grpc \
+  --grpc_python_out=./qdrant_client/grpc
 
 sed -i -re 's/^import (\w*)_pb2/from . import \1_pb2/g' ./qdrant_client/grpc/*.py

--- a/tools/generate_rest_client.sh
+++ b/tools/generate_rest_client.sh
@@ -1,23 +1,18 @@
 #!/usr/bin/env bash
 set -e
 
-# Define the project root relative to this script.
 PROJECT_ROOT="$(pwd)/$(dirname "$0")/../"
 
-# Create temporary directories for the qdrant clone, pydantic_openapi_v3 clone,
-# and a separate temporary directory for poetry's virtual environment.
 TMP_QDRANT=$(mktemp -d)
 TMP_PYDANTIC=$(mktemp -d)
 TMP_POETRY_ENV=$(mktemp -d)
 
-# Function to cleanup temporary directories on exit.
 cleanup() {
   echo "Cleaning up temporary directories..."
   rm -rf "$TMP_QDRANT" "$TMP_PYDANTIC" "$TMP_POETRY_ENV"
 }
 trap cleanup EXIT
 
-# --- Clone qdrant repository and extract the openapi.json ---
 cd "$TMP_QDRANT"
 git clone --sparse --filter=blob:none --depth=1 -b dev git@github.com:qdrant/qdrant.git
 cd qdrant
@@ -29,21 +24,16 @@ if [ ! -f "$OPENAPI_PATH" ]; then
   exit 1
 fi
 
-# --- Clone pydantic_openapi_v3 repository and set up a separated poetry environment ---
 cd "$TMP_PYDANTIC"
 git clone git@github.com:qdrant/pydantic_openapi_v3.git
 cd pydantic_openapi_v3
 
-# Set the poetry virtual environment path to our temporary directory.
 export POETRY_VIRTUALENVS_PATH="$TMP_POETRY_ENV"
-# Force poetry to use python3.10 for this environment.
 poetry env use python3.10
 poetry install
 
-# Copy the openapi spec to the working directory.
 cp "$OPENAPI_PATH" openapi-qdrant.yaml
 
-# Run the model data generator script with the proper environment variables.
 PATH_TO_QDRANT_CLIENT="$PROJECT_ROOT"
 INPUT_YAML=openapi-qdrant.yaml \
 ROOT_PACKAGE_NAME="qdrant_client" \
@@ -51,6 +41,5 @@ IMPORT_NAME="qdrant_client.http" \
 PACKAGE_NAME=qdrant_openapi_client \
 bash -x scripts/model_data_generator.sh
 
-# Replace the qdrant client's http module with the generated one.
 rm -rf "${PATH_TO_QDRANT_CLIENT}/qdrant_client/http/"
 mv scripts/output/qdrant_openapi_client "${PATH_TO_QDRANT_CLIENT}/qdrant_client/http/"

--- a/tools/generate_rest_client.sh
+++ b/tools/generate_rest_client.sh
@@ -3,9 +3,28 @@ set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TEMP_ENV=$(mktemp -d)
-VENV_DIR="$TEMP_ENV/venv"
+QDRANT_PATH=$(mktemp -d)
+GENERATOR_PATH=$(mktemp -d)
+VENV_DIR="$TEMP_ENV/rest_generator_venv"
 
-python -m venv "$VENV_DIR"
+PYTHON_BIN=""
+
+if [[ "$(python --version 2>&1 | awk '{print $2}')" == "3.10.10" ]]; then
+    PYTHON_BIN="python"
+elif [[ "$(python3 --version 2>&1 | awk '{print $2}')" == "3.10.10" ]]; then
+    PYTHON_BIN="python3"
+elif [[ "$(python3.10 --version 2>&1 | awk '{print $2}')" == "3.10.10" ]]; then
+    PYTHON_BIN="python3.10"
+fi
+
+if [[ -z "$PYTHON_BIN" ]]; then
+    echo "Error: No suitable Python 3.10.10 installation found among {python, python3, python3.10}" >&2
+    exit 1
+fi
+
+trap 'rm -rf "$TEMP_ENV"; rm -rf "$QDRANT_PATH"; rm -rf "$GENERATOR_PATH"' EXIT
+
+"$PYTHON_BIN" -m venv "$VENV_DIR"
 source "$VENV_DIR/bin/activate"
 
 if ! command -v poetry &>/dev/null; then
@@ -17,7 +36,7 @@ fi
 cd "$PROJECT_ROOT"
 poetry install
 
-cd $(mktemp -d)
+cd "$QDRANT_PATH"
 git clone --sparse --filter=blob:none --depth=1 -b dev git@github.com:qdrant/qdrant.git
 cd qdrant
 git sparse-checkout add docs/redoc/master
@@ -29,7 +48,7 @@ if [ ! -f "$OPENAPI_PATH" ]; then
   exit 1
 fi
 
-cd $(mktemp -d)
+cd "$GENERATOR_PATH"
 git clone git@github.com:qdrant/pydantic_openapi_v3.git
 cd pydantic_openapi_v3
 
@@ -37,12 +56,9 @@ poetry install
 
 cp "$OPENAPI_PATH" openapi-qdrant.yaml
 
-PATH_TO_QDRANT_CLIENT=$PROJECT_ROOT
-
 INPUT_YAML="openapi-qdrant.yaml" ROOT_PACKAGE_NAME="qdrant_client" IMPORT_NAME="qdrant_client.http" PACKAGE_NAME=qdrant_openapi_client bash -x scripts/model_data_generator.sh
 
-rm -rf "${PATH_TO_QDRANT_CLIENT}/qdrant_client/http/"
-mv scripts/output/qdrant_openapi_client "${PATH_TO_QDRANT_CLIENT}/qdrant_client/http/"
+rm -rf "${PROJECT_ROOT}/qdrant_client/http/"
+mv scripts/output/qdrant_openapi_client "${PROJECT_ROOT}/qdrant_client/http/"
 
 deactivate
-rm -rf "$TEMP_ENV"

--- a/tools/generate_rest_client.sh
+++ b/tools/generate_rest_client.sh
@@ -5,11 +5,11 @@ PROJECT_ROOT="$(pwd)/$(dirname "$0")/../"
 
 TMP_QDRANT=$(mktemp -d)
 TMP_PYDANTIC=$(mktemp -d)
-TMP_POETRY_ENV=$(mktemp -d)
+TMP_VENV=$(mktemp -d)
 
 cleanup() {
   echo "Cleaning up temporary directories..."
-  rm -rf "$TMP_QDRANT" "$TMP_PYDANTIC" "$TMP_POETRY_ENV"
+  rm -rf "$TMP_QDRANT" "$TMP_PYDANTIC" "$TMP_VENV"
 }
 trap cleanup EXIT
 
@@ -28,9 +28,11 @@ cd "$TMP_PYDANTIC"
 git clone git@github.com:qdrant/pydantic_openapi_v3.git
 cd pydantic_openapi_v3
 
-export POETRY_VIRTUALENVS_PATH="$TMP_POETRY_ENV"
-poetry env use python3.10
-poetry install
+# Set up venv instead of poetry
+python3.10 -m venv "$TMP_VENV"
+source "$TMP_VENV/bin/activate"
+pip install --upgrade pip
+pip install .
 
 cp "$OPENAPI_PATH" openapi-qdrant.yaml
 
@@ -43,3 +45,5 @@ bash -x scripts/model_data_generator.sh
 
 rm -rf "${PATH_TO_QDRANT_CLIENT}/qdrant_client/http/"
 mv scripts/output/qdrant_openapi_client "${PATH_TO_QDRANT_CLIENT}/qdrant_client/http/"
+
+deactivate

--- a/tools/generate_rest_client.sh
+++ b/tools/generate_rest_client.sh
@@ -1,35 +1,56 @@
 #!/usr/bin/env bash
-
 set -e
 
+# Define the project root relative to this script.
 PROJECT_ROOT="$(pwd)/$(dirname "$0")/../"
 
-cd $(mktemp -d)
+# Create temporary directories for the qdrant clone, pydantic_openapi_v3 clone,
+# and a separate temporary directory for poetry's virtual environment.
+TMP_QDRANT=$(mktemp -d)
+TMP_PYDANTIC=$(mktemp -d)
+TMP_POETRY_ENV=$(mktemp -d)
 
+# Function to cleanup temporary directories on exit.
+cleanup() {
+  echo "Cleaning up temporary directories..."
+  rm -rf "$TMP_QDRANT" "$TMP_PYDANTIC" "$TMP_POETRY_ENV"
+}
+trap cleanup EXIT
+
+# --- Clone qdrant repository and extract the openapi.json ---
+cd "$TMP_QDRANT"
 git clone --sparse --filter=blob:none --depth=1 -b dev git@github.com:qdrant/qdrant.git
-
 cd qdrant
 git sparse-checkout add docs/redoc/master
 
 OPENAPI_PATH="$(pwd)/docs/redoc/master/openapi.json"
-
-if [ $? -ne 0 ]; then
+if [ ! -f "$OPENAPI_PATH" ]; then
   echo "Failed to generate inference structures"
   exit 1
 fi
 
-cd $(mktemp -d)
-
+# --- Clone pydantic_openapi_v3 repository and set up a separated poetry environment ---
+cd "$TMP_PYDANTIC"
 git clone git@github.com:qdrant/pydantic_openapi_v3.git
 cd pydantic_openapi_v3
 
+# Set the poetry virtual environment path to our temporary directory.
+export POETRY_VIRTUALENVS_PATH="$TMP_POETRY_ENV"
+# Force poetry to use python3.10 for this environment.
+poetry env use python3.10
 poetry install
 
-cp $OPENAPI_PATH openapi-qdrant.yaml
+# Copy the openapi spec to the working directory.
+cp "$OPENAPI_PATH" openapi-qdrant.yaml
 
-PATH_TO_QDRANT_CLIENT=$PROJECT_ROOT
+# Run the model data generator script with the proper environment variables.
+PATH_TO_QDRANT_CLIENT="$PROJECT_ROOT"
+INPUT_YAML=openapi-qdrant.yaml \
+ROOT_PACKAGE_NAME="qdrant_client" \
+IMPORT_NAME="qdrant_client.http" \
+PACKAGE_NAME=qdrant_openapi_client \
+bash -x scripts/model_data_generator.sh
 
-INPUT_YAML=openapi-qdrant.yaml ROOT_PACKAGE_NAME="qdrant_client" IMPORT_NAME="qdrant_client.http" PACKAGE_NAME=qdrant_openapi_client bash -x scripts/model_data_generator.sh
-
-rm -rf ${PATH_TO_QDRANT_CLIENT}/qdrant_client/http/
-mv scripts/output/qdrant_openapi_client ${PATH_TO_QDRANT_CLIENT}/qdrant_client/http/
+# Replace the qdrant client's http module with the generated one.
+rm -rf "${PATH_TO_QDRANT_CLIENT}/qdrant_client/http/"
+mv scripts/output/qdrant_openapi_client "${PATH_TO_QDRANT_CLIENT}/qdrant_client/http/"


### PR DESCRIPTION
Now:
Rest client should not break environment by downgrading pydentic to version 1.10
GRPC client generation should execute in a separate python environment of python3.10 and should not also break environment