### PR TITLE
new: relax test comparison

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -32,6 +32,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install jq
+        uses: dcarbone/install-jq-action@v3.2.0
       - name: Install dependencies
         run: |
           python -m pip install poetry
@@ -74,3 +76,10 @@ jobs:
           pytest -x tests/test_fastembed.py
           pytest -x tests/embed_tests/test_local_inference.py
         shell: bash
+      - name: Upload failed snapshot if tests fail
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: failed_snapshot
+          path: failed_snapshot.snapshot
+          retention-days: 10

--- a/tests/congruence_tests/test_common.py
+++ b/tests/congruence_tests/test_common.py
@@ -232,21 +232,21 @@ def compare_scored_record(
     point2: models.ScoredPoint,
     idx: int,
     rel_tol: float = 1e-4,
-    abs_tol: float = 0,
+    abs_tol: float = 1e-6,
 ) -> None:
-    assert (
-        point1.id == point2.id
-    ), f"point1[{idx}].id = {point1.id}, point2[{idx}].id = {point2.id}"
     assert math.isclose(
         np.float32(point1.score), np.float32(point2.score), rel_tol=rel_tol, abs_tol=abs_tol
     ), f"point1[{idx}].score = {point1.score}, point2[{idx}].score = {point2.score}, rel_tol={rel_tol}"
-    assert (
-        point1.payload == point2.payload
-    ), f"point1[{idx}].payload = {point1.payload}, point2[{idx}].payload = {point2.payload}"
-    compare_vectors(point1.vector, point2.vector, idx)
+    if point1.id == point2.id:
+        # same id means same payload
+        assert (
+            point1.payload == point2.payload
+        ), f"id:{point1.id} point1[{idx}].payload = {point1.payload}, point2[{idx}].payload = {point2.payload}"
+
+        compare_vectors(point1.vector, point2.vector, idx)
 
 
-def compare_records(res1: list, res2: list, rel_tol: float = 1e-4, abs_tol: float = 0) -> None:
+def compare_records(res1: list, res2: list, rel_tol: float = 1e-4, abs_tol: float = 1e-6) -> None:
     assert len(res1) == len(res2), f"len(res1) = {len(res1)}, len(res2) = {len(res2)}"
     for i in range(len(res2)):
         res1_item = res1[i]
