### PR TITLE
Change user agent to python-client

### DIFF
--- a/qdrant_client/async_qdrant_remote.py
+++ b/qdrant_client/async_qdrant_remote.py
@@ -129,7 +129,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
             self._grpc_headers.append(("api-key", api_key))
         client_version = importlib.metadata.version("qdrant-client")
         python_version = platform.python_version()
-        user_agent = f"qdrant-client/{client_version} python/{python_version}"
+        user_agent = f"python-client/{client_version} python/{python_version}"
         self._rest_headers["User-Agent"] = user_agent
         self._grpc_options["grpc.primary_user_agent"] = user_agent
         grpc_compression: Optional[Compression] = kwargs.pop("grpc_compression", None)

--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -145,7 +145,7 @@ class QdrantRemote(QdrantBase):
 
         client_version = importlib.metadata.version("qdrant-client")
         python_version = platform.python_version()
-        user_agent = f"qdrant-client/{client_version} python/{python_version}"
+        user_agent = f"python-client/{client_version} python/{python_version}"
         self._rest_headers["User-Agent"] = user_agent
         self._grpc_options["grpc.primary_user_agent"] = user_agent
 

--- a/tests/test_qdrant_client.py
+++ b/tests/test_qdrant_client.py
@@ -2009,7 +2009,7 @@ def test_timeout_propagation():
 
 def test_grpc_options():
     client_version = importlib.metadata.version("qdrant-client")
-    user_agent = f"qdrant-client/{client_version}"
+    user_agent = f"python-client/{client_version}"
     python_version = f"python/{platform.python_version()}"
 
     client = QdrantClient(prefer_grpc=True)


### PR DESCRIPTION
Bumps <https://github.com/qdrant/qdrant-client/pull/861>

Change the first user agent component of the Python client from `qdrant-client/1.2.3` to `python-client/1.2.3`.

It makes it consistent with the other clients we have. I get that this repo is called `qdrant-client`, but I'd argue `python-client` more clearly shows Python is used.

Note that cloud requested this as part of their client notification efforts.

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you installed `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`?