### PR TITLE
feat: add retry/resilience middleware with exponential backoff

### DIFF
--- a/qdrant_client/__init__.py
+++ b/qdrant_client/__init__.py
@@ -1,2 +1,3 @@
 from .async_qdrant_client import AsyncQdrantClient as AsyncQdrantClient
+from .common.retry import RetryConfig as RetryConfig
 from .qdrant_client import QdrantClient as QdrantClient

--- a/qdrant_client/async_qdrant_client.py
+++ b/qdrant_client/async_qdrant_client.py
@@ -15,6 +15,7 @@ import numpy as np
 from qdrant_client import grpc as grpc
 from qdrant_client.async_client_base import AsyncQdrantBase
 from qdrant_client.common.client_warnings import show_warning_once
+from qdrant_client.common.retry import RetryConfig
 from qdrant_client.conversions import common_types as types
 from qdrant_client.embed.type_inspector import Inspector
 from qdrant_client.http import AsyncApiClient, AsyncApis
@@ -78,6 +79,10 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
         pool_size: connection pool size, Default: None. Default value for gRPC connection pool is 3, rest default is
             inherited from `httpx` (default: 100)
         headers: Custom headers to send with every request.
+        retry_config:
+            Configuration for automatic retries with exponential backoff.
+            If ``None`` (default), no retries are performed and behaviour is unchanged.
+            Pass a ``RetryConfig`` instance to enable retries for transient failures.
         **kwargs: Additional arguments passed directly into REST client initialization
     """
 
@@ -102,6 +107,7 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
         check_compatibility: bool = True,
         pool_size: int | None = None,
         headers: dict[str, str] | None = None,
+        retry_config: RetryConfig | None = None,
         **kwargs: Any,
     ):
         self._init_options = {
@@ -141,6 +147,7 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
                 check_compatibility=check_compatibility,
                 pool_size=pool_size,
                 headers=headers,
+                retry_config=retry_config,
                 **kwargs,
             )
         if isinstance(self._client, AsyncQdrantLocal) and cloud_inference:

--- a/qdrant_client/async_qdrant_fastembed.py
+++ b/qdrant_client/async_qdrant_fastembed.py
@@ -394,31 +394,31 @@ class AsyncQdrantFastembedMixin(AsyncQdrantBase):
     def _validate_collection_info(self, collection_info: models.CollectionInfo) -> None:
         (embeddings_size, distance) = self._get_model_params(model_name=self.embedding_model_name)
         vector_field_name = self.get_vector_field_name()
-        assert isinstance(
-            collection_info.config.params.vectors, dict
-        ), f"Collection have incompatible vector params: {collection_info.config.params.vectors}"
-        assert (
-            vector_field_name in collection_info.config.params.vectors
-        ), f"Collection have incompatible vector params: {collection_info.config.params.vectors}, expected {vector_field_name}"
+        assert isinstance(collection_info.config.params.vectors, dict), (
+            f"Collection have incompatible vector params: {collection_info.config.params.vectors}"
+        )
+        assert vector_field_name in collection_info.config.params.vectors, (
+            f"Collection have incompatible vector params: {collection_info.config.params.vectors}, expected {vector_field_name}"
+        )
         vector_params = collection_info.config.params.vectors[vector_field_name]
-        assert (
-            embeddings_size == vector_params.size
-        ), f"Embedding size mismatch: {embeddings_size} != {vector_params.size}"
-        assert (
-            distance == vector_params.distance
-        ), f"Distance mismatch: {distance} != {vector_params.distance}"
+        assert embeddings_size == vector_params.size, (
+            f"Embedding size mismatch: {embeddings_size} != {vector_params.size}"
+        )
+        assert distance == vector_params.distance, (
+            f"Distance mismatch: {distance} != {vector_params.distance}"
+        )
         sparse_vector_field_name = self.get_sparse_vector_field_name()
         if sparse_vector_field_name is not None:
-            assert (
-                sparse_vector_field_name in collection_info.config.params.sparse_vectors
-            ), f"Collection have incompatible vector params: {collection_info.config.params.vectors}"
+            assert sparse_vector_field_name in collection_info.config.params.sparse_vectors, (
+                f"Collection have incompatible vector params: {collection_info.config.params.vectors}"
+            )
             if self.sparse_embedding_model_name in IDF_EMBEDDING_MODELS:
                 modifier = collection_info.config.params.sparse_vectors[
                     sparse_vector_field_name
                 ].modifier
-                assert (
-                    modifier == models.Modifier.IDF
-                ), f"{self.sparse_embedding_model_name} requires modifier IDF, current modifier is {modifier}"
+                assert modifier == models.Modifier.IDF, (
+                    f"{self.sparse_embedding_model_name} requires modifier IDF, current modifier is {modifier}"
+                )
 
     def get_embedding_size(self, model_name: str | None = None) -> int:
         """Get the size of the embeddings produced by the specified model.

--- a/qdrant_client/async_qdrant_remote.py
+++ b/qdrant_client/async_qdrant_remote.py
@@ -20,6 +20,7 @@ from grpc import Compression
 from urllib3.util import Url, parse_url
 from urllib.parse import urljoin
 from qdrant_client.common.client_warnings import show_warning, show_warning_once
