### PR TITLE
fix: keep filtered vector updates processing

### DIFF
--- a/qdrant_client/local/local_collection.py
+++ b/qdrant_client/local/local_collection.py
@@ -2646,7 +2646,7 @@ class LocalCollection:
                 if not check_filter(
                     update_filter, self.payload[idx], self.ids_inv[idx], has_vector
                 ):
-                    return None
+                    continue
             self._update_named_vectors(idx, fixed_vectors)
             self._persist_by_id(point_id)
 

--- a/tests/congruence_tests/test_updates.py
+++ b/tests/congruence_tests/test_updates.py
@@ -508,6 +508,41 @@ def test_update_vectors():
     # endregion
 
 
+def test_update_vectors_filter_skips_only_non_matching_points():
+    local_client = init_local()
+    local_client.create_collection(
+        collection_name=COLLECTION_NAME,
+        vectors_config=models.VectorParams(size=4, distance=models.Distance.DOT),
+    )
+    local_client.upsert(
+        COLLECTION_NAME,
+        points=[
+            models.PointStruct(id=1, vector=[1, 0, 0, 0], payload={"type": "a"}),
+            models.PointStruct(id=2, vector=[0, 1, 0, 0], payload={"type": "b"}),
+            models.PointStruct(id=3, vector=[0, 0, 1, 0], payload={"type": "a"}),
+        ],
+    )
+
+    local_client.update_vectors(
+        COLLECTION_NAME,
+        points=[
+            models.PointVectors(id=1, vector=[0.5, 0.5, 0, 0]),
+            models.PointVectors(id=2, vector=[0, 0, 0.5, 0.5]),
+            models.PointVectors(id=3, vector=[0, 0, 0, 1]),
+        ],
+        update_filter=models.Filter(
+            must=[models.FieldCondition(key="type", match=models.MatchValue(value="a"))]
+        ),
+    )
+
+    retrieved_points = local_client.retrieve(
+        collection_name=COLLECTION_NAME, ids=[1, 2, 3], with_vectors=True
+    )
+    assert retrieved_points[0].vector == [0.5, 0.5, 0.0, 0.0]
+    assert retrieved_points[1].vector == [0.0, 1.0, 0.0, 0.0]
+    assert retrieved_points[2].vector == [0.0, 0.0, 0.0, 1.0]
+
+
 @pytest.mark.parametrize("prefer_grpc", [False, True])
 def test_update_filter(prefer_grpc):
     local_client = init_local()


### PR DESCRIPTION
Closes #1237.

`LocalCollection.update_vectors()` returned from the whole method when one point failed `update_filter`. That skipped every remaining point in the batch, even when later points matched the filter and should have been updated.

This changes that branch to skip only the non-matching point and continue processing the rest of the batch. I added a local-mode regression test where point 2 does not match the filter but point 3 does, so point 3 must still be updated.

Validation:

- Reproduced the issue on `origin/master`: point 3 stayed at its original vector after point 2 failed the filter.
- `uv run --with numpy --with pydantic --with portalocker --with grpcio --with protobuf --with urllib3 --with 'httpx[http2]' --with pytest pytest tests/congruence_tests/test_updates.py::test_update_vectors_filter_skips_only_non_matching_points -q`
- `uv run --with 'ruff==0.4.3' ruff check qdrant_client/local/local_collection.py tests/congruence_tests/test_updates.py`
- `git diff --check`

Duplicate check immediately before opening: searched open PRs for `1237 OR update_vectors update_filter returns early skipping remaining points`; no matches.
