### PR TITLE
fix: accept dict-shaped vector params in RestToGrpc converters

### DIFF
--- a/qdrant_client/conversions/conversion.py
+++ b/qdrant_client/conversions/conversion.py
@@ -3595,6 +3595,8 @@ class RestToGrpc:
 
     @classmethod
     def convert_vector_params(cls, model: rest.VectorParams) -> grpc.VectorParams:
+        if isinstance(model, dict):
+            model = rest.VectorParams(**model)
         return grpc.VectorParams(
             size=model.size,
             distance=cls.convert_distance(model.distance),
@@ -4529,6 +4531,8 @@ class RestToGrpc:
 
     @classmethod
     def convert_vector_params_diff(cls, model: rest.VectorParamsDiff) -> grpc.VectorParamsDiff:
+        if isinstance(model, dict):
+            model = rest.VectorParamsDiff(**model)
         return grpc.VectorParamsDiff(
             hnsw_config=(
                 cls.convert_hnsw_config_diff(model.hnsw_config)
@@ -4793,6 +4797,8 @@ class RestToGrpc:
     def convert_sparse_vector_params(
         cls, model: rest.SparseVectorParams
     ) -> grpc.SparseVectorParams:
+        if isinstance(model, dict):
+            model = rest.SparseVectorParams(**model)
         return grpc.SparseVectorParams(
             index=(
                 cls.convert_sparse_index_params(model.index) if model.index is not None else None

--- a/tests/conversions/test_validate_conversions.py
+++ b/tests/conversions/test_validate_conversions.py
@@ -594,3 +594,63 @@ def test_optimizers_config_diff_max_threads():
     assert restored_grpc_opt_conf.max_optimization_threads == q_grpc.MaxOptimizationThreads(
         value=value
     )
+
+
+def test_convert_vector_params_accepts_dict():
+    from qdrant_client import models
+    from qdrant_client.conversions.conversion import RestToGrpc
+
+    raw = {
+        "size": 1024,
+        "distance": "Cosine",
+        "on_disk": True,
+        "datatype": "float16",
+    }
+    from_dict = RestToGrpc.convert_vector_params(raw)
+    from_model = RestToGrpc.convert_vector_params(models.VectorParams(**raw))
+
+    assert from_dict == from_model
+
+
+def test_convert_vectors_config_named_dict_values():
+    from qdrant_client import models
+    from qdrant_client.conversions.conversion import RestToGrpc
+
+    raw = {
+        "vector1": {
+            "size": 1024,
+            "distance": "Cosine",
+            "on_disk": True,
+            "datatype": "float16",
+        },
+        "vector2": {"size": 768, "distance": "Dot"},
+    }
+    from_dict = RestToGrpc.convert_vectors_config(raw)
+    from_models = RestToGrpc.convert_vectors_config(
+        {name: models.VectorParams(**params) for name, params in raw.items()}
+    )
+
+    assert from_dict == from_models
+
+
+def test_convert_vector_params_diff_accepts_dict():
+    from qdrant_client import models
+    from qdrant_client.conversions.conversion import RestToGrpc
+
+    raw = {"on_disk": True}
+    assert RestToGrpc.convert_vector_params_diff(raw) == RestToGrpc.convert_vector_params_diff(
+        models.VectorParamsDiff(**raw)
+    )
+
+
+def test_convert_sparse_vector_config_dict_values():
+    from qdrant_client import models
+    from qdrant_client.conversions.conversion import RestToGrpc
+
+    raw = {"sparse1": {"modifier": "idf"}, "sparse2": {}}
+    from_dict = RestToGrpc.convert_sparse_vector_config(raw)
+    from_models = RestToGrpc.convert_sparse_vector_config(
+        {name: models.SparseVectorParams(**params) for name, params in raw.items()}
+    )
+
+    assert from_dict == from_models


### PR DESCRIPTION
## Summary

When `vectors_config` (or `sparse_vectors_config`, or `VectorParamsDiff`) is passed as a raw `dict` — e.g. parsed back from telemetry JSON — the gRPC path fails with `AttributeError: 'dict' object has no attribute 'size'`. The HTTP path works because pydantic on `models.CreateCollection` coerces the dict for free, but the gRPC converters access `.size` / `.distance` / `.modifier` directly and assume a fully-validated pydantic model.

This PR coerces dict input to the corresponding pydantic model at the top of three converters so both transports accept the same input shapes:

- `RestToGrpc.convert_vector_params`
- `RestToGrpc.convert_vector_params_diff`
- `RestToGrpc.convert_sparse_vector_params`

Coercing once at the leaf converter is enough — `convert_vectors_config` / `convert_sparse_vector_config` / `convert_vectors_config_diff` all fan out to these.

Fixes #1066

## Reproduction (before)

```python
from qdrant_client import QdrantClient

vectors_config = {
    "vector1": {"size": 1024, "distance": "Cosine", "on_disk": True, "datatype": "float16"},
    "vector2": {"size": 1024, "distance": "Cosine", "on_disk": True, "datatype": "float16"},
}
q = QdrantClient(url="http://localhost:6333", prefer_grpc=True)
q.create_collection("foo", vectors_config=vectors_config)
# AttributeError: 'dict' object has no attribute 'size'
```

After: works on both `prefer_grpc=True` and the default HTTP path.

## Test plan

- [x] Added 4 unit tests in `tests/conversions/test_validate_conversions.py` covering the named-vectors dict case, the single-`VectorParams` dict case, `VectorParamsDiff` dict, and `SparseVectorParams` dict — each asserts dict input produces the same gRPC output as the equivalent pydantic-model input.
- [x] `pytest tests/conversions/ -q` — 25 passed.
- [x] `mypy qdrant_client/conversions/conversion.py` — clean.
- [x] `ruff format --check --line-length=99 qdrant_client/conversions/conversion.py tests/conversions/test_validate_conversions.py` — clean.