+from qdrant_client.common.retry import RetryConfig, install_retry_middleware
 from qdrant_client import grpc as grpc
 from qdrant_client._pydantic_compat import construct
 from qdrant_client.auth import BearerAuth
@@ -60,9 +61,11 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         check_compatibility: bool = True,
         pool_size: int | None = None,
         headers: dict[str, str] | None = None,
+        retry_config: RetryConfig | None = None,
         **kwargs: Any,
     ):
         super().__init__(**kwargs)
+        self._retry_config = retry_config
         self._prefer_grpc = prefer_grpc
         self._grpc_port = grpc_port
         self._grpc_options = grpc_options or {}
@@ -187,6 +190,8 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         self.openapi_client: AsyncApis[AsyncApiClient] = AsyncApis(
             host=self.rest_uri, **self._rest_args
         )
+        if self._retry_config is not None:
+            install_retry_middleware(self.openapi_client, self._retry_config)
         self._grpc_channel_pool: list[grpc.Channel] = []
         self._grpc_points_client_pool: list[grpc.PointsStub] | None = None
         self._grpc_collections_client_pool: list[grpc.CollectionsStub] | None = None
@@ -296,6 +301,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                         options=self._grpc_options,
                         compression=self._grpc_compression,
                         auth_token_provider=self._auth_token_provider,
+                        retry_config=self._retry_config,
                     )
                     channel_pool.append(channel)
                 self._grpc_channel_pool = channel_pool

