### PR TITLE
fix: fix local mode backward compatibility

### DIFF
--- a/qdrant_client/local/async_qdrant_local.py
+++ b/qdrant_client/local/async_qdrant_local.py
@@ -89,7 +89,7 @@ class AsyncQdrantLocal(AsyncQdrantBase):
             pass
 
     def _load(self) -> None:
-        deprecated_config_fields = "init_from"
+        deprecated_config_fields = ("init_from",)
         if not self.persistent:
             return
         meta_path = os.path.join(self.location, META_INFO_FILENAME)

--- a/qdrant_client/local/qdrant_local.py
+++ b/qdrant_client/local/qdrant_local.py
@@ -92,7 +92,7 @@ class QdrantLocal(QdrantBase):
             pass
 
     def _load(self) -> None:
-        deprecated_config_fields = "init_from"
+        deprecated_config_fields = ("init_from",)
 
         if not self.persistent:
             return


### PR DESCRIPTION
Local mode could not start from an existing persisted db create with previous versions of `qdrant-client` because `meta.json` contained parameters removed from `rest.CreateCollection`, in particular: `init_from`
