### PR TITLE
Fix/validate nan query vectors

### DIFF
--- a/qdrant_client/conversions/conversion.py
+++ b/qdrant_client/conversions/conversion.py
@@ -3727,11 +3727,13 @@ class RestToGrpc:
 
     @staticmethod
     def _validate_no_nan(vector: list[float]) -> None:
-        """validate that vector does not contain NaN values
+        """Validate that vector does not contain NaN values.
+
         Args:
-            vector: List of float values to validate
+            vector: List of float values to validate.
+
         Raises:
-            UnexpectedResponse: If the vector contains NaN values
+            UnexpectedResponse: If the vector contains NaN values.
         """
         if any(math.isnan(val) for val in vector):
             from qdrant_client.http.exceptions import UnexpectedResponse

--- a/tests/congruence_tests/test_query.py
+++ b/tests/congruence_tests/test_query.py
@@ -1583,9 +1583,8 @@ def test_query_with_nan():
     with pytest.raises(UnexpectedResponse):
         http_client.query_points(COLLECTION_NAME, query=query, using="text")
 
-    # TODO: this doesn't fail, instead it returns points with `nan` score
-    # with pytest.raises(UnexpectedResponse):
-    # print(grpc_client.query_points(COLLECTION_NAME, query=query, using="text"))
+    with pytest.raises(UnexpectedResponse):
+        grpc_client.query_points(COLLECTION_NAME, query=query, using="text")
 
     single_vector_config = models.VectorParams(
         size=text_vector_size, distance=models.Distance.COSINE
@@ -1607,9 +1606,8 @@ def test_query_with_nan():
     with pytest.raises(UnexpectedResponse):
         http_client.query_points(COLLECTION_NAME, query=query)
 
-    # TODO: this doesn't fail, instead it returns points with `nan` score
-    # with pytest.raises(UnexpectedResponse):
-    #     print(grpc_client.query_points(COLLECTION_NAME, query=query))
+    with pytest.raises(UnexpectedResponse):
+        grpc_client.query_points(COLLECTION_NAME, query=query)
 
 
 def test_flat_query_dense_interface():

--- a/tests/conversions/test_validate_conversions.py
+++ b/tests/conversions/test_validate_conversions.py
@@ -594,3 +594,46 @@ def test_optimizers_config_diff_max_threads():
     assert restored_grpc_opt_conf.max_optimization_threads == q_grpc.MaxOptimizationThreads(
         value=value
     )
+
+
+def test_convert_dense_vector_with_nan_raises_error():
+    """test that convert_dense_vector raises UnexpectedResponse when vector contains NaN values."""
+    from qdrant_client.conversions.conversion import RestToGrpc
+    from qdrant_client.http.exceptions import UnexpectedResponse
+
+    # valid vector should work
+    result = RestToGrpc.convert_dense_vector([1.0, 2.0, 3.0])
+    assert result.data == [1.0, 2.0, 3.0]
+
+    # vector with NaN should raise UnexpectedResponse
+    with pytest.raises(UnexpectedResponse):
+        RestToGrpc.convert_dense_vector([1.0, float('nan'), 3.0])
+
+
+def test_convert_sparse_vector_with_nan_raises_error():
+    """test that convert_sparse_vector raises UnexpectedResponse when vector contains NaN values"""
+    from qdrant_client.conversions.conversion import RestToGrpc
+    from qdrant_client.http.models import SparseVector
+    from qdrant_client.http.exceptions import UnexpectedResponse
+
+    # valid sparse vector should work
+    result = RestToGrpc.convert_sparse_vector(SparseVector(values=[1.0, 2.0], indices=[0, 1]))
+    assert result.values == [1.0, 2.0]
+
+    # sparse vector with NaN should raise UnexpectedResponse
+    with pytest.raises(UnexpectedResponse):
+        RestToGrpc.convert_sparse_vector(SparseVector(values=[1.0, float('nan')], indices=[0, 1]))
+
+
+def test_convert_multi_dense_vector_with_nan_raises_error():
+    """test that convert_multi_dense_vector raises UnexpectedResponse when any vector contains NaN values."""
+    from qdrant_client.conversions.conversion import RestToGrpc
+    from qdrant_client.http.exceptions import UnexpectedResponse
+
+    # valid multi-dense vector should work
+    result = RestToGrpc.convert_multi_dense_vector([[1.0, 2.0], [3.0, 4.0]])
+    assert len(result.vectors) == 2
+
+    # multi-dense vector with NaN should raise UnexpectedResponse
+    with pytest.raises(UnexpectedResponse):
+        RestToGrpc.convert_multi_dense_vector([[1.0, 2.0], [3.0, float('nan')]])


### PR DESCRIPTION
### description 
 
validate query vectors for nan values in grpc client before sending to the server
before : grpc client would return points with nan scores when given vector that contains nan, while local and http clients properly rejected it 
those nan values in query vectors would propagate through distance calculations, this can causes confusion for users who receives invalid results without clear error message 

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you installed `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
