### PR TITLE
fix `is_empty/is_null=False` conversion to grpc

### DIFF
--- a/qdrant_client/conversions/conversion.py
+++ b/qdrant_client/conversions/conversion.py
@@ -2795,9 +2795,9 @@ class RestToGrpc:
 
     @classmethod
     def convert_field_condition(cls, model: rest.FieldCondition) -> grpc.FieldCondition:
-        if model.match:
+        if model.match is not None:
             return grpc.FieldCondition(key=model.key, match=cls.convert_match(model.match))
-        if model.range:
+        if model.range is not None:
             if isinstance(model.range, rest.Range):
                 return grpc.FieldCondition(key=model.key, range=cls.convert_range(model.range))
             if isinstance(model.range, rest.DatetimeRange):
@@ -2805,27 +2805,27 @@ class RestToGrpc:
                     key=model.key,
                     datetime_range=cls.convert_datetime_range(model.range),
                 )
-        if model.geo_bounding_box:
+        if model.geo_bounding_box is not None:
             return grpc.FieldCondition(
                 key=model.key,
                 geo_bounding_box=cls.convert_geo_bounding_box(model.geo_bounding_box),
             )
-        if model.geo_radius:
+        if model.geo_radius is not None:
             return grpc.FieldCondition(
                 key=model.key, geo_radius=cls.convert_geo_radius(model.geo_radius)
             )
-        if model.geo_polygon:
+        if model.geo_polygon is not None:
             return grpc.FieldCondition(
                 key=model.key, geo_polygon=cls.convert_geo_polygon(model.geo_polygon)
             )
-        if model.values_count:
+        if model.values_count is not None:
             return grpc.FieldCondition(
                 key=model.key, values_count=cls.convert_values_count(model.values_count)
             )
-        if model.is_empty:
+        if model.is_empty is not None:
             return grpc.FieldCondition(key=model.key, is_empty=model.is_empty)
 
-        if model.is_null:
+        if model.is_null is not None:
             return grpc.FieldCondition(key=model.key, is_null=model.is_null)
         raise ValueError(f"invalid FieldCondition model: {model}")  # pragma: no cover
 

--- a/tests/conversions/fixtures.py
+++ b/tests/conversions/fixtures.py
@@ -99,6 +99,7 @@ values_count = grpc.ValuesCount(
 
 field_condition_values_count = grpc.FieldCondition(key="match_field", values_count=values_count)
 field_condition_is_empty = grpc.FieldCondition(key="is_empty_field", is_empty=True)
+field_condition_is_empty_false = grpc.FieldCondition(key="is_empty_field", is_empty=False)
 field_condition_is_null = grpc.FieldCondition(key="is_null_field", is_null=True)
 
 condition_has_id = grpc.Condition(has_id=has_id)
@@ -113,6 +114,7 @@ condition_geo_bounding_box = grpc.Condition(field=field_condition_geo_bounding_b
 condition_geo_polygon = grpc.Condition(field=field_condition_geo_polygon)
 condition_values_count = grpc.Condition(field=field_condition_values_count)
 condition_field_is_empty = grpc.Condition(field=field_condition_is_empty)
+condition_field_is_empty_false = grpc.Condition(field=field_condition_is_empty_false)
 condition_field_is_null = grpc.Condition(field=field_condition_is_null)
 
 condition_keywords = grpc.Condition(field=field_condition_match_keywords)
@@ -160,6 +162,7 @@ filter_ = grpc.Filter(
             condition_except_keywords,
             condition_except_integers,
             condition_field_is_empty,
+            condition_field_is_empty_false,
             condition_field_is_null,
         ],
         min_count=3,


### PR DESCRIPTION
Conversion to grpc for `is_empty` field condition was broken because python returns `False` for `None` and also for `False` in `if model.is_empty` 