--- a/qdrant_client/common/retry.py
+++ b/qdrant_client/common/retry.py
@@ -1,0 +1,405 @@
+"""Retry / resilience middleware for qdrant-client.
+
+Provides automatic retries with exponential backoff for transient failures
+on both REST (via httpx middleware) and gRPC (via interceptors).
+
+Disabled by default — pass ``retry_config=RetryConfig(...)`` to ``QdrantClient``
+to enable.
+
+Note: Most Qdrant write operations (upsert, delete by ID, set payload, …) are
+idempotent, so retrying them is generally safe.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+import time
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Set
+
+import grpc
+import grpc.aio
+from httpx import ConnectError, ConnectTimeout, ReadTimeout, Request, Response, WriteTimeout
+
+from qdrant_client.common.client_exceptions import ResourceExhaustedResponse
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_DEFAULT_RETRYABLE_STATUS_CODES: frozenset[int] = frozenset({429, 500, 502, 503, 504})
+
+_DEFAULT_RETRYABLE_GRPC_CODES: frozenset[grpc.StatusCode] = frozenset(
+    {
+        grpc.StatusCode.UNAVAILABLE,
+        grpc.StatusCode.DEADLINE_EXCEEDED,
+        grpc.StatusCode.RESOURCE_EXHAUSTED,
+    }
+)
+
+# httpx exceptions that indicate a transient connection-level problem.
+_RETRYABLE_HTTPX_EXCEPTIONS = (ConnectError, ConnectTimeout, ReadTimeout, WriteTimeout)
+
+
+@dataclass(frozen=True)
+class RetryConfig:
+    """User-facing retry configuration.
+
+    Args:
+        max_retries: Maximum number of retry attempts (0 = no retries). Default: 3.
+        initial_backoff: Base backoff duration in seconds. Default: 0.1.
+        max_backoff: Upper bound on backoff duration in seconds. Default: 30.
+        backoff_multiplier: Multiplier applied per attempt. Default: 2.
+        jitter: Jitter factor (0–1) added to backoff to avoid thundering herd. Default: 0.1.
+        retryable_status_codes: HTTP status codes eligible for retry.
+    """
+
+    max_retries: int = 3
+    initial_backoff: float = 0.1
+    max_backoff: float = 30.0
+    backoff_multiplier: float = 2.0
+    jitter: float = 0.1
+    retryable_status_codes: frozenset[int] = _DEFAULT_RETRYABLE_STATUS_CODES
+    retryable_grpc_codes: frozenset[grpc.StatusCode] = _DEFAULT_RETRYABLE_GRPC_CODES
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def compute_backoff(
+    attempt: int,
+    config: RetryConfig,
+    retry_after: float | None = None,
+) -> float:
+    """Return the backoff duration (seconds) for a given *attempt* (0-indexed).
+
+    If *retry_after* is provided (e.g. from a ``Retry-After`` header), it is
+    used as a floor.
+    """
+    base = config.initial_backoff * (config.backoff_multiplier ** attempt)
+    jitter_amount = random.random() * config.jitter * base  # noqa: S311 – not crypto
+    backoff = min(base + jitter_amount, config.max_backoff)
+    if retry_after is not None:
+        backoff = max(backoff, retry_after)
+    return backoff
+
+
+def is_retryable_status(status_code: int, config: RetryConfig) -> bool:
+    return status_code in config.retryable_status_codes
+
+
+def is_retryable_grpc_code(code: grpc.StatusCode, config: RetryConfig) -> bool:
+    return code in config.retryable_grpc_codes
+
+
+def _parse_retry_after(value: str | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# REST middleware (httpx)
+# ---------------------------------------------------------------------------
+
+# Signature matches ``MiddlewareT`` from ``api_client.py``:
+#   Callable[[Request, Send], Response]
+# where Send = Callable[[Request], Response]
+
+
+def retry_middleware(
+    config: RetryConfig,
+) -> Callable[[Request, Callable[[Request], Response]], Response]:
+    """Return a sync REST middleware that retries transient failures."""
+
+    def middleware(
+        request: Request,
+        call_next: Callable[[Request], Response],
+    ) -> Response:
+        last_exc: Exception | None = None
+        for attempt in range(config.max_retries + 1):
+            try:
+                response = call_next(request)
+            except _RETRYABLE_HTTPX_EXCEPTIONS as exc:
+                last_exc = exc
+                if attempt >= config.max_retries:
+                    raise
+                backoff = compute_backoff(attempt, config)
+                logger.debug(
+                    "Retry %d/%d after connection error: %s (backoff=%.2fs)",
+                    attempt + 1,
+                    config.max_retries,
+                    exc,
+                    backoff,
+                )
+                time.sleep(backoff)
+                continue
+
+            if is_retryable_status(response.status_code, config) and attempt < config.max_retries:
+                retry_after = _parse_retry_after(response.headers.get("Retry-After"))
+                backoff = compute_backoff(attempt, config, retry_after=retry_after)
+                logger.debug(
+                    "Retry %d/%d after HTTP %d (backoff=%.2fs)",
+                    attempt + 1,
+                    config.max_retries,
+                    response.status_code,
+                    backoff,
+                )
+                time.sleep(backoff)
+                continue
+
+            return response
+
+        # Shouldn't be reached, but satisfy type checker.
+        if last_exc is not None:
+            raise last_exc
+        return response  # type: ignore[possibly-undefined]
+
+    return middleware
+
+
+def async_retry_middleware(
+    config: RetryConfig,
+) -> Callable[[Request, Callable[[Request], Awaitable[Response]]], Awaitable[Response]]:
+    """Return an async REST middleware that retries transient failures."""
+
+    async def middleware(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        last_exc: Exception | None = None
+        for attempt in range(config.max_retries + 1):
+            try:
+                response = await call_next(request)
+            except _RETRYABLE_HTTPX_EXCEPTIONS as exc:
+                last_exc = exc
+                if attempt >= config.max_retries:
+                    raise
+                backoff = compute_backoff(attempt, config)
+                logger.debug(
+                    "Retry %d/%d after connection error: %s (backoff=%.2fs)",
+                    attempt + 1,
+                    config.max_retries,
+                    exc,
+                    backoff,
+                )
+                await asyncio.sleep(backoff)
+                continue
+
+            if is_retryable_status(response.status_code, config) and attempt < config.max_retries:
+                retry_after = _parse_retry_after(response.headers.get("Retry-After"))
+                backoff = compute_backoff(attempt, config, retry_after=retry_after)
+                logger.debug(
+                    "Retry %d/%d after HTTP %d (backoff=%.2fs)",
+                    attempt + 1,
+                    config.max_retries,
+                    response.status_code,
+                    backoff,
+                )
+                await asyncio.sleep(backoff)
+                continue
+
+            return response
+
+        if last_exc is not None:
+            raise last_exc
+        return response  # type: ignore[possibly-undefined]
+
+    return middleware
+
+
+# ---------------------------------------------------------------------------
+# REST install helper
+# ---------------------------------------------------------------------------
+
+
+def install_retry_middleware(openapi_client: Any, config: RetryConfig) -> None:
+    """Install retry middleware on a ``SyncApis`` or ``AsyncApis`` wrapper.
+
+    Runtime-dispatches on the underlying client type so generated async code
+    does not need special-cased imports.
+    """
+    from qdrant_client.http.api_client import ApiClient, AsyncApiClient
+
+    client = openapi_client.client
+    if isinstance(client, AsyncApiClient):
+        client.add_middleware(async_retry_middleware(config))
+    elif isinstance(client, ApiClient):
+        client.add_middleware(retry_middleware(config))
+
+
+# ---------------------------------------------------------------------------
+# gRPC interceptors
+# ---------------------------------------------------------------------------
+
+
+def retry_interceptor(config: RetryConfig) -> Any:
+    """Return a sync gRPC client interceptor that retries transient failures."""
+    from qdrant_client.connection import (
+        _ClientCallDetails,
+        _GenericClientInterceptor,
+    )
+
+    def intercept_call(
+        client_call_details: Any,
+        request_iterator: Any,
+        request_streaming: bool,
+        response_streaming: bool,
+    ) -> tuple:
+        # Only retry unary-unary and unary-stream calls.
+        # Stream requests consume the iterator on the first attempt.
+        if request_streaming:
+            return client_call_details, request_iterator, None
+
+        def postprocess(response: Any) -> Any:
+            return response
+
+        return client_call_details, request_iterator, None
+
+    # We cannot use the generic interceptor pattern for retry because we need
+    # to re-invoke `continuation`.  Instead, build a custom interceptor class.
+
+    class _RetryInterceptor(
+        grpc.UnaryUnaryClientInterceptor,
+        grpc.UnaryStreamClientInterceptor,
+        grpc.StreamUnaryClientInterceptor,
+        grpc.StreamStreamClientInterceptor,
+    ):
+        def intercept_unary_unary(
+            self, continuation: Any, client_call_details: Any, request: Any
+        ) -> Any:
+            for attempt in range(config.max_retries + 1):
+                try:
+                    response = continuation(client_call_details, request)
+                    # Force the call to complete so we can inspect the status.
+                    code = response.code()
+                    if code is not None and is_retryable_grpc_code(code, config) and attempt < config.max_retries:
+                        backoff = compute_backoff(attempt, config)
+                        logger.debug(
+                            "gRPC retry %d/%d after %s (backoff=%.2fs)",
+                            attempt + 1,
+                            config.max_retries,
+                            code,
+                            backoff,
+                        )
+                        time.sleep(backoff)
+                        continue
+                    return response
+                except grpc.RpcError as exc:
+                    if is_retryable_grpc_code(exc.code(), config) and attempt < config.max_retries:
+                        backoff = compute_backoff(attempt, config)
+                        logger.debug(
+                            "gRPC retry %d/%d after %s (backoff=%.2fs)",
+                            attempt + 1,
+                            config.max_retries,
+                            exc.code(),
+                            backoff,
+                        )
+                        time.sleep(backoff)
+                        continue
+                    raise
+                except ResourceExhaustedResponse as exc:
+                    if attempt < config.max_retries:
+                        backoff = compute_backoff(
+                            attempt, config, retry_after=float(exc.retry_after_s) if exc.retry_after_s else None
+                        )
+                        logger.debug(
+                            "gRPC retry %d/%d after ResourceExhausted (backoff=%.2fs)",
+                            attempt + 1,
+                            config.max_retries,
+                            backoff,
+                        )
+                        time.sleep(backoff)
+                        continue
+                    raise
+            return response  # type: ignore[possibly-undefined]
+
+        def intercept_unary_stream(
+            self, continuation: Any, client_call_details: Any, request: Any
+        ) -> Any:
+            # Don't retry streaming responses – just pass through.
+            return continuation(client_call_details, request)
+
+        def intercept_stream_unary(
+            self, continuation: Any, client_call_details: Any, request_iterator: Any
+        ) -> Any:
+            return continuation(client_call_details, request_iterator)
+
+        def intercept_stream_stream(
+            self, continuation: Any, client_call_details: Any, request_iterator: Any
+        ) -> Any:
+            return continuation(client_call_details, request_iterator)
+
+    return _RetryInterceptor()
+
+
+def retry_async_interceptor(config: RetryConfig) -> Any:
+    """Return an async gRPC client interceptor that retries transient failures."""
+
+    class _AsyncRetryInterceptor(
+        grpc.aio.UnaryUnaryClientInterceptor,
+        grpc.aio.UnaryStreamClientInterceptor,
+        grpc.aio.StreamUnaryClientInterceptor,
+        grpc.aio.StreamStreamClientInterceptor,
+    ):
+        async def intercept_unary_unary(
+            self, continuation: Any, client_call_details: Any, request: Any
+        ) -> Any:
+            for attempt in range(config.max_retries + 1):
+                try:
+                    response = await continuation(client_call_details, request)
+                    return response
+                except grpc.aio.AioRpcError as exc:
+                    if is_retryable_grpc_code(exc.code(), config) and attempt < config.max_retries:
+                        backoff = compute_backoff(attempt, config)
+                        logger.debug(
+                            "async gRPC retry %d/%d after %s (backoff=%.2fs)",
+                            attempt + 1,
+                            config.max_retries,
+                            exc.code(),
+                            backoff,
+                        )
+                        await asyncio.sleep(backoff)
+                        continue
+                    raise
+                except ResourceExhaustedResponse as exc:
+                    if attempt < config.max_retries:
+                        backoff = compute_backoff(
+                            attempt, config, retry_after=float(exc.retry_after_s) if exc.retry_after_s else None
+                        )
+                        logger.debug(
+                            "async gRPC retry %d/%d after ResourceExhausted (backoff=%.2fs)",
+                            attempt + 1,
+                            config.max_retries,
+                            backoff,
+                        )
+                        await asyncio.sleep(backoff)
+                        continue
+                    raise
+            return response  # type: ignore[possibly-undefined]
+
+        async def intercept_unary_stream(
+            self, continuation: Any, client_call_details: Any, request: Any
+        ) -> Any:
+            return await continuation(client_call_details, request)
+
+        async def intercept_stream_unary(
+            self, continuation: Any, client_call_details: Any, request_iterator: Any
+        ) -> Any:
+            return await continuation(client_call_details, request_iterator)
+
+        async def intercept_stream_stream(
+            self, continuation: Any, client_call_details: Any, request_iterator: Any
+        ) -> Any:
+            return await continuation(client_call_details, request_iterator)
+
+    return _AsyncRetryInterceptor()

--- a/qdrant_client/connection.py
+++ b/qdrant_client/connection.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import collections
 from typing import Any, Awaitable, Callable
@@ -6,6 +8,7 @@ import grpc
 
 from qdrant_client.common.client_exceptions import ResourceExhaustedResponse
 from qdrant_client.common.client_warnings import show_warning_once
+from qdrant_client.common.retry import RetryConfig, retry_async_interceptor, retry_interceptor
 
 
 # type: ignore # noqa: F401
@@ -297,6 +300,7 @@ def get_channel(
     options: dict[str, Any] | None = None,
     compression: grpc.Compression | None = None,
     auth_token_provider: Callable[[], str] | None = None,
+    retry_config: RetryConfig | None = None,
 ) -> grpc.Channel:
     # Parse gRPC client options
     _copied_options = (
@@ -308,13 +312,18 @@ def get_channel(
         new_metadata=metadata or [], auth_token_provider=auth_token_provider
     )
 
+    interceptors: list[Any] = [metadata_interceptor]
+    if retry_config is not None:
+        # Retry interceptor wraps the metadata interceptor (outermost).
+        interceptors.insert(0, retry_interceptor(retry_config))
+
     if ssl:
         ssl_creds = grpc.ssl_channel_credentials(**_ssl_cred_options)
         channel = grpc.secure_channel(f"{host}:{port}", ssl_creds, _options, compression)
-        return grpc.intercept_channel(channel, metadata_interceptor)
+        return grpc.intercept_channel(channel, *interceptors)
     else:
         channel = grpc.insecure_channel(f"{host}:{port}", _options, compression)
-        return grpc.intercept_channel(channel, metadata_interceptor)
+        return grpc.intercept_channel(channel, *interceptors)
 
 
 def get_async_channel(
@@ -325,6 +334,7 @@ def get_async_channel(
     options: dict[str, Any] | None = None,
     compression: grpc.Compression | None = None,
     auth_token_provider: Callable[[], str] | Callable[[], Awaitable[str]] | None = None,
+    retry_config: RetryConfig | None = None,
 ) -> grpc.aio.Channel:
     # Parse gRPC client options
     _copied_options = (
@@ -338,6 +348,11 @@ def get_async_channel(
         new_metadata=metadata or [], auth_token_provider=auth_token_provider
     )
 
+    interceptors: list[Any] = [metadata_interceptor]
+    if retry_config is not None:
+        # Retry interceptor outermost.
+        interceptors.insert(0, retry_async_interceptor(retry_config))
+
     if ssl:
         ssl_creds = grpc.ssl_channel_credentials(**_ssl_cred_options)
         return grpc.aio.secure_channel(
@@ -345,9 +360,9 @@ def get_async_channel(
             ssl_creds,
             _options,
             compression,
-            interceptors=[metadata_interceptor],
+            interceptors=interceptors,
         )
     else:
         return grpc.aio.insecure_channel(
-            f"{host}:{port}", _options, compression, interceptors=[metadata_interceptor]
+            f"{host}:{port}", _options, compression, interceptors=interceptors
         )

--- a/qdrant_client/local/async_qdrant_local.py
+++ b/qdrant_client/local/async_qdrant_local.py
@@ -799,6 +799,7 @@ class AsyncQdrantLocal(AsyncQdrantBase):
         update_mode: types.UpdateMode | None = None,
         **kwargs: Any,
     ) -> None:
+
         def uuid_generator() -> Generator[str, None, None]:
             while True:
                 yield str(uuid4())
@@ -807,9 +808,9 @@ class AsyncQdrantLocal(AsyncQdrantBase):
         if isinstance(vectors, dict) and any(
             (isinstance(v, np.ndarray) for v in vectors.values())
         ):
-            assert (
-                len(set([arr.shape[0] for arr in vectors.values()])) == 1
-            ), "Each named vector should have the same number of vectors"
+            assert len(set([arr.shape[0] for arr in vectors.values()])) == 1, (
+                "Each named vector should have the same number of vectors"
+            )
             num_vectors = next(iter(vectors.values())).shape[0]
             vectors = [
                 {name: vectors[name][i].tolist() for name in vectors.keys()}

--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -13,6 +13,7 @@ import numpy as np
 from qdrant_client import grpc as grpc
 from qdrant_client.client_base import QdrantBase
 from qdrant_client.common.client_warnings import show_warning_once
+from qdrant_client.common.retry import RetryConfig
 from qdrant_client.conversions import common_types as types
 from qdrant_client.embed.type_inspector import Inspector
 from qdrant_client.http import ApiClient, SyncApis
@@ -77,6 +78,10 @@ class QdrantClient(QdrantFastembedMixin):
         pool_size: connection pool size, Default: None. Default value for gRPC connection pool is 3, rest default is
             inherited from `httpx` (default: 100)
         headers: Custom headers to send with every request.
+        retry_config:
+            Configuration for automatic retries with exponential backoff.
+            If ``None`` (default), no retries are performed and behaviour is unchanged.
+            Pass a ``RetryConfig`` instance to enable retries for transient failures.
         **kwargs: Additional arguments passed directly into REST client initialization
     """
 
