### PR TITLE
Fix: Add explicit re-exports for public API

### DIFF
--- a/qdrant_client/auth/__init__.py
+++ b/qdrant_client/auth/__init__.py
@@ -1,1 +1,1 @@
-from qdrant_client.auth.bearer_auth import BearerAuth
+from qdrant_client.auth.bearer_auth import BearerAuth as BearerAuth

--- a/qdrant_client/migrate/__init__.py
+++ b/qdrant_client/migrate/__init__.py
@@ -1,1 +1,1 @@
-from .migrate import migrate
+from .migrate import migrate as migrate


### PR DESCRIPTION
## Description

This PR adds explicit re-exports to public API modules to fix linting warnings and improve type checking clarity.

## Changes Made

- **auth/__init__.py**: Change `BearerAuth` import to explicit re-export syntax
- **migrate/__init__.py**: Change `migrate` import to explicit re-export syntax

## Motivation

When using `from module import name` in [__init__.py](cci:7://file:///Users/limemanas/Desktop/qdrant-client/tests/__init__.py:0:0-0:0), type checkers (mypy, pyright) can't determine if the import is for internal use or part of the public API. Using `import name as name` explicitly signals that this is a public re-export.

This pattern:
-  Fixes F401 linting warnings from ruff
-  Improves API clarity for type checkers
-  Follows PEP 484 type hinting standards
-  Makes it clear these are intentional public exports

## Testing

- `ruff check` confirms linting issues are resolved
-  No functional changes - purely type hint improvements
-  All existing imports continue to work

## Type of Change

- [x] Code quality improvement
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change