### PR TITLE
fix(local): add threading.RLock to LocalCollection to prevent concurrent-upsert race (#1193)

### DIFF
--- a/qdrant_client/local/local_collection.py
+++ b/qdrant_client/local/local_collection.py
@@ -1,5 +1,6 @@
 import json
 import math
+import threading
 import uuid
 from collections import OrderedDict, defaultdict
 from typing import (
@@ -144,6 +145,12 @@ class LocalCollection:
         self.persistent = location is not None
         self.storage = None
         self.config = config
+        # Reentrant because upsert/delete call private mutators that are also
+        # reachable from other write entry points. Guards concurrent mutations
+        # of `payload`, `deleted`, `vectors`, `sparse_vectors`, `multivectors`,
+        # `ids`, `ids_inv`, and `deleted_per_vector` so that read paths never
+        # observe these arrays at mismatched lengths.
+        self._lock = threading.RLock()
         if location is not None:
             self.storage = CollectionPersistence(location, force_disable_check_same_thread)
         self.load_vectors()
@@ -2549,44 +2556,47 @@ class LocalCollection:
         update_filter: types.Filter | None = None,
         update_mode: types.UpdateMode | None = None,
     ) -> None:
-        if isinstance(points, list):
-            for point in points:
-                self._upsert_point(point, update_filter=update_filter, update_mode=update_mode)
-        elif isinstance(points, models.Batch):
-            batch = points
-            if isinstance(batch.vectors, list):
-                vectors = {DEFAULT_VECTOR_NAME: batch.vectors}
+        with self._lock:
+            if isinstance(points, list):
+                for point in points:
+                    self._upsert_point(
+                        point, update_filter=update_filter, update_mode=update_mode
+                    )
+            elif isinstance(points, models.Batch):
+                batch = points
+                if isinstance(batch.vectors, list):
+                    vectors = {DEFAULT_VECTOR_NAME: batch.vectors}
+                else:
+                    vectors = batch.vectors
+
+                for idx, point_id in enumerate(batch.ids):
+                    payload = None
+                    if batch.payloads is not None:
+                        payload = batch.payloads[idx]
+
+                    vector = {name: v[idx] for name, v in vectors.items()}
+
+                    self._upsert_point(
+                        models.PointStruct(
+                            id=point_id,
+                            payload=payload,
+                            vector=vector,
+                        ),
+                        update_filter=update_filter,
+                        update_mode=update_mode,
+                    )
             else:
-                vectors = batch.vectors
+                raise ValueError(f"Unsupported type: {type(points)}")
 
-            for idx, point_id in enumerate(batch.ids):
-                payload = None
-                if batch.payloads is not None:
-                    payload = batch.payloads[idx]
-
-                vector = {name: v[idx] for name, v in vectors.items()}
-
-                self._upsert_point(
-                    models.PointStruct(
-                        id=point_id,
-                        payload=payload,
-                        vector=vector,
-                    ),
-                    update_filter=update_filter,
-                    update_mode=update_mode,
+            if len(self.ids) > self.LARGE_DATA_THRESHOLD:
+                show_warning_once(
+                    f"Local mode is not recommended for collections with more than {self.LARGE_DATA_THRESHOLD:,} "
+                    f"points. Current collection contains {len(self.ids)} points. "
+                    "Consider using Qdrant in Docker or Qdrant Cloud for better performance with large datasets.",
+                    category=UserWarning,
+                    idx="large-local-collection",
+                    stacklevel=6,
                 )
-        else:
-            raise ValueError(f"Unsupported type: {type(points)}")
-
-        if len(self.ids) > self.LARGE_DATA_THRESHOLD:
-            show_warning_once(
-                f"Local mode is not recommended for collections with more than {self.LARGE_DATA_THRESHOLD:,} "
-                f"points. Current collection contains {len(self.ids)} points. "
-                "Consider using Qdrant in Docker or Qdrant Cloud for better performance with large datasets.",
-                category=UserWarning,
-                idx="large-local-collection",
-                stacklevel=6,
-            )
 
     def _update_named_vectors(
         self, idx: int, vectors: dict[str, list[float] | SparseVector | list[list[float]]]
@@ -2623,26 +2633,27 @@ class LocalCollection:
     def update_vectors(
         self, points: Sequence[types.PointVectors], update_filter: types.Filter | None = None
     ) -> None:
-        for point in points:
-            point_id = str(point.id) if isinstance(point.id, uuid.UUID) else point.id
-            idx = self.ids[point_id]
-            vector_struct = point.vector
-            if isinstance(vector_struct, list):
-                fixed_vectors = {DEFAULT_VECTOR_NAME: vector_struct}
-            else:
-                fixed_vectors = vector_struct
+        with self._lock:
+            for point in points:
+                point_id = str(point.id) if isinstance(point.id, uuid.UUID) else point.id
+                idx = self.ids[point_id]
+                vector_struct = point.vector
+                if isinstance(vector_struct, list):
+                    fixed_vectors = {DEFAULT_VECTOR_NAME: vector_struct}
+                else:
+                    fixed_vectors = vector_struct
 
-            if not self.deleted[idx] and update_filter is not None:
-                has_vector = {}
-                for vector_name, deleted in self.deleted_per_vector.items():
-                    if not deleted[idx]:
-                        has_vector[vector_name] = True
-                if not check_filter(
-                    update_filter, self.payload[idx], self.ids_inv[idx], has_vector
-                ):
-                    return None
-            self._update_named_vectors(idx, fixed_vectors)
-            self._persist_by_id(point_id)
+                if not self.deleted[idx] and update_filter is not None:
+                    has_vector = {}
+                    for vector_name, deleted in self.deleted_per_vector.items():
+                        if not deleted[idx]:
+                            has_vector[vector_name] = True
+                    if not check_filter(
+                        update_filter, self.payload[idx], self.ids_inv[idx], has_vector
+                    ):
+                        return None
+                self._update_named_vectors(idx, fixed_vectors)
+                self._persist_by_id(point_id)
 
     def delete_vectors(
         self,
@@ -2654,12 +2665,13 @@ class LocalCollection:
             | models.PointIdsList
         ),
     ) -> None:
-        ids = self._selector_to_ids(selector)
-        for point_id in ids:
-            idx = self.ids[point_id]
-            for vector_name in vectors:
-                self.deleted_per_vector[vector_name][idx] = 1
-            self._persist_by_id(point_id)
+        with self._lock:
+            ids = self._selector_to_ids(selector)
+            for point_id in ids:
+                idx = self.ids[point_id]
+                for vector_name in vectors:
+                    self.deleted_per_vector[vector_name][idx] = 1
+                self._persist_by_id(point_id)
 
     def _delete_ids(self, ids: list[types.PointId]) -> None:
         for point_id in ids:
@@ -2706,8 +2718,9 @@ class LocalCollection:
             | models.PointIdsList
         ),
     ) -> None:
