### PR TITLE
ci: add release sanity check to prevent publishing broken packages

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -33,6 +33,11 @@ jobs:
         poetry install
     - name: Build package
       run: poetry build
+    - name: Smoke-test built package
+      run: |
+        python -m venv /tmp/smoke-venv
+        /tmp/smoke-venv/bin/pip install --quiet dist/*.whl
+        /tmp/smoke-venv/bin/python -c "from qdrant_client import QdrantClient; print('Import OK')"
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:


### PR DESCRIPTION
## Changes

Adds a smoke-test step to the publish workflow that installs the built wheel in a fresh virtualenv and verifies the package can be imported. This catches issues like dev dependencies leaking into production code before the package is published to PyPI.

### Why

We've already had 2 broken releases due to pytest leaking into the qdrant-client code (it was not in tests/). Both times this was only caught after making a release via just \pip install qdrant-client\ in a fresh venv, forcing yanked packages and patch releases.

### What

Added a smoke-test step to \.github/workflows/python-publish.yml\ that:
1. Creates a fresh Python virtualenv
2. Installs the built \dist/*.whl\ (no dev dependencies)
3. Imports \QdrantClient\ to verify the package loads correctly

Closes #958