### PR TITLE
new: include pyi into the package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ authors = ["Andrey Vasnetsov <andrey@qdrant.tech>"]
 packages = [
     {include = "qdrant_client"}
 ]
-exclude = ["qdrant_client/grpc/*.pyi"]
 license = "Apache-2.0"
 readme = "README.md"
 homepage = "https://github.com/qdrant/qdrant-client"


### PR DESCRIPTION
After updating grpc version, we have to include pyi files to help static analyzers to understand our grpc structures