### PR TITLE
fix: support MatchPhrase filter in local mode

### DIFF
--- a/qdrant_client/local/payload_filters.py
+++ b/qdrant_client/local/payload_filters.py
@@ -146,6 +146,21 @@ def check_datetime_range(condition: models.DatetimeRange, value: Any) -> bool:
     )
 
 
+def check_phrase_match(phrase: str, value: str) -> bool:
+    phrase_tokens = phrase.split()
+    value_tokens = value.split()
+
+    if not phrase_tokens:
+        return True
+    if len(phrase_tokens) > len(value_tokens):
+        return False
+
+    for start in range(len(value_tokens) - len(phrase_tokens) + 1):
+        if value_tokens[start : start + len(phrase_tokens)] == phrase_tokens:
+            return True
+    return False
+
+
 def check_match(condition: models.Match, value: Any) -> bool:
     if isinstance(condition, models.MatchValue):
         return value == condition.value
@@ -153,6 +168,8 @@ def check_match(condition: models.Match, value: Any) -> bool:
         return value is not None and condition.text in value
     if isinstance(condition, models.MatchTextAny):
         return value is not None and any(word in value for word in condition.text_any.split())
+    if isinstance(condition, models.MatchPhrase):
+        return value is not None and check_phrase_match(condition.phrase, value)
     if isinstance(condition, models.MatchAny):
         return value in condition.any
     if isinstance(condition, models.MatchExcept):

--- a/qdrant_client/local/tests/test_payload_filters.py
+++ b/qdrant_client/local/tests/test_payload_filters.py
@@ -187,3 +187,39 @@ def test_geo_polygon_filter_query():
 
     res = check_filter(query, payload, 0, has_vector={})
     assert res is False
+
+
+def test_match_phrase_filter_query():
+    payload = {"text": "the quick brown fox"}
+
+    def matches(phrase: str, target: dict = payload) -> bool:
+        query = models.Filter(
+            must=[models.FieldCondition(key="text", match=models.MatchPhrase(phrase=phrase))]
+        )
+        return check_filter(query, target, 0, has_vector={})
+
+    # exact contiguous sub-phrase matches, preserving order
+    assert matches("quick brown fox") is True
+    assert matches("brown fox") is True
+    assert matches("the quick") is True
+    assert matches("the quick brown fox") is True
+
+    # wrong order does not match
+    assert matches("fox brown") is False
+
+    # non-contiguous tokens do not match
+    assert matches("quick fox") is False
+
+    # partial tokens do not match (matching is token-based, not substring)
+    assert matches("brown fo") is False
+
+    # phrase longer than the text does not match
+    assert matches("the quick brown fox jumps") is False
+
+    # phrase against a list-valued field matches any element
+    list_payload = {"text": ["lazy dog sleeps", "quick brown fox"]}
+    assert matches("brown fox", list_payload) is True
+    assert matches("sleeps quick", list_payload) is False
+
+    # missing field does not match
+    assert matches("brown fox", {"other": "value"}) is False


### PR DESCRIPTION
### Problem

Using a `MatchPhrase` condition in a filter against a local-mode client
(`QdrantClient(":memory:")` or local persistence) raises:

```
ValueError: Unknown match condition: phrase='...'
```

Phrase matching is supported by the server and is already handled by the
gRPC/REST converters (`RestToGrpc`/`GrpcToRest`), but `check_match` in
`qdrant_client/local/payload_filters.py` does not handle `models.MatchPhrase`,
so it falls through to the "Unknown match condition" error. This makes local
mode diverge from server behavior for any filter that uses a phrase match.

Minimal reproduction:

```python
from qdrant_client import QdrantClient, models

client = QdrantClient(":memory:")
client.create_collection(
    "t", vectors_config=models.VectorParams(size=2, distance=models.Distance.COSINE)
)
client.upsert("t", [
    models.PointStruct(id=1, vector=[0.1, 0.2], payload={"text": "quick brown fox"}),
])

client.scroll(
    "t",
    scroll_filter=models.Filter(
        must=[models.FieldCondition(key="text", match=models.MatchPhrase(phrase="brown fox"))]
    ),
)  # -> ValueError: Unknown match condition
```

### Fix

Handle `MatchPhrase` in `check_match`. The phrase is matched as a contiguous,
order-preserving sub-sequence of the field value's tokens (whitespace
tokenization, consistent with the existing `MatchTextAny` handling). This
matches the documented phrase semantics, e.g. `"quick brown fox"` is matched
by `"brown fox"` but not by `"fox brown"`.

### Tests

Added `test_match_phrase_filter_query` in
`qdrant_client/local/tests/test_payload_filters.py` covering contiguous
matches, wrong order, non-contiguous tokens, partial tokens, list-valued
fields and missing fields. The test fails before the change (with the
`ValueError`) and passes after.

### Checklist
- [x] Targets the `dev` branch.
- [x] Added a test for the change.
- [x] `pre-commit` (ruff-format) and `mypy` pass locally; local-mode test suite passes.