### PR TITLE
fix: close SQLite connection before removing collection directory on delete

### DIFF
--- a/qdrant_client/local/async_qdrant_local.py
+++ b/qdrant_client/local/async_qdrant_local.py
@@ -704,6 +704,8 @@ class AsyncQdrantLocal(AsyncQdrantBase):
         if self.closed:
             raise RuntimeError("QdrantLocal instance is closed. Please create a new instance.")
         _collection = self.collections.pop(collection_name, None)
+        if _collection is not None:
+            _collection.close()
         del _collection
         self.aliases = {
             alias_name: name
@@ -800,9 +802,9 @@ class AsyncQdrantLocal(AsyncQdrantBase):
         if isinstance(vectors, dict) and any(
             (isinstance(v, np.ndarray) for v in vectors.values())
         ):
-            assert (
-                len(set([arr.shape[0] for arr in vectors.values()])) == 1
-            ), "Each named vector should have the same number of vectors"
+            assert len(set([arr.shape[0] for arr in vectors.values()])) == 1, (
+                "Each named vector should have the same number of vectors"
+            )
             num_vectors = next(iter(vectors.values())).shape[0]
             vectors = [
                 {name: vectors[name][i].tolist() for name in vectors.keys()}

--- a/qdrant_client/local/qdrant_local.py
+++ b/qdrant_client/local/qdrant_local.py
@@ -764,6 +764,8 @@ class QdrantLocal(QdrantBase):
             raise RuntimeError("QdrantLocal instance is closed. Please create a new instance.")
 
         _collection = self.collections.pop(collection_name, None)
+        if _collection is not None:
+            _collection.close()
         del _collection
         self.aliases = {
             alias_name: name
@@ -865,9 +867,9 @@ class QdrantLocal(QdrantBase):
 
         collection = self._get_collection(collection_name)
         if isinstance(vectors, dict) and any(isinstance(v, np.ndarray) for v in vectors.values()):
-            assert (
-                len(set([arr.shape[0] for arr in vectors.values()])) == 1
-            ), "Each named vector should have the same number of vectors"
+            assert len(set([arr.shape[0] for arr in vectors.values()])) == 1, (
+                "Each named vector should have the same number of vectors"
+            )
 
             num_vectors = next(iter(vectors.values())).shape[0]
             # convert dict[str, np.ndarray] to list[dict[str, list[float]]]

--- a/tests/test_local_persistence.py
+++ b/tests/test_local_persistence.py
@@ -240,3 +240,5 @@ def test_delete_collection_removes_storage_files():
         assert not os.path.exists(collection_path), (
             "Collection directory should be removed after deletion"
         )
+
+        client.close()

--- a/tests/test_local_persistence.py
+++ b/tests/test_local_persistence.py
@@ -200,3 +200,43 @@ def test_update_persisence():
             "important": "meta information",
             "not_important": "missing",
         }
+
+
+def test_delete_collection_removes_storage_files():
+    """Test that delete_collection properly closes the SQLite connection
+    and removes the storage files from disk.
+
+    Regression test for https://github.com/qdrant/qdrant-client/issues/1067
+    """
+    import os
+
+    collection_name = "delete_test"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        client = qdrant_client.QdrantClient(path=tmpdir)
+
+        client.create_collection(
+            collection_name,
+            vectors_config=rest.VectorParams(
+                size=4,
+                distance=rest.Distance.COSINE,
+            ),
+        )
+
+        client.upsert(
+            collection_name=collection_name,
+            points=[
+                rest.PointStruct(id=1, vector=[1.0, 0.0, 0.0, 0.0], payload={"text": "hello"}),
+                rest.PointStruct(id=2, vector=[0.0, 1.0, 0.0, 0.0], payload={"text": "world"}),
+            ],
+        )
+
+        collection_path = os.path.join(tmpdir, "collection", collection_name)
+        storage_file = os.path.join(collection_path, "storage.sqlite")
+        assert os.path.exists(storage_file), "Storage file should exist before deletion"
+
+        client.delete_collection(collection_name)
+
+        assert not os.path.exists(storage_file), "Storage file should be removed after deletion"
+        assert not os.path.exists(collection_path), (
+            "Collection directory should be removed after deletion"
+        )


### PR DESCRIPTION
## Summary
- Fixed `delete_collection` in local mode not explicitly closing the SQLite connection before attempting to remove the collection directory with `shutil.rmtree`
- On Windows, this left the database file locked, causing `shutil.rmtree` to silently fail (due to `ignore_errors=True`), leaving the `storage.sqlite` file on disk
- The fix calls `collection.close()` before directory removal in both sync (`QdrantLocal`) and async (`AsyncQdrantLocal`) implementations, matching the pattern already used in `QdrantLocal.close()`
- Added regression test that verifies storage files are properly removed after `delete_collection`

## Root Cause
In `delete_collection`, the `LocalCollection` was popped from the dict and `del` was called on the variable. However, `del` in Python only decrements the reference count and does not guarantee the SQLite connection is closed. On Windows, the open connection holds a file lock on `storage.sqlite`, preventing `shutil.rmtree` from deleting it.

## Test Plan
- [x] Added `test_delete_collection_removes_storage_files` to verify that storage files are properly removed after deletion
- [x] All existing `test_local_persistence.py` tests pass
- [x] All existing `test_in_memory.py` tests pass
- [x] `test_async_qdrant_client_local` passes

Fixes #1067