### PR TITLE
fix: detect dead upload workers while draining

### DIFF
--- a/qdrant_client/parallel_processor.py
+++ b/qdrant_client/parallel_processor.py
@@ -7,6 +7,7 @@ from multiprocessing.context import BaseContext
 from multiprocessing.process import BaseProcess
 from multiprocessing.sharedctypes import Synchronized as BaseValue
 from queue import Empty
+from time import monotonic
 from typing import Any, Iterable, Type
 
 # Single item should be processed in less than:
@@ -162,7 +163,7 @@ class ParallelWorkerPool:
                         out_item = None
                 else:
                     try:
-                        out_item = self.output_queue.get(timeout=processing_timeout)
+                        out_item = self._get_output()
                     except Empty as e:
                         self.join_or_terminate()
                         raise e
@@ -180,7 +181,7 @@ class ParallelWorkerPool:
                 self.input_queue.put(QueueSignals.stop)
 
             while read < pushed:
-                out_item = self.output_queue.get(timeout=processing_timeout)
+                out_item = self._get_output()
                 if out_item == QueueSignals.error:
                     self.join_or_terminate()
                     raise RuntimeError("Thread unexpectedly terminated")
@@ -211,6 +212,19 @@ class ParallelWorkerPool:
             while next_expected in buffer:
                 yield buffer.pop(next_expected)
                 next_expected += 1
+
+    def _get_output(self) -> Any:
+        assert self.output_queue is not None, "Output queue was not initialized"
+        deadline = monotonic() + processing_timeout
+        while True:
+            self.check_worker_health()
+            timeout = min(1.0, deadline - monotonic())
+            if timeout <= 0:
+                raise Empty
+            try:
+                return self.output_queue.get(timeout=timeout)
+            except Empty:
+                pass
 
     def check_worker_health(self) -> None:
         """

--- a/tests/test_parallel_processor.py
+++ b/tests/test_parallel_processor.py
@@ -1,0 +1,27 @@
+import os
+from typing import Any, Iterable
+
+import pytest
+
+from qdrant_client import parallel_processor
+from qdrant_client.parallel_processor import ParallelWorkerPool, Worker
+
+
+class CrashingWorker(Worker):
+    @classmethod
+    def start(cls, *args: Any, **kwargs: Any) -> "CrashingWorker":
+        return cls()
+
+    def process(self, items: Iterable[Any]) -> Iterable[Any]:
+        for _ in items:
+            os._exit(3)
+            yield
+
+
+def test_unordered_map_detects_dead_worker_while_draining(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(parallel_processor, "processing_timeout", 3)
+
+    pool = ParallelWorkerPool(num_workers=1, worker=CrashingWorker)
+
+    with pytest.raises(RuntimeError, match="terminated unexpectedly with code 3"):
+        list(pool.unordered_map([1]))


### PR DESCRIPTION
## Summary

Fixes #973.

- Poll worker process health while waiting for `ParallelWorkerPool` output.
- Keep the existing `processing_timeout` behavior for healthy workers.
- Add a focused regression test for a child process that exits without sending `QueueSignals.error`.

## Tests

- `/tmp/qdrant-client-973-venv/bin/python -m pytest tests/test_parallel_processor.py -q`
- `/tmp/qdrant-client-973-venv/bin/python -m ruff check qdrant_client/parallel_processor.py tests/test_parallel_processor.py`
- `/tmp/qdrant-client-973-venv/bin/python -m mypy qdrant_client/parallel_processor.py tests/test_parallel_processor.py --disallow-incomplete-defs --disallow-untyped-defs`
- `git diff --check`

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [ ] Have you installed `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
