### PR TITLE
fix(payload_filters): guard MatchText against non-string field values

### DIFF
--- a/qdrant_client/local/payload_filters.py
+++ b/qdrant_client/local/payload_filters.py
@@ -150,9 +150,9 @@ def check_match(condition: models.Match, value: Any) -> bool:
     if isinstance(condition, models.MatchValue):
         return value == condition.value
     if isinstance(condition, models.MatchText):
-        return value is not None and condition.text in value
+        return isinstance(value, str) and condition.text in value
     if isinstance(condition, models.MatchTextAny):
-        return value is not None and any(word in value for word in condition.text_any.split())
+        return isinstance(value, str) and any(word in value for word in condition.text_any.split())
     if isinstance(condition, models.MatchAny):
         return value in condition.any
     if isinstance(condition, models.MatchExcept):

--- a/tests/test_in_memory.py
+++ b/tests/test_in_memory.py
@@ -296,3 +296,26 @@ def test_fusion_dbsf_score_threshold(qdrant: QdrantClient):
     )
 
 
+def test_match_text_on_non_string_field_does_not_crash(qdrant: QdrantClient):
+    """MatchText applied to a numeric field should not raise TypeError."""
+    qdrant.create_collection(
+        collection_name="test_match_text_numeric",
+        vectors_config=models.VectorParams(size=2, distance=models.Distance.DOT),
+    )
+    qdrant.upsert(
+        collection_name="test_match_text_numeric",
+        points=[
+            models.PointStruct(id=1, vector=[1.0, 0.0], payload={"count": 42}),
+            models.PointStruct(id=2, vector=[0.0, 1.0], payload={"count": "hello world"}),
+        ],
+    )
+    result = qdrant.query_points(
+        collection_name="test_match_text_numeric",
+        query=[1.0, 0.0],
+        query_filter=models.Filter(
+            must=[models.FieldCondition(key="count", match=models.MatchText(text="hello"))]
+        ),
+        limit=10,
+    ).points
+    assert len(result) == 1
+    assert result[0].id == 2


### PR DESCRIPTION
## What's broken

When a collection stores mixed payload types on the same key — for example one point has `{"count": 42}` (integer) and another has `{"count": "hello"}` (string) — applying a `MatchText` or `MatchTextAny` filter crashes with `TypeError: argument of type 'int' is not iterable`. This also happens if a user applies a text filter to a field that only ever holds numeric values.

## Why it happens

In `check_match()`, the guard `value is not None` only filters out `None`. Python's `in` operator raises `TypeError` when the right-hand operand is a non-iterable type like `int` or `float`, so any non-string payload value on a text-filtered key causes a crash.

## Fix

Changed the guard from `value is not None` to `isinstance(value, str)` for both the `MatchText` and `MatchTextAny` branches. Non-string values now correctly return `False` instead of crashing.

## Test

Added `test_match_text_on_non_string_field_does_not_crash` in `tests/test_in_memory.py`. It upserts two points where one has an integer value and one has a matching string, applies a `MatchText` filter, and asserts that only the string-bearing point is returned without raising any exception.

Fixes #1221