### PR TITLE
refactoring: remove is_context_search, reduce limits in context queries

### DIFF
--- a/tests/congruence_tests/test_common.py
+++ b/tests/congruence_tests/test_common.py
@@ -285,9 +285,6 @@ def compare_client_results(
     foo: Callable[[QdrantBase, Any], Any],
     **kwargs: Any,
 ) -> None:
-    # context search can have many points with the same 0.0 score
-    is_context_search = kwargs.pop("is_context_search", False)
-
     # get results from both clients
     res1 = foo(client1, **kwargs)
     res2 = foo(client2, **kwargs)
@@ -300,19 +297,9 @@ def compare_client_results(
             assert offset1 == offset2, f"offset1 = {offset1}, offset2 = {offset2}"
 
     if isinstance(res1, list):
-        if is_context_search is True:
-            sorted_1 = sorted(res1, key=lambda x: (x.id))
-            sorted_2 = sorted(res2, key=lambda x: (x.id))
-            compare_records(sorted_1, sorted_2, abs_tol=1e-5)
-        else:
-            compare_records(res1, res2)
+        compare_records(res1, res2)
     elif isinstance(res1, models.QueryResponse) and isinstance(res2, models.QueryResponse):
-        if is_context_search is True:
-            sorted_1 = sorted(res1.points, key=lambda x: (x.id))
-            sorted_2 = sorted(res2.points, key=lambda x: (x.id))
-            compare_records(sorted_1, sorted_2, abs_tol=1e-5)
-        else:
-            compare_records(res1.points, res2.points)
+        compare_records(res1.points, res2.points)
     elif isinstance(res1, models.SearchMatrixOffsetsResponse):
         assert res1.ids == res2.ids, f"res1.ids = {res1.ids}, res2.ids = {res2.ids}"
         # compare scores with margin

--- a/tests/congruence_tests/test_discovery.py
+++ b/tests/congruence_tests/test_discovery.py
@@ -66,12 +66,12 @@ def test_context_cosine(
             collection_name=COLLECTION_NAME,
             context=[models.ContextExamplePair(positive=10, negative=19)],
             with_payload=True,
-            limit=1000,
+            limit=10,
             using="text",
         )
 
-    compare_client_results(grpc_client, http_client, f, is_context_search=True)
-    compare_client_results(local_client, http_client, f, is_context_search=True)
+    compare_client_results(grpc_client, http_client, f)
+    compare_client_results(local_client, http_client, f)
 
 
 def test_context_dot(
@@ -84,12 +84,12 @@ def test_context_dot(
             collection_name=COLLECTION_NAME,
             context=[models.ContextExamplePair(positive=10, negative=19)],
             with_payload=True,
-            limit=1000,
+            limit=10,
             using="image",
         )
 
-    compare_client_results(grpc_client, http_client, f, is_context_search=True)
-    compare_client_results(local_client, http_client, f, is_context_search=True)
+    compare_client_results(grpc_client, http_client, f)
+    compare_client_results(local_client, http_client, f)
 
 
 def test_context_euclidean(
@@ -102,12 +102,12 @@ def test_context_euclidean(
             collection_name=COLLECTION_NAME,
             context=[models.ContextExamplePair(positive=11, negative=19)],
             with_payload=True,
-            limit=1000,
+            limit=10,
             using="code",
         )
 
-    compare_client_results(grpc_client, http_client, f, is_context_search=True)
-    compare_client_results(local_client, http_client, f, is_context_search=True)
+    compare_client_results(grpc_client, http_client, f)
+    compare_client_results(local_client, http_client, f)
 
 
 def test_context_many_pairs(
@@ -131,12 +131,12 @@ def test_context_many_pairs(
                 models.ContextExamplePair(positive=random_image_vector_1, negative=15),
             ],
             with_payload=True,
-            limit=1000,
+            limit=10,
             using="image",
         )
 
-    compare_client_results(grpc_client, http_client, f, is_context_search=True)
-    compare_client_results(local_client, http_client, f, is_context_search=True)
+    compare_client_results(grpc_client, http_client, f)
+    compare_client_results(local_client, http_client, f)
 
 
 def test_discover_cosine(
@@ -356,6 +356,9 @@ def test_discover_with_filters(local_client, http_client, grpc_client, filter: m
             query_filter=filter,
         )
 
+    compare_client_results(grpc_client, http_client, f)
+    compare_client_results(local_client, http_client, f)
+
 
 @pytest.mark.parametrize("filter", [one_random_filter_please() for _ in range(10)])
 def test_context_with_filters(local_client, http_client, grpc_client, filter: models.Filter):
@@ -363,13 +366,13 @@ def test_context_with_filters(local_client, http_client, grpc_client, filter: mo
         return client.discover(
             collection_name=COLLECTION_NAME,
             context=[models.ContextExamplePair(positive=15, negative=7)],
-            limit=1000,
+            limit=10,
             using="image",
             query_filter=filter,
         )
 
-    compare_client_results(grpc_client, http_client, f, is_context_search=True)
-    compare_client_results(local_client, http_client, f, is_context_search=True)
+    compare_client_results(grpc_client, http_client, f)
+    compare_client_results(local_client, http_client, f)
 
 
 def test_query_with_nan():

--- a/tests/congruence_tests/test_multivector_discovery_queries.py
+++ b/tests/congruence_tests/test_multivector_discovery_queries.py
@@ -77,12 +77,12 @@ def test_context_cosine(
             collection_name=COLLECTION_NAME,
             query=models.ContextQuery(context=[models.ContextPair(positive=10, negative=19)]),
             with_payload=True,
-            limit=NUM_MULTI_VECTORS,
+            limit=10,
             using="multi-text",
         ).points
 
-    compare_client_results(grpc_client, http_client, f, is_context_search=True)
-    compare_client_results(local_client, http_client, f, is_context_search=True)
+    compare_client_results(grpc_client, http_client, f)
+    compare_client_results(local_client, http_client, f)
 
 
 def test_context_dot(
@@ -95,12 +95,12 @@ def test_context_dot(
             collection_name=COLLECTION_NAME,
             query=models.ContextQuery(context=[models.ContextPair(positive=10, negative=19)]),
             with_payload=True,
-            limit=NUM_MULTI_VECTORS,
+            limit=10,
             using="multi-image",
         ).points
 
-    compare_client_results(grpc_client, http_client, f, is_context_search=True)
-    compare_client_results(local_client, http_client, f, is_context_search=True)
+    compare_client_results(grpc_client, http_client, f)
+    compare_client_results(local_client, http_client, f)
 
 
 def test_context_euclidean(
@@ -113,12 +113,12 @@ def test_context_euclidean(
             collection_name=COLLECTION_NAME,
             query=models.ContextQuery(context=[models.ContextPair(positive=11, negative=19)]),
             with_payload=True,
-            limit=NUM_MULTI_VECTORS,
+            limit=10,
             using="multi-code",
         ).points
 
-    compare_client_results(grpc_client, http_client, f, is_context_search=True)
-    compare_client_results(local_client, http_client, f, is_context_search=True)
+    compare_client_results(grpc_client, http_client, f)
+    compare_client_results(local_client, http_client, f)
 
 
 def test_context_many_pairs(
@@ -148,12 +148,12 @@ def test_context_many_pairs(
                 ]
             ),
             with_payload=True,
-            limit=NUM_MULTI_VECTORS,
+            limit=10,
             using="multi-image",
         ).points
 
-    compare_client_results(grpc_client, http_client, f, is_context_search=True)
-    compare_client_results(local_client, http_client, f, is_context_search=True)
+    compare_client_results(grpc_client, http_client, f)
+    compare_client_results(local_client, http_client, f)
 
 
 def test_discover_cosine(
@@ -263,12 +263,12 @@ def test_context_raw_positive(
             query=models.ContextQuery(
                 context=[models.ContextPair(positive=random_image_multivector, negative=19)]
             ),
-            limit=NUM_MULTI_VECTORS,
+            limit=10,
             using="multi-image",
         ).points
 
-    compare_client_results(grpc_client, http_client, f, is_context_search=True)
-    compare_client_results(local_client, http_client, f, is_context_search=True)
+    compare_client_results(grpc_client, http_client, f)
+    compare_client_results(local_client, http_client, f)
 
 
 def test_only_target(

--- a/tests/congruence_tests/test_query.py
+++ b/tests/congruence_tests/test_query.py
@@ -702,7 +702,7 @@ class TestSimpleSearcher:
             collection_name=COLLECTION_NAME,
             query=models.ContextQuery(context=models.ContextPair(positive=11, negative=19)),
             with_payload=True,
-            limit=limit,
+            limit=10,
             using="image",
         )
 
@@ -1187,8 +1187,6 @@ def test_dense_query_discovery_context():
         http_client,
         grpc_client,
         searcher.dense_context_image,
-        is_context_search=True,
-        limit=n_vectors,
     )
 
 

--- a/tests/congruence_tests/test_sparse_discovery.py
+++ b/tests/congruence_tests/test_sparse_discovery.py
@@ -80,12 +80,12 @@ def test_context(
             collection_name=COLLECTION_NAME,
             context=[models.ContextExamplePair(positive=10, negative=19)],
             with_payload=True,
-            limit=200,
+            limit=10,
             using="sparse-image",
         )
 
-    compare_client_results(grpc_client, http_client, f, is_context_search=True)
-    compare_client_results(local_client, http_client, f, is_context_search=True)
+    compare_client_results(grpc_client, http_client, f)
+    compare_client_results(local_client, http_client, f)
 
 
 def test_context_many_pairs(
@@ -113,12 +113,12 @@ def test_context_many_pairs(
                 models.ContextExamplePair(positive=random_sparse_image_vector_1, negative=15),
             ],
             with_payload=True,
-            limit=200,
+            limit=10,
             using="sparse-image",
         )
 
-    compare_client_results(grpc_client, http_client, f, is_context_search=True)
-    compare_client_results(local_client, http_client, f, is_context_search=True)
+    compare_client_results(grpc_client, http_client, f)
+    compare_client_results(local_client, http_client, f)
 
 
 def test_discover(
@@ -132,7 +132,7 @@ def test_discover(
             target=10,
             context=[models.ContextExamplePair(positive=11, negative=19)],
             with_payload=True,
-            limit=100,
+            limit=10,
             using="sparse-image",
         )
 
@@ -154,7 +154,7 @@ def test_discover_raw_target(
             collection_name=COLLECTION_NAME,
             target=random_sparse_image_vector,
             context=[models.ContextExamplePair(positive=10, negative=19)],
-            limit=100,
+            limit=10,
             using="sparse-image",
         )
 
@@ -276,13 +276,13 @@ def test_context_with_filters(local_client, http_client, grpc_client, filter_: m
         return client.discover(
             collection_name=COLLECTION_NAME,
             context=[models.ContextExamplePair(positive=15, negative=7)],
-            limit=200,
+            limit=10,
             using="sparse-image",
             query_filter=filter_,
         )
 
-    compare_client_results(grpc_client, http_client, f, is_context_search=True)
-    compare_client_results(local_client, http_client, f, is_context_search=True)
+    compare_client_results(grpc_client, http_client, f)
+    compare_client_results(local_client, http_client, f)
 
 
 def test_query_with_nan():


### PR DESCRIPTION
As now we consider points with the close scores but different ids to be the same to be equal, we don't need `is_context_search` to ignore order anymore.