### PR TITLE
Fix sparse vector config key in update_collection REST body

### DIFF
--- a/qdrant_client/http/models/models.py
+++ b/qdrant_client/http/models/models.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 from pydantic.types import StrictBool, StrictFloat, StrictInt, StrictStr
+from pydantic.version import VERSION as PYDANTIC_VERSION
 
 Payload = Dict[str, Any]
 SparseVectorsConfig = Dict[str, "SparseVectorParams"]
@@ -13,6 +14,10 @@ StrictModeMultivectorConfigOutput = Dict[str, "StrictModeMultivectorOutput"]
 StrictModeSparseConfig = Dict[str, "StrictModeSparse"]
 StrictModeSparseConfigOutput = Dict[str, "StrictModeSparseOutput"]
 VectorsConfigDiff = Dict[str, "VectorParamsDiff"]
+_PYDANTIC_V2 = PYDANTIC_VERSION.startswith("2.")
+_POPULATE_BY_NAME_CONFIG = (
+    {"populate_by_name": True} if _PYDANTIC_V2 else {"allow_population_by_field_name": True}
+)
 
 
 class AbortReshardingOperation(BaseModel, extra="forbid"):
@@ -3629,7 +3634,7 @@ class TurboQuantization(BaseModel, extra="forbid"):
     turbo: "TurboQuantQuantizationConfig" = Field(..., description="")
 
 
-class UpdateCollection(BaseModel, extra="forbid"):
+class UpdateCollection(BaseModel, extra="forbid", **_POPULATE_BY_NAME_CONFIG):
     """
     Operation for updating parameters of the existing collection
     """
@@ -3652,7 +3657,9 @@ class UpdateCollection(BaseModel, extra="forbid"):
         default=None, description="Quantization parameters to update. If none - it is left unchanged."
     )
     sparse_vectors: Optional["SparseVectorsConfig"] = Field(
-        default=None, description="Map of sparse vector data parameters to update for each sparse vector."
+        default=None,
+        alias="sparse_vectors_config",
+        description="Map of sparse vector data parameters to update for each sparse vector.",
     )
     strict_mode_config: Optional["StrictModeConfig"] = Field(
         default=None, description="Operation for updating parameters of the existing collection"

--- a/tests/test_collections_api.py
+++ b/tests/test_collections_api.py
@@ -1,0 +1,41 @@
+import json
+from typing import Any
+
+from qdrant_client.http import models
+from qdrant_client.http.api.collections_api import SyncCollectionsApi
+
+
+class RecordingApiClient:
+    def __init__(self) -> None:
+        self.request_kwargs: dict[str, Any] | None = None
+
+    def request(self, **kwargs: Any) -> models.InlineResponse2001:
+        self.request_kwargs = kwargs
+        return models.InlineResponse2001(result=True, status="ok", time=0.0)
+
+
+def test_update_collection_serializes_sparse_vectors_config() -> None:
+    api_client = RecordingApiClient()
+    collections_api = SyncCollectionsApi(api_client)
+
+    collections_api.update_collection(
+        collection_name="text_documents",
+        update_collection=models.UpdateCollection(
+            sparse_vectors={
+                "text-bm25": models.SparseVectorParams(
+                    index=models.SparseIndexParams(on_disk=False),
+                    modifier=models.Modifier.IDF,
+                )
+            }
+        ),
+    )
+
+    assert api_client.request_kwargs is not None
+    body = json.loads(api_client.request_kwargs["content"])
+
+    assert "sparse_vectors_config" in body
+    assert "sparse_vectors" not in body
+    assert body["sparse_vectors_config"]["text-bm25"] == {
+        "index": {"on_disk": False},
+        "modifier": "idf",
+    }


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

This fixes the REST request body generated by `update_collection` when `sparse_vectors_config` is provided. The public client accepts `sparse_vectors_config`, but the generated REST model currently serializes that update field as `sparse_vectors`. The PATCH endpoint expects `sparse_vectors_config`, so the request can fail with a 400 response.

The change keeps the existing Python API intact and adds the expected REST alias to the update model, so the existing request encoder emits the correct PATCH body. It also adds a focused regression test that records the generated request content and checks that sparse vector updates are sent with the expected REST key.

Fixes #1203

Testing:

* `uv run --no-project --python 3.11 --with pytest --with pydantic --with numpy --with grpcio --with protobuf --with httpx --with portalocker --with urllib3 pytest tests/test_collections_api.py -q`
* `uv run --no-project --python 3.11 --with pytest --with 'pydantic>=1.10.8,<2' --with numpy --with grpcio --with protobuf --with httpx --with portalocker --with urllib3 pytest tests/test_collections_api.py -q`
* `uv run --no-project --python 3.11 --with ruff==0.4.3 ruff check tests/test_collections_api.py`
* `git diff --check`
