### PR TITLE
Sparse no overlap distance computation

### DIFF
--- a/qdrant_client/local/sparse_distances.py
+++ b/qdrant_client/local/sparse_distances.py
@@ -97,17 +97,29 @@ SparseQueryVector = Union[
 
 
 def calculate_distance_sparse(
-    query: SparseVector, vectors: list[SparseVector]
+    query: SparseVector, vectors: list[SparseVector], empty_is_zero: bool = False
 ) -> types.NumpyArray:
+    """Calculate distances between a query sparse vector and a list of sparse vectors.
+
+    Args:
+        query (SparseVector): The query sparse vector.
+        vectors (list[SparseVector]): A list of sparse vectors to compare against.
+        empty_is_zero (bool): If True, distance between vectors with no overlap is treated as zero.
+            Otherwise, it is treated as negative infinity.
+            Simple nearest search requires `empty_is_zero` to be False, while methods like
+            recommend, discovery, and context search require True.
+    """
     scores = []
 
     for vector in vectors:
         score = sparse_dot_product(query, vector)
         if score is not None:
             scores.append(score)
-        else:
+        elif not empty_is_zero:
             # means no overlap
             scores.append(np.float32("-inf"))
+        else:
+            scores.append(np.float32(0.0))
 
     return np.array(scores, dtype=np.float32)
 

--- a/qdrant_client/local/sparse_distances.py
+++ b/qdrant_client/local/sparse_distances.py
@@ -158,8 +158,8 @@ def calculate_sparse_discovery_ranks(
     overall_ranks: types.NumpyArray = np.zeros(len(vectors), dtype=np.int32)
     for pair in context:
         # Get distances to positive and negative vectors
-        pos = calculate_distance_sparse(pair.positive, vectors)
-        neg = calculate_distance_sparse(pair.negative, vectors)
+        pos = calculate_distance_sparse(pair.positive, vectors, empty_is_zero=True)
+        neg = calculate_distance_sparse(pair.negative, vectors, empty_is_zero=True)
 
         pair_ranks = np.array(
             [
@@ -179,7 +179,7 @@ def calculate_sparse_discovery_scores(
     ranks = calculate_sparse_discovery_ranks(query.context, vectors)
 
     # Get distances to target
-    distances_to_target = calculate_distance_sparse(query.target, vectors)
+    distances_to_target = calculate_distance_sparse(query.target, vectors, empty_is_zero=True)
 
     sigmoided_distances = np.fromiter(
         (scaled_fast_sigmoid(xi) for xi in distances_to_target), np.float32
@@ -194,8 +194,8 @@ def calculate_sparse_context_scores(
     overall_scores: types.NumpyArray = np.zeros(len(vectors), dtype=np.float32)
     for pair in query.context_pairs:
         # Get distances to positive and negative vectors
-        pos = calculate_distance_sparse(pair.positive, vectors)
-        neg = calculate_distance_sparse(pair.negative, vectors)
+        pos = calculate_distance_sparse(pair.positive, vectors, empty_is_zero=True)
+        neg = calculate_distance_sparse(pair.negative, vectors, empty_is_zero=True)
 
         difference = pos - neg - EPSILON
         pair_scores = np.fromiter(
@@ -215,7 +215,7 @@ def calculate_sparse_recommend_best_scores(
         # Get scores to all examples
         scores: list[types.NumpyArray] = []
         for example in examples:
-            score = calculate_distance_sparse(example, vectors)
+            score = calculate_distance_sparse(example, vectors, empty_is_zero=True)
             scores.append(score)
 
         # Keep only max for each vector
@@ -245,7 +245,7 @@ def calculate_sparse_recommend_sum_scores(
 
         scores: list[types.NumpyArray] = []
         for example in examples:
-            score = calculate_distance_sparse(example, vectors)
+            score = calculate_distance_sparse(example, vectors, empty_is_zero=True)
             scores.append(score)
 
         if len(scores) == 0:


### PR DESCRIPTION
Simple nearest neighbours search requires dot product between non-overlapping vectors to produce -inf (so there are no points in the results if there are no overlap between indices of sparse vectors).
However, for methods such as recommend (with strategy != average), discovery and context 0.0 distance is assumed.