### PR TITLE
Add release sanity check to catch pytest leakage before publish

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -33,6 +33,13 @@ jobs:
         poetry install
     - name: Build package
       run: poetry build
+    - name: Release sanity check (wheel install without dev deps)
+      run: |
+        python -m venv .venv-release-sanity
+        . .venv-release-sanity/bin/activate
+        pip install --upgrade pip
+        pip install dist/*.whl
+        python tests/release_sanity_check.py
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:

--- a/tests/release_sanity_check.py
+++ b/tests/release_sanity_check.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Release sanity checks for qdrant-client.
+
+This script is meant to run in CI in an environment where the package is installed
+as a wheel (without dev dependencies like pytest).
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+import re
+import sys
+from pathlib import Path
+
+
+def fail(message: str) -> None:
+    print(f"::error::{message}")
+    raise SystemExit(1)
+
+
+def check_no_pytest_import_in_library_sources() -> None:
+    root = Path("qdrant_client")
+    offenders: list[str] = []
+
+    for py_file in root.rglob("*.py"):
+        rel = py_file.as_posix()
+
+        # Test-only modules are allowed to import pytest.
+        if "/tests/" in rel or rel.endswith("/conftest.py") or py_file.name.startswith("test_"):
+            continue
+
+        text = py_file.read_text(encoding="utf-8")
+        if re.search(r"^\s*import\s+pytest\b", text, re.MULTILINE) or re.search(
+            r"^\s*from\s+pytest\b", text, re.MULTILINE
+        ):
+            offenders.append(rel)
+
+    if offenders:
+        fail(
+            "Found pytest import(s) in library code (outside tests): "
+            + ", ".join(offenders)
+        )
+
+
+def check_runtime_imports() -> None:
+    try:
+        import qdrant_client  # noqa: F401
+    except Exception as exc:  # pragma: no cover - defensive
+        fail(f"Importing qdrant_client failed: {exc!r}")
+
+    import qdrant_client as qc
+
+    for module_info in pkgutil.walk_packages(qc.__path__, prefix="qdrant_client."):
+        name = module_info.name
+
+        # Never import tests in this sanity check.
+        if ".tests" in name or name.endswith(".conftest"):
+            continue
+
+        try:
+            importlib.import_module(name)
+        except ModuleNotFoundError as exc:
+            if exc.name == "pytest":
+                fail(f"Module '{name}' requires pytest at runtime")
+            # optional dependency modules are allowed to fail.
+        except Exception:
+            # Ignore other runtime side effects; this check targets pytest leakage.
+            pass
+
+
+if __name__ == "__main__":
+    print(f"Python: {sys.version.split()[0]}")
+    check_no_pytest_import_in_library_sources()
+    check_runtime_imports()
+    print("Release sanity checks passed")


### PR DESCRIPTION
## Summary
This PR adds a release sanity check step to the publish workflow to prevent shipping broken packages when `pytest` accidentally leaks into library code.

## What changed
- Added `tests/release_sanity_check.py` which:
  - Fails if `pytest` is imported in `qdrant_client/**` outside test modules
  - Imports package modules and fails if any module requires `pytest` at runtime
- Updated `.github/workflows/python-publish.yml` to:
  - Build wheel
  - Create a clean virtual environment
  - Install the built wheel (without dev deps)
  - Run `tests/release_sanity_check.py` before publishing

## Why
Issue #958 mentions multiple broken releases caused by `pytest` leaking into package code and only being discovered after `pip install qdrant-client` in a fresh environment. This check makes that failure mode visible in CI before publish.

Closes #958