@@ -101,6 +106,7 @@ class QdrantClient(QdrantFastembedMixin):
         check_compatibility: bool = True,
         pool_size: int | None = None,
         headers: dict[str, str] | None = None,
+        retry_config: RetryConfig | None = None,
         **kwargs: Any,
     ):
         # Saving the init options to facilitate building AsyncQdrantClient from QdrantClient and vice versa.
@@ -146,6 +152,7 @@ class QdrantClient(QdrantFastembedMixin):
                 check_compatibility=check_compatibility,
                 pool_size=pool_size,
                 headers=headers,
+                retry_config=retry_config,
                 **kwargs,
             )
 

--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -22,6 +22,7 @@ from urllib3.util import Url, parse_url
 from urllib.parse import urljoin
 
 from qdrant_client.common.client_warnings import show_warning, show_warning_once
+from qdrant_client.common.retry import RetryConfig, install_retry_middleware
 from qdrant_client import grpc as grpc
 from qdrant_client._pydantic_compat import construct
 from qdrant_client.auth import BearerAuth
@@ -62,9 +63,11 @@ class QdrantRemote(QdrantBase):
         check_compatibility: bool = True,
         pool_size: int | None = None,
         headers: dict[str, str] | None = None,
+        retry_config: RetryConfig | None = None,
         **kwargs: Any,
     ):
         super().__init__(**kwargs)
