### PR TITLE
Relax minmum version of portalocker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ pydantic = ">=1.10.8,!=2.0.*,!=2.1.*,!=2.2.0"  # can't use poetry ">=1.10.8,<2.0
 grpcio = { version = ">=1.41.0", allow-prereleases = true }
 protobuf = ">=3.20.0"
 urllib3 = ">=1.26.14,<3"
-portalocker = "^2.7.0"
+portalocker = ">=2.7.0"
 fastembed = [
     { version = "^0.7", optional = true },
 ]


### PR DESCRIPTION
### All Submissions:

* [X] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you installed `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

closes: https://github.com/qdrant/qdrant-client/issues/1033

There is no reason to hold back version of portalocker. This is very limiting and results in not able to use qdrant with newer packages that need portalocker version 3