### PR TITLE
fix: parse flat hardware usage responses

### DIFF
--- a/qdrant_client/http/models/models.py
+++ b/qdrant_client/http/models/models.py
@@ -1188,6 +1188,11 @@ class HardwareUsage(BaseModel):
     vector_io_write: int = Field(..., description="Usage of the hardware resources, spent to process the request")
 
 
+_HARDWARE_USAGE_FIELDS = frozenset(
+    HardwareUsage.model_fields if hasattr(HardwareUsage, "model_fields") else HardwareUsage.__fields__
+)
+
+
 class HasIdCondition(BaseModel, extra="forbid"):
     """
     ID-based filtering condition
@@ -3724,6 +3729,18 @@ class Usage(BaseModel):
     """
     Usage of the hardware resources, spent to process the request
     """
+
+    def __init__(self, **data: Any) -> None:
+        if "hardware" not in data:
+            hardware = {
+                field_name: data.pop(field_name)
+                for field_name in _HARDWARE_USAGE_FIELDS
+                if field_name in data
+            }
+            if hardware:
+                data["hardware"] = hardware
+
+        super().__init__(**data)
 
     hardware: Optional["HardwareUsage"] = Field(
         default=None, description="Usage of the hardware resources, spent to process the request"

--- a/tests/test_http_models.py
+++ b/tests/test_http_models.py
@@ -1,0 +1,64 @@
+from qdrant_client.http.api_client import parse_as_type
+from qdrant_client.http.models import models as m
+
+
+def test_flat_hardware_usage_response_is_parsed_as_hardware_usage():
+    response = {
+        "usage": {
+            "cpu": 0,
+            "payload_io_read": 1,
+            "payload_io_write": 2,
+            "payload_index_io_read": 3,
+            "payload_index_io_write": 4,
+            "vector_io_read": 5,
+            "vector_io_write": 6,
+        },
+        "time": 0.1,
+        "status": "ok",
+        "result": None,
+    }
+
+    parsed = parse_as_type(response, m.InlineResponse2006)
+
+    assert parsed.usage is not None
+    assert parsed.usage.hardware == m.HardwareUsage(
+        cpu=0,
+        payload_io_read=1,
+        payload_io_write=2,
+        payload_index_io_read=3,
+        payload_index_io_write=4,
+        vector_io_read=5,
+        vector_io_write=6,
+    )
+
+
+def test_nested_hardware_usage_response_is_preserved():
+    response = {
+        "usage": {
+            "hardware": {
+                "cpu": 0,
+                "payload_io_read": 1,
+                "payload_io_write": 2,
+                "payload_index_io_read": 3,
+                "payload_index_io_write": 4,
+                "vector_io_read": 5,
+                "vector_io_write": 6,
+            }
+        },
+        "time": 0.1,
+        "status": "ok",
+        "result": None,
+    }
+
+    parsed = parse_as_type(response, m.InlineResponse2006)
+
+    assert parsed.usage is not None
+    assert parsed.usage.hardware == m.HardwareUsage(
+        cpu=0,
+        payload_io_read=1,
+        payload_io_write=2,
+        payload_index_io_read=3,
+        payload_index_io_write=4,
+        vector_io_read=5,
+        vector_io_write=6,
+    )


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Summary

Fixes #935 as a backward-compatibility follow-up for REST responses that still return hardware usage counters directly under `usage`. Current models expect `usage.hardware`, so this normalizes the flat shape into the existing nested `HardwareUsage` model while preserving the already-supported nested response shape.

I checked for duplicate open PRs and only found the previously merged #1053 schema update, which fixed the OpenAPI usage structure but does not preserve flat hardware usage fields.

### Tests

* `uv run --with pytest pytest tests/test_http_models.py -q`
* `uv run --with pytest pytest tests/test_common.py tests/test_http_models.py -q`
* `uv run --with pytest --with 'pydantic==1.10.24' pytest tests/test_http_models.py -q`
* `uv run --with ruff==0.4.3 ruff check qdrant_client/http/models/models.py tests/test_http_models.py`
* `git diff --check`

AI assistance disclosure: I used OpenAI Codex to investigate the issue, prepare the patch, and run the validation above; I reviewed the resulting diff before submission.