+        self._retry_config = retry_config
         self._prefer_grpc = prefer_grpc
         self._grpc_port = grpc_port
         self._grpc_options = grpc_options or {}
@@ -235,6 +238,9 @@ class QdrantRemote(QdrantBase):
             **self._rest_args,
         )
 
+        if self._retry_config is not None:
+            install_retry_middleware(self.openapi_client, self._retry_config)
+
         self._grpc_channel_pool: list[grpc.Channel] = []
         self._grpc_points_client_pool: list[grpc.PointsStub] | None = None
         self._grpc_collections_client_pool: list[grpc.CollectionsStub] | None = None
@@ -361,6 +367,7 @@ class QdrantRemote(QdrantBase):
                         # sync get_channel does not accept coroutine functions,
                         # but we can't check type here, since it'll get into async client as well
                         auth_token_provider=self._auth_token_provider,  # type: ignore
+                        retry_config=self._retry_config,
                     )
                     channel_pool.append(channel)
 

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,405 @@
+"""Tests for retry / resilience middleware."""
+
+import asyncio
+import time
+from unittest.mock import MagicMock, AsyncMock, patch
+
+import grpc
+import grpc.aio
+import pytest
+from httpx import ConnectError, Request, Response
+
+from qdrant_client.common.client_exceptions import ResourceExhaustedResponse
+from qdrant_client.common.retry import (
+    RetryConfig,
+    async_retry_middleware,
+    compute_backoff,
+    is_retryable_grpc_code,
+    is_retryable_status,
+    retry_interceptor,
+    retry_middleware,
+)
+
+
+# ---------------------------------------------------------------------------
+# compute_backoff
+# ---------------------------------------------------------------------------
+
+
+class TestComputeBackoff:
+    def test_first_attempt(self):
+        config = RetryConfig(initial_backoff=1.0, backoff_multiplier=2.0, jitter=0.0)
+        assert compute_backoff(0, config) == 1.0
+
+    def test_exponential_growth(self):
+        config = RetryConfig(initial_backoff=1.0, backoff_multiplier=2.0, jitter=0.0)
+        assert compute_backoff(0, config) == 1.0
+        assert compute_backoff(1, config) == 2.0
+        assert compute_backoff(2, config) == 4.0
+
+    def test_max_backoff_cap(self):
+        config = RetryConfig(initial_backoff=1.0, backoff_multiplier=10.0, max_backoff=5.0, jitter=0.0)
+        assert compute_backoff(2, config) == 5.0
+
+    def test_retry_after_floor(self):
+        config = RetryConfig(initial_backoff=0.1, jitter=0.0)
+        result = compute_backoff(0, config, retry_after=10.0)
+        assert result == 10.0
+
+    def test_jitter_adds_randomness(self):
+        config = RetryConfig(initial_backoff=1.0, jitter=1.0, backoff_multiplier=1.0)
+        values = {compute_backoff(0, config) for _ in range(50)}
+        # With jitter=1.0, values should vary (not all identical).
+        assert len(values) > 1
+
+
+# ---------------------------------------------------------------------------
+# is_retryable_status / is_retryable_grpc_code
+# ---------------------------------------------------------------------------
+
+
+class TestRetryableChecks:
+    def test_default_retryable_statuses(self):
+        config = RetryConfig()
+        assert is_retryable_status(429, config)
+        assert is_retryable_status(503, config)
+        assert not is_retryable_status(200, config)
+        assert not is_retryable_status(404, config)
+
+    def test_custom_retryable_statuses(self):
+        config = RetryConfig(retryable_status_codes=frozenset({418}))
+        assert is_retryable_status(418, config)
+        assert not is_retryable_status(429, config)
+
+    def test_default_retryable_grpc_codes(self):
+        config = RetryConfig()
+        assert is_retryable_grpc_code(grpc.StatusCode.UNAVAILABLE, config)
+        assert is_retryable_grpc_code(grpc.StatusCode.DEADLINE_EXCEEDED, config)
+        assert not is_retryable_grpc_code(grpc.StatusCode.NOT_FOUND, config)
+
+
+# ---------------------------------------------------------------------------
+# REST sync middleware
+# ---------------------------------------------------------------------------
+
+
+class TestSyncRetryMiddleware:
+    def test_no_retry_on_success(self):
+        config = RetryConfig(max_retries=3)
+        mw = retry_middleware(config)
+
+        call_count = 0
+
+        def call_next(request: Request) -> Response:
+            nonlocal call_count
+            call_count += 1
+            return Response(200)
+
+        request = Request("GET", "http://localhost/test")
+        response = mw(request, call_next)
+        assert response.status_code == 200
+        assert call_count == 1
+
+    def test_retries_on_503(self):
+        config = RetryConfig(max_retries=2, initial_backoff=0.001, jitter=0.0)
+        mw = retry_middleware(config)
+
+        call_count = 0
+
+        def call_next(request: Request) -> Response:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                return Response(503)
+            return Response(200)
+
+        request = Request("GET", "http://localhost/test")
+        response = mw(request, call_next)
+        assert response.status_code == 200
+        assert call_count == 3
+
+    def test_gives_up_after_max_retries(self):
+        config = RetryConfig(max_retries=2, initial_backoff=0.001, jitter=0.0)
+        mw = retry_middleware(config)
+
+        call_count = 0
+
+        def call_next(request: Request) -> Response:
+            nonlocal call_count
+            call_count += 1
+            return Response(503)
+
+        request = Request("GET", "http://localhost/test")
+        response = mw(request, call_next)
+        assert response.status_code == 503
+        assert call_count == 3  # 1 original + 2 retries
+
+    def test_retries_on_connection_error(self):
+        config = RetryConfig(max_retries=2, initial_backoff=0.001, jitter=0.0)
+        mw = retry_middleware(config)
+
+        call_count = 0
+
+        def call_next(request: Request) -> Response:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise ConnectError("Connection refused")
+            return Response(200)
+
+        request = Request("GET", "http://localhost/test")
+        response = mw(request, call_next)
+        assert response.status_code == 200
+        assert call_count == 3
+
+    def test_connection_error_raises_after_max_retries(self):
+        config = RetryConfig(max_retries=1, initial_backoff=0.001, jitter=0.0)
+        mw = retry_middleware(config)
+
+        def call_next(request: Request) -> Response:
+            raise ConnectError("Connection refused")
+
+        request = Request("GET", "http://localhost/test")
+        with pytest.raises(ConnectError):
+            mw(request, call_next)
+
+    def test_no_retry_on_non_retryable_status(self):
+        config = RetryConfig(max_retries=3)
+        mw = retry_middleware(config)
+
+        call_count = 0
+
+        def call_next(request: Request) -> Response:
+            nonlocal call_count
+            call_count += 1
+            return Response(404)
+
+        request = Request("GET", "http://localhost/test")
+        response = mw(request, call_next)
+        assert response.status_code == 404
+        assert call_count == 1
+
+    def test_zero_retries_means_no_retry(self):
+        config = RetryConfig(max_retries=0)
+        mw = retry_middleware(config)
+
+        call_count = 0
+
+        def call_next(request: Request) -> Response:
+            nonlocal call_count
+            call_count += 1
+            return Response(503)
+
+        request = Request("GET", "http://localhost/test")
+        response = mw(request, call_next)
+        assert response.status_code == 503
+        assert call_count == 1
+
+    def test_retry_after_header_respected(self):
+        config = RetryConfig(max_retries=1, initial_backoff=0.001, jitter=0.0)
+        mw = retry_middleware(config)
+
+        call_count = 0
+
+        def call_next(request: Request) -> Response:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return Response(429, headers={"Retry-After": "0.01"})
+            return Response(200)
+
+        request = Request("GET", "http://localhost/test")
+        start = time.monotonic()
+        response = mw(request, call_next)
+        elapsed = time.monotonic() - start
+
+        assert response.status_code == 200
+        assert elapsed >= 0.01
+
+
+# ---------------------------------------------------------------------------
+# REST async middleware
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncRetryMiddleware:
+    @pytest.mark.asyncio
+    async def test_no_retry_on_success(self):
+        config = RetryConfig(max_retries=3)
+        mw = async_retry_middleware(config)
+
+        call_count = 0
+
+        async def call_next(request: Request) -> Response:
+            nonlocal call_count
+            call_count += 1
+            return Response(200)
+
+        request = Request("GET", "http://localhost/test")
+        response = await mw(request, call_next)
+        assert response.status_code == 200
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_retries_on_503(self):
+        config = RetryConfig(max_retries=2, initial_backoff=0.001, jitter=0.0)
+        mw = async_retry_middleware(config)
+
+        call_count = 0
+
+        async def call_next(request: Request) -> Response:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                return Response(503)
+            return Response(200)
+
+        request = Request("GET", "http://localhost/test")
+        response = await mw(request, call_next)
+        assert response.status_code == 200
+        assert call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_retries_on_connection_error(self):
+        config = RetryConfig(max_retries=2, initial_backoff=0.001, jitter=0.0)
+        mw = async_retry_middleware(config)
+
+        call_count = 0
+
+        async def call_next(request: Request) -> Response:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise ConnectError("Connection refused")
+            return Response(200)
+
+        request = Request("GET", "http://localhost/test")
+        response = await mw(request, call_next)
+        assert response.status_code == 200
+        assert call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# gRPC sync retry interceptor
+# ---------------------------------------------------------------------------
+
+
+class TestGrpcRetryInterceptor:
+    def test_no_retry_on_success(self):
+        config = RetryConfig(max_retries=3)
+        interceptor = retry_interceptor(config)
+
+        mock_response = MagicMock()
+        mock_response.code.return_value = grpc.StatusCode.OK
+
+        def continuation(details, request):
+            return mock_response
+
+        result = interceptor.intercept_unary_unary(continuation, MagicMock(), MagicMock())
+        assert result is mock_response
+
+    def test_retries_on_unavailable(self):
+        config = RetryConfig(max_retries=2, initial_backoff=0.001, jitter=0.0)
+        interceptor = retry_interceptor(config)
+
+        call_count = 0
+        mock_success = MagicMock()
+        mock_success.code.return_value = grpc.StatusCode.OK
+
+        mock_fail = MagicMock()
+        mock_fail.code.return_value = grpc.StatusCode.UNAVAILABLE
+
+        def continuation(details, request):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                return mock_fail
+            return mock_success
+
+        result = interceptor.intercept_unary_unary(continuation, MagicMock(), MagicMock())
+        assert result is mock_success
+        assert call_count == 3
+
+    def test_retries_on_rpc_error(self):
+        config = RetryConfig(max_retries=2, initial_backoff=0.001, jitter=0.0)
+        interceptor = retry_interceptor(config)
+
+        call_count = 0
+
+        class FakeRpcError(grpc.RpcError):
+            def code(self):
+                return grpc.StatusCode.UNAVAILABLE
+
+        mock_success = MagicMock()
+        mock_success.code.return_value = grpc.StatusCode.OK
+
+        def continuation(details, request):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise FakeRpcError()
+            return mock_success
+
+        result = interceptor.intercept_unary_unary(continuation, MagicMock(), MagicMock())
+        assert result is mock_success
+        assert call_count == 3
+
+    def test_does_not_retry_stream_requests(self):
+        """Stream-unary and stream-stream just pass through."""
+        config = RetryConfig(max_retries=3)
+        interceptor = retry_interceptor(config)
+
+        mock_response = MagicMock()
+
+        def continuation(details, request_iterator):
+            return mock_response
+
+        result = interceptor.intercept_stream_unary(continuation, MagicMock(), iter([]))
+        assert result is mock_response
+
+    def test_retries_on_resource_exhausted_exception(self):
+        config = RetryConfig(max_retries=1, initial_backoff=0.001, jitter=0.0)
+        interceptor = retry_interceptor(config)
+
+        call_count = 0
+        mock_success = MagicMock()
+        mock_success.code.return_value = grpc.StatusCode.OK
+
+        def continuation(details, request):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ResourceExhaustedResponse(message="Rate limited", retry_after_s=0)
+            return mock_success
+
+        result = interceptor.intercept_unary_unary(continuation, MagicMock(), MagicMock())
+        assert result is mock_success
+        assert call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# RetryConfig defaults
+# ---------------------------------------------------------------------------
+
+
+class TestRetryConfig:
+    def test_defaults(self):
+        config = RetryConfig()
+        assert config.max_retries == 3
+        assert config.initial_backoff == 0.1
+        assert config.max_backoff == 30.0
+        assert config.backoff_multiplier == 2.0
+        assert config.jitter == 0.1
+        assert 429 in config.retryable_status_codes
+        assert grpc.StatusCode.UNAVAILABLE in config.retryable_grpc_codes
+
+    def test_frozen(self):
+        config = RetryConfig()
+        with pytest.raises(AttributeError):
+            config.max_retries = 5  # type: ignore
+
+    def test_custom_values(self):
+        config = RetryConfig(max_retries=5, initial_backoff=0.5, max_backoff=60.0)
+        assert config.max_retries == 5
+        assert config.initial_backoff == 0.5
+        assert config.max_backoff == 60.0


