### PR TITLE
Fix: Remove unused imports and variables

### DIFF
--- a/qdrant_client/conversions/common_types.py
+++ b/qdrant_client/conversions/common_types.py
@@ -1,4 +1,3 @@
-import sys
 
 import numpy as np
 import numpy.typing as npt

--- a/qdrant_client/conversions/conversion.py
+++ b/qdrant_client/conversions/conversion.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import date, datetime, timezone
-from typing import Any, Mapping, Sequence, get_args
+from typing import Any, Mapping, get_args
 
 from google.protobuf.internal.containers import MessageMap
 from google.protobuf.json_format import MessageToDict

--- a/qdrant_client/embed/schema_parser.py
+++ b/qdrant_client/embed/schema_parser.py
@@ -17,7 +17,7 @@ try:
         INCLUDED_RECURSIVE_REFS,
         NAME_RECURSIVE_REF_MAPPING,
     )
-except ImportError as e:
+except ImportError:
     DEFS = {}
     CACHE_STR_PATH = {}
     RECURSIVE_REFS = set()  # type: ignore


### PR DESCRIPTION
## Description

This PR fixes linting issues identified by `ruff` by removing unused imports and variables that were causing code quality warnings.

## Changes Made

- **conversions/common_types.py**: Removed unused `sys` import
- **conversions/conversion.py**: Removed unused `Sequence` import from typing
- **embed/schema_parser.py**: Removed unused exception variable `e` in ImportError handler

## Motivation

These changes improve code quality by:
- Reducing unnecessary imports that consume memory
- Making the codebase cleaner and easier to maintain
- Fixing linting warnings detected by `ruff check`

## Testing

-  All existing unit tests pass
-  `ruff check` confirms the linting issues are resolved
-  No functional changes - purely cleanup

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code quality improvement
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published