### PR TITLE
Fix: Set gRPC reconnection backoff to prevent indefinite hangs

### DIFF
--- a/qdrant_client/connection.py
+++ b/qdrant_client/connection.py
@@ -241,6 +241,9 @@ def parse_channel_options(options: dict[str, Any] | None = None) -> list[tuple[s
     default_options: list[tuple[str, Any]] = [
         ("grpc.max_send_message_length", -1),
         ("grpc.max_receive_message_length", -1),
+        ("grpc.enable_retries", 1),
+        ("grpc.initial_reconnect_backoff_ms", 1000),
+        ("grpc.max_reconnect_backoff_ms", 30000),
     ]
 
     if options is None:


### PR DESCRIPTION
### Problem
In certain network environments (e.g., high-concurrency batch updates), the Python client could hang indefinitely if the connection dropped mid-stream due to default gRPC settings.

### Solution
This PR updates `parse_channel_options` to include standard gRPC reconnection backoff parameters (`grpc.initial_reconnect_backoff_ms` and `grpc.max_reconnect_backoff_ms`). This ensures the client follows an exponential backoff strategy instead of hanging or retrying immediately in a tight loop.

### Impact
- Improves stability for long-running batch operations.
- Zero breaking changes to public API.

Bounty Address (USDT-TRC20): `TPCeXK1ziCgwZM8JgypZzdKxBemV7Q2TJn`