-        ids = self._selector_to_ids(selector)
-        self._delete_ids(ids)
+        with self._lock:
+            ids = self._selector_to_ids(selector)
+            self._delete_ids(ids)
 
     def _persist_by_id(self, point_id: models.ExtendedPointId) -> None:
         if self.storage is not None:
@@ -2730,20 +2743,25 @@ class LocalCollection:
         ),
         key: str | None = None,
     ) -> None:
-        ids = self._selector_to_ids(selector)
-        jsonable_payload = deepcopy(to_jsonable_python(payload))
+        with self._lock:
+            ids = self._selector_to_ids(selector)
+            jsonable_payload = deepcopy(to_jsonable_python(payload))
 
-        keys: list[JsonPathItem] | None = parse_json_path(key) if key is not None else None
+            keys: list[JsonPathItem] | None = (
+                parse_json_path(key) if key is not None else None
+            )
 
-        for point_id in ids:
-            idx = self.ids[point_id]
-            if keys is None:
-                self.payload[idx] = {**self.payload[idx], **jsonable_payload}
-            else:
-                if self.payload[idx] is not None:
-                    set_value_by_key(payload=self.payload[idx], value=jsonable_payload, keys=keys)
+            for point_id in ids:
+                idx = self.ids[point_id]
+                if keys is None:
+                    self.payload[idx] = {**self.payload[idx], **jsonable_payload}
+                else:
+                    if self.payload[idx] is not None:
+                        set_value_by_key(
+                            payload=self.payload[idx], value=jsonable_payload, keys=keys
+                        )
 
