### PR TITLE
feat: ban pytest imports in source code and centralize ruff config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 default_language_version:
-   python: python3.10
+  python: python3.10
 
-exclude: 'qdrant_client/(grpc|http|models)/'
+exclude: "qdrant_client/(grpc|http|models)/"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -16,10 +16,8 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.4.3
     hooks:
-# ToDo: re-introduce ruff linter later
-#      - id: ruff
-#        types_or: [ python, pyi ]
-#        args: [ --fix ]
+      - id: ruff
+        types_or: [python, pyi]
+        args: [--fix]
       - id: ruff-format
-        types_or: [ python, pyi ]
-        args: [ --line-length=99 ]
+        types_or: [python, pyi]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,3 +76,16 @@ markers = [
 
 [tool.isort]
 known_third_party = "grpc"
+
+[tool.ruff]
+line-length = 99
+
+[tool.ruff.lint]
+# TODO: Enable all rules later
+select = ["TID251"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"pytest".msg = "pytest is a testing library and should not be imported into application source code."
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["TID251"]


### PR DESCRIPTION
- Add TID251 rule to prevent pytest imports outside tests/
- Move ruff settings to pyproject.toml for consistency

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you installed `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
