### PR TITLE
fix: guard QdrantClient destructor cleanup

### DIFF
--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -166,7 +166,12 @@ class QdrantClient(QdrantFastembedMixin):
         # Httpx has specific set of params, which it accepts and will raise an error if it receives any other params.
 
     def __del__(self) -> None:
-        self.close()
+        try:
+            self.close()
+        except Exception:
+            # Destructors may run during interpreter shutdown, when transports or logging
+            # hooks are already partially torn down. Explicit close() still surfaces errors.
+            pass
 
     def close(self, grpc_grace: float | None = None, **kwargs: Any) -> None:
         """Closes the connection to Qdrant

--- a/tests/test_qdrant_client.py
+++ b/tests/test_qdrant_client.py
@@ -1735,6 +1735,17 @@ def test_client_close():
     # endregion local
 
 
+def test_client_del_suppresses_close_errors(monkeypatch):
+    client = QdrantClient.__new__(QdrantClient)
+
+    def close_raises(*args, **kwargs):
+        raise RuntimeError("connection cleanup failed during shutdown")
+
+    monkeypatch.setattr(QdrantClient, "close", close_raises)
+
+    client.__del__()
+
+
 def test_timeout_propagation():
     client = QdrantClient()
     vectors_config = models.VectorParams(size=2, distance=models.Distance.COSINE)


### PR DESCRIPTION
## Summary

Fixes #465.

This change guards the fallback cleanup path in `QdrantClient.__del__()`. If `close()` raises while the client is being garbage-collected, especially during interpreter shutdown when transports or logging hooks may already be partially torn down, the destructor no longer surfaces an `Exception ignored in: ...` traceback.

Explicit `client.close()` behavior is unchanged: callers that close the client directly still see close-time errors in the normal call path.

## Testing

- `.venv/bin/python -m pytest tests/test_qdrant_client.py::test_client_del_suppresses_close_errors -q`
- `.venv/bin/ruff check qdrant_client/qdrant_client.py`
- `.venv/bin/ruff check tests/test_qdrant_client.py --ignore F841`
- `git diff --check`

Note: `ruff check tests/test_qdrant_client.py` without the ignore is currently blocked by an existing unrelated `F841` at `tests/test_qdrant_client.py:2239`.

## AI assistance

I used AI assistance to identify the minimal fix and draft the regression test, then ran the checks above locally.
