### PR TITLE
ci: update third-party actions to node 24

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -39,7 +39,7 @@ jobs:
         /tmp/smoke-venv/bin/pip install --quiet dist/*.whl
         /tmp/smoke-venv/bin/python -c "from qdrant_client import QdrantClient; print('Import OK')"
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Update all third-party GitHub Actions to Node 24-compatible versions before the June 2 deadline.