### PR TITLE
fix: fix grpc document, image, inference object without options conversion

### DIFF
--- a/qdrant_client/conversions/conversion.py
+++ b/qdrant_client/conversions/conversion.py
@@ -3485,7 +3485,9 @@ class RestToGrpc:
     @classmethod
     def convert_document(cls, model: rest.Document) -> grpc.Document:
         return grpc.Document(
-            text=model.text, model=model.model, options=payload_to_grpc(model.options)
+            text=model.text,
+            model=model.model,
+            options=payload_to_grpc(model.options) if model.options is not None else None,
         )
 
     @classmethod
@@ -3493,7 +3495,7 @@ class RestToGrpc:
         return grpc.Image(
             image=json_to_value(model.image),
             model=model.model,
-            options=payload_to_grpc(model.options),
+            options=payload_to_grpc(model.options) if model.options is not None else None,
         )
 
     @classmethod
@@ -3501,7 +3503,7 @@ class RestToGrpc:
         return grpc.InferenceObject(
             object=json_to_value(model.object),
             model=model.model,
-            options=payload_to_grpc(model.options),
+            options=payload_to_grpc(model.options) if model.options is not None else None,
         )
 
     @classmethod

--- a/tests/conversions/test_validate_conversions.py
+++ b/tests/conversions/test_validate_conversions.py
@@ -503,3 +503,24 @@ def test_convert_text_index_params_stopwords():
     recovered_4 = GrpcToRest.convert_text_index_params(grpc_text_index_params_4)
 
     assert recovered_4.stopwords == models.Language.ENGLISH
+
+
+def test_inference_without_options():
+    from qdrant_client import models
+    from qdrant_client.conversions.conversion import GrpcToRest, RestToGrpc
+
+    doc_wo_options = models.Document(text="qwerty-text", model="qwerty-text-model")
+    image_wo_options = models.Image(image="qwerty-image", model="qwerty-image-model")
+    inference_wo_options = models.InferenceObject(object="qwerty-any", model="qwerty-any-model")
+
+    grpc_doc_wo_options = RestToGrpc.convert_document(doc_wo_options)
+    grpc_image_wo_options = RestToGrpc.convert_image(image_wo_options)
+    grpc_inference_wo_options = RestToGrpc.convert_inference_object(inference_wo_options)
+
+    recovered_doc_wo_options = GrpcToRest.convert_document(grpc_doc_wo_options)
+    recovered_image_wo_options = GrpcToRest.convert_image(grpc_image_wo_options)
+    recovered_inference_wo_options = GrpcToRest.convert_inference_object(grpc_inference_wo_options)
+
+    assert recovered_doc_wo_options.options == {}
+    assert recovered_image_wo_options.options == {}
+    assert recovered_inference_wo_options.options == {}


### PR DESCRIPTION
conversion of inference objects was broken when options=None
tests did not catch it, because we do conversions from grpc to rest and then from rest to grpc, which was working fine because after the first conversion we were loosing None in favour of an empty dict