@@ -301,15 +301,15 @@ def compare_client_results(
 
     if isinstance(res1, list):
         if is_context_search is True:
-            sorted_1 = sorted(res1, key=lambda x: (x.id))
-            sorted_2 = sorted(res2, key=lambda x: (x.id))
+            sorted_1 = sorted(res1, key=lambda x: (x.score, x.id))
+            sorted_2 = sorted(res2, key=lambda x: (x.score, x.id))
             compare_records(sorted_1, sorted_2, abs_tol=1e-5)
         else:
             compare_records(res1, res2)
     elif isinstance(res1, models.QueryResponse) and isinstance(res2, models.QueryResponse):
         if is_context_search is True:
-            sorted_1 = sorted(res1.points, key=lambda x: (x.id))
-            sorted_2 = sorted(res2.points, key=lambda x: (x.id))
+            sorted_1 = sorted(res1.points, key=lambda x: (x.score, x.id))
+            sorted_2 = sorted(res2.points, key=lambda x: (x.score, x.id))
             compare_records(sorted_1, sorted_2, abs_tol=1e-5)
         else:
             compare_records(res1.points, res2.points)

--- a/tests/congruence_tests/test_common.py
+++ b/tests/congruence_tests/test_common.py
@@ -301,15 +301,15 @@ def compare_client_results(
 
     if isinstance(res1, list):
         if is_context_search is True:
-            sorted_1 = sorted(res1, key=lambda x: (x.score, x.id))
-            sorted_2 = sorted(res2, key=lambda x: (x.score, x.id))
+            sorted_1 = sorted(res1, key=lambda x: x.id)
+            sorted_2 = sorted(res2, key=lambda x: x.id)
             compare_records(sorted_1, sorted_2, abs_tol=1e-5)
         else:
             compare_records(res1, res2)
     elif isinstance(res1, models.QueryResponse) and isinstance(res2, models.QueryResponse):
         if is_context_search is True:
-            sorted_1 = sorted(res1.points, key=lambda x: (x.score, x.id))
-            sorted_2 = sorted(res2.points, key=lambda x: (x.score, x.id))
+            sorted_1 = sorted(res1.points, key=lambda x: x.id)
+            sorted_2 = sorted(res2.points, key=lambda x: x.id)
             compare_records(sorted_1, sorted_2, abs_tol=1e-5)
         else:
             compare_records(res1.points, res2.points)

--- a/tests/congruence_tests/test_common.py
+++ b/tests/congruence_tests/test_common.py
@@ -301,15 +301,15 @@ def compare_client_results(
 
     if isinstance(res1, list):
         if is_context_search is True:
-            sorted_1 = sorted(res1, key=lambda x: x.id)
-            sorted_2 = sorted(res2, key=lambda x: x.id)
+            sorted_1 = sorted(res1, key=lambda x: (x.id))
+            sorted_2 = sorted(res2, key=lambda x: (x.id))
             compare_records(sorted_1, sorted_2, abs_tol=1e-5)
         else:
             compare_records(res1, res2)
     elif isinstance(res1, models.QueryResponse) and isinstance(res2, models.QueryResponse):
         if is_context_search is True:
-            sorted_1 = sorted(res1.points, key=lambda x: x.id)
-            sorted_2 = sorted(res2.points, key=lambda x: x.id)
+            sorted_1 = sorted(res1.points, key=lambda x: (x.id))
+            sorted_2 = sorted(res2.points, key=lambda x: (x.id))
             compare_records(sorted_1, sorted_2, abs_tol=1e-5)
         else:
             compare_records(res1.points, res2.points)

--- a/tests/congruence_tests/test_common.py
+++ b/tests/congruence_tests/test_common.py
@@ -234,9 +234,19 @@ def compare_scored_record(
     rel_tol: float = 1e-4,
     abs_tol: float = 1e-6,
 ) -> None:
+    # This is a special case, likely the result of scroll or context search
+    # We need to ensure ordering by another field
+    is_score_zero = point1.score == 0.0 and point2.score == 0.0
+
     assert math.isclose(
         np.float32(point1.score), np.float32(point2.score), rel_tol=rel_tol, abs_tol=abs_tol
     ), f"point1[{idx}].score = {point1.score}, point2[{idx}].score = {point2.score}, rel_tol={rel_tol}"
+
+    assert point1.order_value == point2.order_value, f"point1[{idx}].order_value = {point1.order_value}, point2[{idx}].order_value = {point2.order_value}"
+
+    if is_score_zero:
+        assert point1.id == point2.id, f"point1[{idx}].id = {point1.id}, point2[{idx}].id = {point2.id}"
+
     if point1.id == point2.id:
         # same id means same payload
         assert (


### PR DESCRIPTION
We frequently have a float precision related error in tests.
Example:

```python
E       AssertionError: point1[839].id = 724, point2[839].id = 361
E       assert 724 == 361
E        +  where 724 = ScoredPoint(id=724, version=0, score=-0.007863790728151798, payload={'id': 824, 'id_str': ['01', '12', '06'], 'text_da...: False, 'mixed_type': [0.45113, 0.18627, 0.33103], 'maybe': 'octopus'}, vector=None, shard_key=None, order_value=None).id
E        +  and   361 = ScoredPoint(id=361, version=45, score=-0.007863835, payload={'id': 461, 'id_str': ['12'], 'text_data': 'f46232dc6f2143...': True, 'mixed_type': 0.40555, 'maybe': 'ant', 'maybe_null': 'spider'}, vector=None, shard_key=None, order_value=None).id
```

Python and Rust can produce slightly different results of distance computation for the same pairs of vectors, which can lead to a broken sort ordering.

In order to mitigate it, we don't require the ids to be the same when comparing scored points, instead, we rely just on the score proximity.

~This PR also contains some improvements for the methods which can produce a list of points with the same scores, which are context pairs and sparse discovery / context / recommend~ 
`is_context_search` option can be safely removed, since we don't care about the order when the scores are the same or really close anymore.