### PR TITLE
fix(embed): convert_paths() drops prefix paths when a longer path shares the same prefix

### DIFF
--- a/qdrant_client/embed/utils.py
+++ b/qdrant_client/embed/utils.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 class FieldPath(BaseModel):
     current: str
     tail: list["FieldPath"] | None = Field(default=None)
+    is_terminal: bool = Field(default=False)
 
     def as_str_list(self) -> list[str]:
         """
@@ -21,6 +22,8 @@ class FieldPath(BaseModel):
                 return [current_path]
             else:
                 paths = []
+                if path.is_terminal:
+                    paths.append(current_path)
                 for sub_path in path.tail:
                     paths.extend(collect_paths(sub_path, current_path + "."))
                 return paths
@@ -64,6 +67,10 @@ def convert_paths(paths: list[str]) -> list[FieldPath]:
                 assert current.tail is not None
                 current.tail.append(new_tail)
                 current = new_tail
+        # Mark this node as a terminal path endpoint so that paths which are a
+        # prefix of another path (e.g. 'a.b' alongside 'a.b.c') are preserved
+        # when the node is later promoted to an interior node.
+        current.is_terminal = True
     return converted_paths
 
 

--- a/tests/embed_tests/test_utils.py
+++ b/tests/embed_tests/test_utils.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from qdrant_client.embed.utils import read_base64
+from qdrant_client.embed.utils import convert_paths, read_base64
 from tests.utils import TESTS_PATH
 
 EMBED_TESTS_DATA = TESTS_PATH / "embed_tests" / "misc"
@@ -24,3 +24,12 @@ def test_image_path_to_b64():
     non_existent_path = Path(EMBED_TESTS_DATA / "gibberish.jpg")
     with pytest.raises(FileNotFoundError):
         read_base64(non_existent_path)
+
+
+def test_convert_paths_prefix_path_not_dropped():
+    # 'a.b' must survive when 'a.b.c' is also present; previously 'a.b' was
+    # silently dropped because the node was promoted to an interior node.
+    result = convert_paths(["a.b", "a.b.c"])
+    recovered = [s for r in result for s in r.as_str_list()]
+    assert "a.b" in recovered
+    assert "a.b.c" in recovered


### PR DESCRIPTION
## What's broken

`convert_paths(['a.b', 'a.b.c'])` returns only `['a.b.c']`. The path `'a.b'` is silently discarded. After sorting, `'a.b'` is processed first and node `b` is created as a leaf. When `'a.b.c'` is then processed, `b` is found and `c` is appended under it, promoting `b` from a leaf to an interior node. Because nothing recorded that `b` was a valid endpoint, `as_str_list()` skips it entirely.

## Why it happens

`convert_paths` never records that an intermediate node was itself a terminal path, so once a node gains children it stops appearing in `as_str_list()` output.

## Fix

Added an `is_terminal: bool` field to `FieldPath` (default `False`). `convert_paths` now sets `is_terminal = True` on the final node of every path. `as_str_list` emits the current path string for interior nodes that are flagged as terminal before recursing into their children.

## Test

`test_convert_paths_prefix_path_not_dropped` calls `convert_paths(['a.b', 'a.b.c'])` and asserts that both `'a.b'` and `'a.b.c'` appear in the recovered string list.

Fixes #1219