### PR TITLE
fix: preserve prefix endpoints in embed paths

### DIFF
--- a/qdrant_client/embed/utils.py
+++ b/qdrant_client/embed/utils.py
@@ -1,12 +1,13 @@
 import base64
 from pathlib import Path
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
 
 
 class FieldPath(BaseModel):
     current: str
     tail: list["FieldPath"] | None = Field(default=None)
+    _is_endpoint: bool = PrivateAttr(default=False)
 
     def as_str_list(self) -> list[str]:
         """
@@ -17,13 +18,13 @@ class FieldPath(BaseModel):
         # Recursive function to collect all paths
         def collect_paths(path: FieldPath, prefix: str = "") -> list[str]:
             current_path = prefix + path.current
+            paths = [current_path] if path._is_endpoint or not path.tail else []
             if not path.tail:
-                return [current_path]
-            else:
-                paths = []
-                for sub_path in path.tail:
-                    paths.extend(collect_paths(sub_path, current_path + "."))
                 return paths
+
+            for sub_path in path.tail:
+                paths.extend(collect_paths(sub_path, current_path + "."))
+            return paths
 
         # Collect all paths starting from this object
         return collect_paths(self)
@@ -64,6 +65,7 @@ def convert_paths(paths: list[str]) -> list[FieldPath]:
                 assert current.tail is not None
                 current.tail.append(new_tail)
                 current = new_tail
+        current._is_endpoint = True
     return converted_paths
 
 

--- a/qdrant_client/embed/utils.py
+++ b/qdrant_client/embed/utils.py
@@ -1,3 +1,5 @@
+"""Utility helpers for embed inputs and path conversion."""
+
 import base64
 from pathlib import Path
 
@@ -5,6 +7,8 @@ from pydantic import BaseModel, Field, PrivateAttr
 
 
 class FieldPath(BaseModel):
+    """Tree node representing one segment of a nested field path."""
+
     current: str
     tail: list["FieldPath"] | None = Field(default=None)
     _is_endpoint: bool = PrivateAttr(default=False)

--- a/qdrant_client/embed/utils.py
+++ b/qdrant_client/embed/utils.py
@@ -10,13 +10,15 @@ class FieldPath(BaseModel):
     _is_endpoint: bool = PrivateAttr(default=False)
 
     def as_str_list(self) -> list[str]:
-        """
+        """Flatten this field path tree into dot-separated endpoint paths.
+
         >>> FieldPath(current='a', tail=[FieldPath(current='b', tail=[FieldPath(current='c'), FieldPath(current='d')])]).as_str_list()
         ['a.b.c', 'a.b.d']
         """
 
         # Recursive function to collect all paths
         def collect_paths(path: FieldPath, prefix: str = "") -> list[str]:
+            """Collect endpoint paths below the current tree node."""
             current_path = prefix + path.current
             paths = [current_path] if path._is_endpoint or not path.tail else []
             if not path.tail:

--- a/tests/embed_tests/test_utils.py
+++ b/tests/embed_tests/test_utils.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from qdrant_client.embed.utils import read_base64
+from qdrant_client.embed.utils import convert_paths, read_base64
 from tests.utils import TESTS_PATH
 
 EMBED_TESTS_DATA = TESTS_PATH / "embed_tests" / "misc"
@@ -24,3 +24,19 @@ def test_image_path_to_b64():
     non_existent_path = Path(EMBED_TESTS_DATA / "gibberish.jpg")
     with pytest.raises(FileNotFoundError):
         read_base64(non_existent_path)
+
+
+def test_convert_paths_preserves_prefix_endpoint():
+    paths = convert_paths(["a.b", "a.b.c"])
+
+    assert [path for root in paths for path in root.as_str_list()] == ["a.b", "a.b.c"]
+
+
+def test_convert_paths_preserves_prefix_endpoint_with_siblings():
+    paths = convert_paths(["a.b", "a.b.c", "a.d"])
+
+    assert [path for root in paths for path in root.as_str_list()] == [
+        "a.b",
+        "a.b.c",
+        "a.d",
+    ]


### PR DESCRIPTION
## Summary

- Preserve `FieldPath` endpoints when one embedded field path is also the prefix of another path.
- Add regression coverage for `convert_paths(["a.b", "a.b.c"])` and sibling paths.

## Root cause

`convert_paths` compresses dotted paths into a small `FieldPath` tree, and `FieldPath.as_str_list()` previously emitted only leaf paths. When a requested path was both a terminal path and a parent path, such as `a.b` in `a.b` plus `a.b.c`, the terminal marker was lost and the round-trip returned only `a.b.c`.

This patch marks nodes that correspond to original input paths as endpoints while keeping the existing compact tree shape.

## Validation

- Baseline reproduction on `origin/master`: `convert_paths(["a.b", "a.b.c", "a.d"])` returned `['a.b.c', 'a.d']` and failed the expected assertion.
- Patched branch: same snippet returned `['a.b', 'a.b.c', 'a.d']`.
- `uv run --with pytest --with numpy --with pydantic --with httpx --with grpcio --with protobuf --with urllib3 --with portalocker pytest tests/embed_tests/test_utils.py -q`
- `uv run --with pytest --with numpy --with pydantic --with httpx --with grpcio --with protobuf --with urllib3 --with portalocker pytest tests/embed_tests/test_inspectors.py tests/embed_tests/test_schema_parser.py -q`
- `uv run --with ruff==0.4.3 ruff check qdrant_client/embed/utils.py tests/embed_tests/test_utils.py`
