### PR TITLE
fix(local): preserve datatype for created dense vectors

### DIFF
--- a/qdrant_client/local/local_collection.py
+++ b/qdrant_client/local/local_collection.py
@@ -2860,6 +2860,7 @@ class LocalCollection:
         params = models.VectorParams(
             size=config.size,
             distance=config.distance,
+            datatype=config.datatype,
             multivector_config=config.multivector_config,
         )
 

--- a/tests/test_in_memory.py
+++ b/tests/test_in_memory.py
@@ -54,6 +54,29 @@ def test_dense_in_memory_key_filter_returns_results(qdrant: QdrantClient):
     assert [r.id for r in search_result] == [4, 2]
 
 
+def test_create_vector_name_preserves_dense_datatype_in_collection_metadata(
+    qdrant: QdrantClient,
+):
+    qdrant.create_collection(collection_name="test_collection", vectors_config={})
+
+    qdrant.create_vector_name(
+        collection_name="test_collection",
+        vector_name="half",
+        vector_name_config=models.DenseVectorNameConfig(
+            dense=models.DenseVectorConfig(
+                size=4,
+                distance=models.Distance.DOT,
+                datatype=models.VectorStorageDatatype.FLOAT16,
+            )
+        ),
+    )
+
+    collection_info = qdrant.get_collection(collection_name="test_collection")
+
+    assert isinstance(collection_info.config.params.vectors, dict)
+    assert collection_info.config.params.vectors["half"].datatype == models.Datatype.FLOAT16
+
+
 def test_sparse_in_memory_key_filter_returns_results(qdrant: QdrantClient):
     qdrant.create_collection(
         collection_name="test_collection",
@@ -294,5 +317,3 @@ def test_fusion_dbsf_score_threshold(qdrant: QdrantClient):
         f"Expected 3 points after filtering (threshold 1.0), got {len(result_with_threshold.points)}. "
         f"Scores: {[p.score for p in result_no_threshold.points]}"
     )
-
-


### PR DESCRIPTION
## Summary
- preserve `DenseVectorConfig.datatype` in collection metadata when local mode creates a dense named vector
- keep local vector storage behavior unchanged; local mode still stores dense vectors as `float32` and does not apply storage datatypes
- add an in-memory regression test for `get_collection()` metadata after `create_vector_name()`

## Validation
- `.venv/bin/python -m pytest tests/test_in_memory.py::test_create_vector_name_preserves_dense_datatype_in_collection_metadata -q`
- `.venv/bin/python -m pytest tests/test_in_memory.py -q`
- `.venv/bin/python -m pytest tests/test_local_persistence.py -q`
- `.venv/bin/ruff check qdrant_client/local/local_collection.py tests/test_in_memory.py`
- `git diff --check`
