### PR TITLE
docs: clarify PointStruct usage for IDs in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ vectors = np.random.rand(100, 100)
 client.upsert(
     collection_name="my_collection",
     points=[
+        # Use PointStruct for strict typing. IDs can be integers or strings (UUIDs)
         PointStruct(
             id=idx,
             vector=vector.tolist(),


### PR DESCRIPTION
### Description

This PR updates the "Insert vectors into a collection" example in the README to explicitly clarify the usage of `PointStruct`.

**Motivation:**
Users (as seen in issue #1141) are encountering `ImportError` when trying to import internal classes like `PointId` to handle custom IDs (UUIDs). This update adds a comment to the code snippet clarifying that `PointStruct` handles ID types automatically, promoting best practices and preventing confusion.

**Changes:**
- Added explanatory comment in the `client.upsert` example in `README.md`.

Closes #1141

### All Submissions:

* [ ] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
