### PR TITLE
fix: ignore non-string values for text payload matches

### DIFF
--- a/qdrant_client/local/payload_filters.py
+++ b/qdrant_client/local/payload_filters.py
@@ -150,9 +150,9 @@ def check_match(condition: models.Match, value: Any) -> bool:
     if isinstance(condition, models.MatchValue):
         return value == condition.value
     if isinstance(condition, models.MatchText):
-        return value is not None and condition.text in value
+        return isinstance(value, str) and condition.text in value
     if isinstance(condition, models.MatchTextAny):
-        return value is not None and any(word in value for word in condition.text_any.split())
+        return isinstance(value, str) and any(word in value for word in condition.text_any.split())
     if isinstance(condition, models.MatchAny):
         return value in condition.any
     if isinstance(condition, models.MatchExcept):

--- a/qdrant_client/local/tests/test_payload_filters.py
+++ b/qdrant_client/local/tests/test_payload_filters.py
@@ -187,3 +187,19 @@ def test_geo_polygon_filter_query():
 
     res = check_filter(query, payload, 0, has_vector={})
     assert res is False
+
+
+def test_text_match_ignores_non_string_values():
+    payload = {"count": 42}
+
+    query = models.Filter(
+        must=[models.FieldCondition(key="count", match=models.MatchText(text="42"))]
+    )
+    res = check_filter(query, payload, 0, has_vector={})
+    assert res is False
+
+    query = models.Filter(
+        must=[models.FieldCondition(key="count", match=models.MatchTextAny(text_any="4 42"))]
+    )
+    res = check_filter(query, payload, 0, has_vector={})
+    assert res is False


### PR DESCRIPTION
## Summary

Fixes #1221.

`MatchText` and `MatchTextAny` in local payload filtering assumed the payload value was string-like. If a collection had mixed payload types on the same key, a text match against an integer value could raise `TypeError` instead of just not matching.

This keeps the change small: text match conditions now only run substring checks for string values.

## Changes

- Added a regression test for `MatchText` and `MatchTextAny` against an integer payload value
- Updated local payload filtering to return `False` for text matches on non-string values
- No new dependencies or public API changes

## Testing

Ran locally:

```bash
.\.venv\Scripts\python.exe -m pytest qdrant_client/local/tests/test_payload_filters.py::test_text_match_ignores_non_string_values -q
.\.venv\Scripts\python.exe -m pytest qdrant_client/local/tests/test_payload_filters.py -q
.\.venv\Scripts\ruff.exe check qdrant_client/local/payload_filters.py qdrant_client/local/tests/test_payload_filters.py
```

I also checked the in-memory client repro from the issue and confirmed it no longer crashes.