### PR TITLE
Close gRPC channels and HTTP clients in batch uploaders

### DIFF
--- a/qdrant_client/uploader/grpc_uploader.py
+++ b/qdrant_client/uploader/grpc_uploader.py
@@ -138,19 +138,22 @@ class GrpcBatchUploader(BaseUploader):
 
     def process_upload(self, items: Iterable[Any]) -> Generator[bool, None, None]:
         channel = get_channel(host=self._host, port=self._port, **self._kwargs)
-        points_client = grpc.PointsStub(channel)
-        for batch in items:
-            yield upload_batch_grpc(
-                points_client,
-                self.collection_name,
-                batch,
-                shard_key_selector=self._shard_key_selector,
-                update_filter=self._update_filter,
-                update_mode=self._update_mode,
-                max_retries=self.max_retries,
-                wait=self._wait,
-                timeout=self._timeout,
-            )
+        try:
+            points_client = grpc.PointsStub(channel)
+            for batch in items:
+                yield upload_batch_grpc(
+                    points_client,
+                    self.collection_name,
+                    batch,
+                    shard_key_selector=self._shard_key_selector,
+                    update_filter=self._update_filter,
+                    update_mode=self._update_mode,
+                    max_retries=self.max_retries,
+                    wait=self._wait,
+                    timeout=self._timeout,
+                )
+        finally:
+            channel.close()
 
     def process(self, items: Iterable[Any]) -> Iterable[bool]:
         yield from self.process_upload(items)

--- a/qdrant_client/uploader/rest_uploader.py
+++ b/qdrant_client/uploader/rest_uploader.py
@@ -112,14 +112,17 @@ class RestBatchUploader(BaseUploader):
         return cls(uri=uri, collection_name=collection_name, max_retries=max_retries, **kwargs)
 
     def process(self, items: Iterable[Any]) -> Iterable[bool]:
-        for batch in items:
-            yield upload_batch(
-                self.openapi_client,
-                self.collection_name,
-                batch,
-                shard_key_selector=self._shard_key_selector,
-                max_retries=self.max_retries,
-                update_filter=self._update_filter,
-                update_mode=self._update_mode,
-                wait=self._wait,
-            )
+        try:
+            for batch in items:
+                yield upload_batch(
+                    self.openapi_client,
+                    self.collection_name,
+                    batch,
+                    shard_key_selector=self._shard_key_selector,
+                    max_retries=self.max_retries,
+                    update_filter=self._update_filter,
+                    update_mode=self._update_mode,
+                    wait=self._wait,
+                )
+        finally:
+            self.openapi_client.close()


### PR DESCRIPTION
## Summary
- Close gRPC channels and HTTP clients in batch uploaders after upload completes
- Prevents file descriptor leaks when using parallel > 1

Each parallel worker in `GrpcBatchUploader` and `RestBatchUploader` creates its own gRPC channel or HTTP client. These were never closed after the upload loop finished, leaking file descriptors. Wrapping the upload loops in `try/finally` ensures cleanup happens both on normal completion and on error.

Fixes #1172