### PR DESCRIPTION
**Body:**                                                                                                                                    

  What this does - 
  Adds built-in automatic retries for transient failures (connection resets, 503s, rate limits, etc.) to both REST and gRPC interfaces. It's off by default so existing behavior doesn't change unless you opt in.

  Usage - 

  `from qdrant_client import QdrantClient, RetryConfig`
  `client = QdrantClient(`
      `url="http://localhost:6333",`
      `retry_config=RetryConfig(max_retries=3),`
 ` )`

  That's it, now the client will retry up to 3 times on transient errors with exponential backoff before giving up.

  RetryConfig lets you tweak things if needed such as initial_backoff, max_backoff, backoff_multiplier, jitter, and which HTTP status codes or    
  gRPC codes count as retryable. The defaults should be sensible for most cases.

  How it works - 

  - REST: A middleware wraps each HTTP request. If it gets a retryable status (429, 500, 502, 503, 504) or a connection error, it waits and
   tries again. It also respects Retry-After headers.
  - gRPC: An interceptor does the same thing for gRPC calls. It retries on UNAVAILABLE, DEADLINE_EXCEEDED, and RESOURCE_EXHAUSTED. Only    
  unary (single request/response) calls are retried — streaming calls pass through since you can't replay a consumed iterator.

  Backoff is exponential with jitter to avoid thundering herd.

 Why this is safe -
 Most Qdrant writes (upsert, delete by ID, set payload) are idempotent, so retrying them wont cause duplicates or corruption. The feature is completely disabled by default so nothing changes for existing users.

  Changes I've done - 

  - created a new qdrant_client/common/retry.py so all the retry logic lives here
  - connection.py for passesing retry interceptors to gRPC channels
  - qdrant_remote.py / qdrant_client.py which will thread the retry_config param through
  - __init__.py to exports RetryConfig
  - Async clients regenerated (picks up changes automatically)
  - 27 new tests covering backoff math, REST middleware, gRPC interceptor, config validation
