### PR TITLE
fix: close local lock file on failure

### DIFF
--- a/qdrant_client/local/async_qdrant_local.py
+++ b/qdrant_client/local/async_qdrant_local.py
@@ -133,9 +133,15 @@ class AsyncQdrantLocal(AsyncQdrantBase):
                 portalocker.LockFlags.EXCLUSIVE | portalocker.LockFlags.NON_BLOCKING,
             )
         except portalocker.exceptions.LockException:
+            self._flock_file.close()
+            self._flock_file = None
             raise RuntimeError(
                 f"Storage folder {self.location} is already accessed by another instance of Qdrant client. If you require concurrent access, use Qdrant server instead."
             )
+        except Exception:
+            self._flock_file.close()
+            self._flock_file = None
+            raise
 
     def _save(self) -> None:
         if not self.persistent:

--- a/qdrant_client/local/qdrant_local.py
+++ b/qdrant_client/local/qdrant_local.py
@@ -146,10 +146,16 @@ class QdrantLocal(QdrantBase):
                 portalocker.LockFlags.EXCLUSIVE | portalocker.LockFlags.NON_BLOCKING,
             )
         except portalocker.exceptions.LockException:
+            self._flock_file.close()
+            self._flock_file = None
             raise RuntimeError(
                 f"Storage folder {self.location} is already accessed by another instance of Qdrant client."
                 f" If you require concurrent access, use Qdrant server instead."
             )
+        except Exception:
+            self._flock_file.close()
+            self._flock_file = None
+            raise
 
     def _save(self) -> None:
         if not self.persistent:

--- a/tests/test_qdrant_client.py
+++ b/tests/test_qdrant_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import builtins
 import concurrent.futures
 import importlib.metadata
 import os
@@ -20,6 +21,7 @@ from qdrant_client._pydantic_compat import to_dict
 from qdrant_client.conversions.common_types import PointVectors, StrictModeConfig
 from qdrant_client.common.client_exceptions import ResourceExhaustedResponse
 from qdrant_client.conversions.conversion import grpc_to_payload, json_to_value
+from qdrant_client.local.async_qdrant_local import AsyncQdrantLocal
 from qdrant_client.local.qdrant_local import QdrantLocal
 from qdrant_client.models import (
     Batch,
@@ -246,6 +248,33 @@ def test_client_init():
         # it's just a mock to check creation of `init_options` with unpickleable objects like ssl context
     )
     assert client.init_options["verify"] is ssl_context
+
+
+@pytest.mark.parametrize("local_cls", [QdrantLocal, AsyncQdrantLocal])
+def test_local_lock_failure_closes_lock_file(tmp_path, monkeypatch, local_cls):
+    import portalocker
+
+    captured_lock_file = None
+    original_open = builtins.open
+
+    def tracking_open(file, mode="r", *args, **kwargs):
+        nonlocal captured_lock_file
+        opened_file = original_open(file, mode, *args, **kwargs)
+        if os.fspath(file).endswith(".lock") and mode == "r+":
+            captured_lock_file = opened_file
+        return opened_file
+
+    def raise_lock_exception(*args, **kwargs):
+        raise portalocker.exceptions.LockException("locked")
+
+    monkeypatch.setattr(builtins, "open", tracking_open)
+    monkeypatch.setattr(portalocker, "lock", raise_lock_exception)
+
+    with pytest.raises(RuntimeError, match="already accessed by another instance"):
+        local_cls(str(tmp_path))
+
+    assert captured_lock_file is not None
+    assert captured_lock_file.closed
 
 
 @pytest.mark.parametrize("prefer_grpc", [False, True])


### PR DESCRIPTION
Closes #1234.

## Summary
- close the local `.lock` file when `portalocker.lock()` fails in `QdrantLocal`
- apply the same cleanup in `AsyncQdrantLocal`
- add a regression test for both local client implementations

## Root cause
The local client opens the `.lock` file before acquiring the portalocker lock. If lock acquisition raises, the constructor raises without closing the opened file handle.

## Validation
- Base reproduction on `origin/master`: monkeypatched `portalocker.lock()` to raise `LockException`; captured `.lock` file remained open (`closed: False`)
- `uv run --with numpy --with pydantic --with portalocker --with grpcio --with protobuf --with urllib3 --with 'httpx[http2]' --with pytest pytest tests/test_qdrant_client.py::test_local_lock_failure_closes_lock_file -q` -> `2 passed`\n- `uv run --with 'ruff==0.4.3' ruff check qdrant_client/local/qdrant_local.py qdrant_client/local/async_qdrant_local.py` -> `All checks passed`\n\nNote: running ruff across the full touched test file also reports an existing unrelated `F841` in `tests/test_qdrant_client.py` on `origin/master` (`except Exception as ex`), so I kept the lint check scoped to the changed local implementation files.