### PR TITLE
fix(remote): skip default port when URL path implies a reverse proxy

### DIFF
--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -104,7 +104,13 @@ class QdrantRemote(QdrantBase):
                 self._https = parsed_url.scheme == "https"
                 self._scheme = parsed_url.scheme
 
-            self._port = self._port if self._port else port
+            # When the URL contains a path (e.g. https://proxy.example.com/qdrant) the user
+            # is connecting through a reverse proxy that already handles the port.  Forcing the
+            # default Qdrant port (6333) onto such a URL produces an incorrect address like
+            # https://proxy.example.com:6333/qdrant.  Only apply the default port when the URL
+            # has no path component, which is the plain "host-only" form where the default port
+            # is meaningful.
+            self._port = self._port if self._port else (None if parsed_url.path else port)
 
             if self._prefix and parsed_url.path:
                 raise ValueError(

--- a/tests/test_qdrant_client.py
+++ b/tests/test_qdrant_client.py
@@ -187,6 +187,19 @@ def test_client_init():
     assert client._client.rest_uri == "http://localhost:6333/custom"
     assert client._client._prefix == "/custom"
 
+    # URL with a path but no explicit port (reverse-proxy setup): the default port 6333
+    # must NOT be appended — the proxy already owns the port (typically 80/443).
+    client = QdrantClient(url="https://proxy.example.com/qdrant/v1", check_compatibility=False)
+    assert isinstance(client._client, QdrantRemote)
+    assert client._client._port is None
+    assert client._client.rest_uri == "https://proxy.example.com/qdrant/v1"
+
+    # URL with explicit port + path: explicit port wins regardless of path.
+    client = QdrantClient(url="https://proxy.example.com:8443/qdrant/v1", check_compatibility=False)
+    assert isinstance(client._client, QdrantRemote)
+    assert client._client._port == 8443
+    assert client._client.rest_uri == "https://proxy.example.com:8443/qdrant/v1"
+
     client = QdrantClient("my-domain.com", check_compatibility=False)
     assert isinstance(client._client, QdrantRemote)
     assert client._client.rest_uri == "http://my-domain.com:6333"


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`? (Note: this repo has only `master`; branched from that)
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

N/A — this is a bug fix, not a new feature.

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

## Summary

When a user connects to Qdrant through a reverse proxy at a sub-path URL —
for example `https://proxy.example.com/qdrant` — the client was incorrectly
appending the default Qdrant port 6333, producing
`https://proxy.example.com:6333/qdrant`. That address does not resolve on
standard proxies because the proxy listens on port 443 and routes by path, not
by Qdrant's internal port. The result is a `ConnectionError` on every request.

**Root cause** — one line in `QdrantRemote.__init__`:

```python
self._port = self._port if self._port else port   # port has default 6333
```

This fallback applied the default port 6333 regardless of whether the URL
already contained a path. A URL with a sub-path implies a reverse-proxy setup
where the port is determined by the scheme (80/443), not by Qdrant's default.

**Fix** — only apply the default port when `parsed_url.path` is absent (bare-
host form). When a path is present but no explicit port is given, `self._port`
is set to `None` so the scheme's standard port is used instead.

URLs with an explicit port in the URL (e.g. `:8443`) are unaffected.

## Issue

Fixes #1146

## Local verification

```
$ python -m pytest tests/test_qdrant_client.py::test_client_init -v

============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0 -- /usr/local/bin/python3
collecting ... collected 1 item

tests/test_qdrant_client.py::test_client_init PASSED                   [100%]

============================== 1 passed in 2.24s ===============================

=== LOCAL_TEST_PASSED ===
```

## Risk

Low. The change is one line in the `url=` code path of `QdrantRemote.__init__`,
affecting only the case where a URL contains a path but no explicit port (which
was always broken and untested). All existing tests that supply an explicit port
(e.g. `http://localhost:6333`) continue to use that port unchanged. Two new
regression assertions were added to `test_client_init` to cover both the
no-port-with-path and the explicit-port-with-path cases.