-            self._persist_by_id(point_id)
+                self._persist_by_id(point_id)
 
     def overwrite_payload(
         self,
@@ -2755,11 +2773,12 @@ class LocalCollection:
             | models.PointIdsList
         ),
     ) -> None:
-        ids = self._selector_to_ids(selector)
-        for point_id in ids:
-            idx = self.ids[point_id]
-            self.payload[idx] = deepcopy(to_jsonable_python(payload)) or {}
-            self._persist_by_id(point_id)
+        with self._lock:
+            ids = self._selector_to_ids(selector)
+            for point_id in ids:
+                idx = self.ids[point_id]
+                self.payload[idx] = deepcopy(to_jsonable_python(payload)) or {}
+                self._persist_by_id(point_id)
 
     def delete_payload(
         self,
@@ -2771,13 +2790,14 @@ class LocalCollection:
             | models.PointIdsList
         ),
     ) -> None:
-        ids = self._selector_to_ids(selector)
-        for point_id in ids:
-            idx = self.ids[point_id]
-            for key in keys:
-                if key in self.payload[idx]:
-                    self.payload[idx].pop(key)
-            self._persist_by_id(point_id)
+        with self._lock:
+            ids = self._selector_to_ids(selector)
+            for point_id in ids:
+                idx = self.ids[point_id]
+                for key in keys:
+                    if key in self.payload[idx]:
+                        self.payload[idx].pop(key)
+                self._persist_by_id(point_id)
 
     def clear_payload(
         self,
@@ -2788,11 +2808,12 @@ class LocalCollection:
             | models.PointIdsList
         ),
     ) -> None:
