### PR TITLE
fix: use continue instead of return in update_vectors filter loop (Fixes #1237)

### DIFF
--- a/qdrant_client/local/local_collection.py
+++ b/qdrant_client/local/local_collection.py
@@ -2646,7 +2646,7 @@ class LocalCollection:
                 if not check_filter(
                     update_filter, self.payload[idx], self.ids_inv[idx], has_vector
                 ):
-                    return None
+                    continue
             self._update_named_vectors(idx, fixed_vectors)
             self._persist_by_id(point_id)
 


### PR DESCRIPTION
Fixes #1237

## Problem

In `LocalCollection.update_vectors()`, when processing a batch of points with an `update_filter`, if any point doesn't match the filter, the function executes `return None` (line 2649), which exits the entire method immediately. This causes all remaining points in the batch to be silently skipped.

## Root Cause

```python
# local_collection.py, line 2646-2649 (before fix)
if not check_filter(
    update_filter, self.payload[idx], self.ids_inv[idx], has_vector
):
    return None  # BUG: exits entire method
```

`return None` exits the entire `update_vectors` method. It should be `continue` to skip only the current point and process the remaining ones.

## Fix

Changed `return None` to `continue` on line 2649 so only the non-matching point is skipped and the remaining points are still processed.

```python
# After fix
if not check_filter(
    update_filter, self.payload[idx], self.ids_inv[idx], has_vector
):
    continue  # Skip this point, continue with the rest
```

## Verification

Verified with a reproduction script that demonstrates the fix:

```python
# Insert 3 points with different types
client.upsert("test", points=[
    PointStruct(id=1, vector=[1,0,0,0], payload={"type": "a"}),
    PointStruct(id=2, vector=[0,1,0,0], payload={"type": "b"}),
    PointStruct(id=3, vector=[0,0,1,0], payload={"type": "a"}),
])

# Update with filter matching only type="a"
client.update_vectors("test", points=[
    PointVectors(id=1, vector=[0.5, 0.5, 0, 0]),  # matches
    PointVectors(id=2, vector=[0, 0, 0.5, 0.5]),   # doesn't match
    PointVectors(id=3, vector=[0, 0, 0, 1]),        # matches
], update_filter=Filter(must=[FieldCondition(key="type", match=MatchValue(value="a"))]))
```

**Before fix:** Point 3 is silently skipped (return None exits loop after Point 2).
**After fix:** Point 3 is correctly updated (continue skips only Point 2).

## Impact

- Fixes silent data loss when `update_vectors` is called with multiple points and an `update_filter`
- Points after the first non-matching point are no longer skipped
- The fix is a single-line change with zero risk of regression

## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-06-21 | Fix `update_vectors` early return in filter loop | rtmalikian |

### Files Changed
- `qdrant_client/local/local_collection.py` — Changed `return None` to `continue` in `update_vectors` filter check

### Verification
- Reproduction script confirms Point 3 is now correctly updated when Point 2 doesn't match the filter
- No existing tests break (no tests cover `update_filter` parameter)

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **MiMo v2.5 Pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
