### PR TITLE
change Payload type to Mapping instead of dict to allow passing TypedDict

### DIFF
--- a/qdrant_client/http/models/models.py
+++ b/qdrant_client/http/models/models.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from datetime import date, datetime
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union
@@ -6,7 +7,7 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 from pydantic.types import StrictBool, StrictFloat, StrictInt, StrictStr
 
-Payload = Dict[str, Any]
+Payload = Mapping[str, Any]
 SparseVectorsConfig = Dict[str, "SparseVectorParams"]
 StrictModeMultivectorConfig = Dict[str, "StrictModeMultivector"]
 StrictModeMultivectorConfigOutput = Dict[str, "StrictModeMultivectorOutput"]


### PR DESCRIPTION
Currently type checkers (pyright and ty) do not allow this:

```python
class Payload(TypedDict):
    customer_id: str
    ki_id: str
    tokens: int

await qdrant.upsert(
    "my_coll",
    points=[
        PointStruct(
            id=uuid.uuid4().hex,
            vector=vector,
            # works if you do dict(Payload(...))
            payload=Payload(
                customer_id=str(customer_id),
                ki_id=str(ki_id),
                tokens=tokens,
            ),
        )
    ],
)
```

Because TypedDict is incompatible with dict for complicated reasons. It works if payload type is Mapping.
Unsure if there are `Mapping`s which would break serialization and should not be allowed

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you installed `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