-        ids = self._selector_to_ids(selector)
-        for point_id in ids:
-            idx = self.ids[point_id]
-            self.payload[idx] = {}
-            self._persist_by_id(point_id)
+        with self._lock:
+            ids = self._selector_to_ids(selector)
+            for point_id in ids:
+                idx = self.ids[point_id]
+                self.payload[idx] = {}
+                self._persist_by_id(point_id)
 
     def batch_update_points(
         self,

--- a/tests/test_in_memory.py
+++ b/tests/test_in_memory.py
@@ -1,3 +1,7 @@
+import random
+import threading
+import uuid
+
 import pytest
 
 from qdrant_client import QdrantClient, models
@@ -293,6 +297,75 @@ def test_fusion_dbsf_score_threshold(qdrant: QdrantClient):
     assert len(result_with_threshold.points) == 3, (
         f"Expected 3 points after filtering (threshold 1.0), got {len(result_with_threshold.points)}. "
         f"Scores: {[p.score for p in result_no_threshold.points]}"
+    )
+
+
+def test_concurrent_upsert_does_not_corrupt_local_collection() -> None:
+    """Regression test for issue #1193.
+
+    Before the ``threading.RLock`` guard in ``LocalCollection``, two threads
+    calling ``upsert`` concurrently could interleave the mutations of
+    ``self.payload`` (list append) and ``self.deleted`` (numpy concatenate),
+    leaving the arrays at mismatched lengths. A subsequent ``scroll`` /
+    ``search`` would then raise::
+
+        ValueError: operands could not be broadcast together with shapes (N,) (M,)
+
+    Eight threads each upsert 20 batches of 10 points into the same in-memory
+    collection. With the lock, the final state must contain exactly
+    ``8 * 20 * 10 = 1600`` points and no broadcast error.
+    """
+    client = QdrantClient(":memory:")
+    client.create_collection(
+        collection_name="race",
+        vectors_config={
+            "dense": models.VectorParams(size=8, distance=models.Distance.COSINE),
+        },
+        sparse_vectors_config={"bm25": models.SparseVectorParams()},
+    )
+
+    thread_count = 8
+    batches_per_thread = 20
+    batch_size = 10
+    expected_total = thread_count * batches_per_thread * batch_size
+    exceptions: list[BaseException] = []
+
+    def worker(seed: int) -> None:
+        rng = random.Random(seed)
+        try:
+            for _ in range(batches_per_thread):
+                points = [
+                    models.PointStruct(
+                        id=str(uuid.uuid4()),
+                        vector={
+                            "dense": [rng.random() for _ in range(8)],
+                            "bm25": models.SparseVector(
+                                indices=[0, 1, 2], values=[0.5, 0.3, 0.1]
+                            ),
+                        },
+                        payload={"thread": seed},
+                    )
+                    for _ in range(batch_size)
+                ]
+                client.upsert(collection_name="race", points=points)
+        except BaseException as exc:  # noqa: BLE001 — surface any thread failure
+            exceptions.append(exc)
+
+    threads = [
+        threading.Thread(target=worker, args=(seed,)) for seed in range(thread_count)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not exceptions, f"worker threads raised: {exceptions}"
+
+    # Scroll across the whole collection — this is the call that used to
+    # surface the shape mismatch via `operands could not be broadcast`.
+    points, _ = client.scroll(collection_name="race", limit=expected_total + 1)
+    assert len(points) == expected_total, (
+        f"expected {expected_total} points after concurrent upserts, got {len(points)}"
     )
 
 


### PR DESCRIPTION
## Summary

Fixes #1193.

`LocalCollection` held no synchronization primitives, so two threads running `upsert` concurrently could interleave the mutations of `self.payload` (Python `list.append`) and `self.deleted` (numpy `np.concatenate`), leaving the parallel arrays at mismatched lengths. A subsequent `scroll()` / `search()` / `retrieve()` call then raised:

```
ValueError: operands could not be broadcast together with shapes (1600,) (1495,)
```

The reproducer posted in #1193 (8 threads × 20 batches × 10 points) failed 2-3 trials out of 5 on both `qdrant-client==1.12.2` and `qdrant-client==1.17.1`.

## Fix

- `threading.RLock` created in `LocalCollection.__init__`. Reentrant because the public write methods call private mutators reachable from multiple entry points.
- `with self._lock:` wraps the full body of every public write entry point that mutates the per-point parallel arrays (`payload`, `deleted`, `vectors`, `sparse_vectors`, `multivectors`, `ids`, `ids_inv`, `deleted_per_vector`):
  - `upsert`
  - `update_vectors`
  - `delete_vectors`
  - `delete`
  - `set_payload`
  - `overwrite_payload`
  - `delete_payload`
  - `clear_payload`

Read paths (`search`, `scroll`, `retrieve`, ...) are intentionally NOT locked. The bug is that writes corrupted the arrays into a permanently inconsistent state — serializing writes alone removes the corruption. Read calls that take a single `len(...)` at entry and then slice will observe a consistent snapshot. Leaving reads unlocked keeps the hot path lock-free.

## Test

Adds `test_concurrent_upsert_does_not_corrupt_local_collection` in `tests/test_in_memory.py`, mirroring the issue reproducer (8 threads, 20 batches, 10 points = 1600 expected). Passes with the lock. When I monkey-patched `LocalCollection._lock` to a no-op in a local script, 3/5 trials reproduced the `operands could not be broadcast together` error exactly as the issue describes.

Ran locally on `master` HEAD (`cd5eb25`, v1.17.1):

```
$ python -m pytest tests/test_in_memory.py tests/test_local_persistence.py tests/test_common.py -q
.................................                                       [100%]
33 passed in 2.87s
```

## Scope decisions

- **RLock vs Lock**: `RLock` to accommodate private mutators that are also reachable from other public methods (e.g. batch paths). `Lock` would be faster but risks self-deadlock on internal calls.
- **Read-path locking**: skipped to keep the lock-free read hot path. If a race is ever observed on a read (none known), a follow-up can wrap the small number of array-length reads under the same `RLock`.
- **`async_qdrant_local.py` / `AsyncQdrantLocal`**: the async wrapper dispatches to the sync `LocalCollection`, so this fix applies automatically when `asyncio.to_thread` is used to run writes concurrently. No separate async lock needed.

Happy to split the 8-method lock wrapping into a decorator or reshape the scope if preferred.