### PR TITLE
feat: added retry mechanism with exponential back-off

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,35 @@ qdrant_client = QdrantClient(
 )
 ```
 
+## Retries
+
+By default the client does not retry failed requests. You can opt in to automatic
+retries with exponential backoff for transient failures (connection errors,
+timeouts, and rate-limit / unavailable responses) by passing a `retry` config.
+It is applied to both the REST and gRPC transports:
+
+```python
+from qdrant_client import QdrantClient, RetryConfig
+
+client = QdrantClient(
+    url="http://localhost:6333",
+    retry=RetryConfig(
+        max_retries=3,       # retries after the initial attempt
+        backoff_factor=0.5,  # base delay in seconds (0.5, 1, 2, ... capped by max_backoff)
+        max_backoff=10.0,    # maximum delay between attempts, in seconds
+    ),
+)
+
+# A plain dict works too:
+client = QdrantClient(url="http://localhost:6333", retry={"max_retries": 3, "backoff_factor": 0.5})
+```
+
+Only transient failures are retried by default: HTTP `429`, `502`, `503`, `504`
+and connection/timeout errors for REST, and `UNAVAILABLE`, `RESOURCE_EXHAUSTED`,
+`DEADLINE_EXCEEDED` for gRPC. The server-provided `Retry-After` header is honoured
+when present. Note that retries can re-send non-idempotent operations, so prefer
+explicit point IDs for upserts when enabling retries.
+
 ## Inference API
 
 Qdrant Client has Inference API that allows to seamlessly create embeddings and use them in Qdrant.

--- a/qdrant_client/__init__.py
+++ b/qdrant_client/__init__.py
@@ -1,2 +1,3 @@
 from .async_qdrant_client import AsyncQdrantClient as AsyncQdrantClient
+from .common.retry import RetryConfig as RetryConfig
 from .qdrant_client import QdrantClient as QdrantClient

--- a/qdrant_client/async_qdrant_client.py
+++ b/qdrant_client/async_qdrant_client.py
@@ -15,6 +15,7 @@ import numpy as np
 from qdrant_client import grpc as grpc
 from qdrant_client.async_client_base import AsyncQdrantBase
 from qdrant_client.common.client_warnings import show_warning_once
+from qdrant_client.common.retry import RetryConfig
 from qdrant_client.conversions import common_types as types
 from qdrant_client.embed.type_inspector import Inspector
 from qdrant_client.http import AsyncApiClient, AsyncApis
@@ -78,6 +79,10 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
         pool_size: connection pool size, Default: None. Default value for gRPC connection pool is 3, rest default is
             inherited from `httpx` (default: 100)
         headers: Custom headers to send with every request.
+        retry: Optional retry configuration with exponential backoff for transient
+            failures, applied to both REST and gRPC transports. Accepts a
+            :class:`qdrant_client.common.retry.RetryConfig` or an equivalent dict.
+            If `None` (default), no automatic retries are performed.
         **kwargs: Additional arguments passed directly into REST client initialization
     """
 
@@ -102,6 +107,7 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
         check_compatibility: bool = True,
         pool_size: int | None = None,
         headers: dict[str, str] | None = None,
+        retry: RetryConfig | dict[str, Any] | None = None,
         **kwargs: Any,
     ):
         self._init_options = {
@@ -141,6 +147,7 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
                 check_compatibility=check_compatibility,
                 pool_size=pool_size,
                 headers=headers,
+                retry=retry,
                 **kwargs,
             )
         if isinstance(self._client, AsyncQdrantLocal) and cloud_inference:

--- a/qdrant_client/async_qdrant_remote.py
+++ b/qdrant_client/async_qdrant_remote.py
@@ -24,6 +24,12 @@ from qdrant_client import grpc as grpc
 from qdrant_client._pydantic_compat import construct
 from qdrant_client.auth import BearerAuth
 from qdrant_client.async_client_base import AsyncQdrantBase
+from qdrant_client.common.retry import (
+    RetryConfig,
+    coerce_retry_config,
+    async_retry_middleware,
+    retry_to_grpc_options,
+)
 from qdrant_client.common.version_check import is_compatible, get_server_version
 from qdrant_client.connection import get_async_channel as get_channel
 from qdrant_client.conversions import common_types as types
@@ -61,12 +67,14 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         check_compatibility: bool = True,
         pool_size: int | None = None,
         headers: dict[str, str] | None = None,
+        retry: RetryConfig | dict[str, Any] | None = None,
         **kwargs: Any,
     ):
         super().__init__(**kwargs)
         self._prefer_grpc = prefer_grpc
         self._grpc_port = grpc_port
         self._grpc_options = grpc_options or {}
+        self._retry = coerce_retry_config(retry)
         self._https = https if https is not None else api_key is not None
         self._scheme = "https" if self._https else "http"
         self._pool_size: int | None = None
@@ -155,6 +163,16 @@ class AsyncQdrantRemote(AsyncQdrantBase):
             )
         self._rest_headers["User-Agent"] = user_agent
         self._grpc_options["grpc.primary_user_agent"] = user_agent
+        if self._retry is not None:
+            for option_name, option_value in retry_to_grpc_options(self._retry).items():
+                if option_name in self._grpc_options:
+                    show_warning_once(
+                        message=f"`{option_name}` has been passed in `grpc_options`, the value derived from `retry` will be ignored.",
+                        category=UserWarning,
+                        stacklevel=4,
+                    )
+                    continue
+                self._grpc_options[option_name] = option_value
         grpc_compression: Compression | None = kwargs.pop("grpc_compression", None)
         if grpc_compression is not None and (not isinstance(grpc_compression, Compression)):
             raise TypeError(
@@ -189,6 +207,8 @@ class AsyncQdrantRemote(AsyncQdrantBase):
             host=self.rest_uri, **self._rest_args
         )
         self.openapi_client.client.add_middleware(async_rest_headers_middleware)
+        if self._retry is not None:
+            self.openapi_client.client.add_middleware(async_retry_middleware(self._retry))
         self._grpc_channel_pool: list[grpc.Channel] = []
         self._grpc_points_client_pool: list[grpc.PointsStub] | None = None
         self._grpc_collections_client_pool: list[grpc.CollectionsStub] | None = None

--- a/qdrant_client/common/retry.py
+++ b/qdrant_client/common/retry.py
@@ -1,0 +1,226 @@
+"""Retry support for the remote Qdrant client.
+
+This module provides a transport-level retry mechanism with exponential backoff
+and jitter for both the REST (httpx) and gRPC transports:
+
+* REST: :func:`retry_middleware` / :func:`async_retry_middleware` are injected
+  into the generated ``ApiClient`` middleware chain. They re-send the request on
+  transient transport errors and on a configurable set of HTTP status codes,
+  honouring the server provided ``Retry-After`` header when present.
+* gRPC: :func:`retry_to_grpc_options` translates a :class:`RetryConfig` into the
+  native gRPC ``service_config`` retry policy, which is handled by gRPC core.
+
+Retries are opt-in: when no :class:`RetryConfig` is provided the client behaves
+exactly as before.
+"""
+
+import asyncio
+import json
+import random
+import time
+from email.utils import parsedate_to_datetime
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Optional, Tuple, Union
+
+import httpx
+from pydantic import BaseModel, Field
+
+from qdrant_client.http.exceptions import ResponseHandlingException
+
+DEFAULT_RETRY_ON_STATUS: Tuple[int, ...] = (429, 502, 503, 504)
+
+
+class RetryConfig(BaseModel):
+    """Configuration for automatic request retries with exponential backoff.
+
+    Args:
+        max_retries: Maximum number of retries *after* the initial attempt.
+            The total number of attempts is ``max_retries + 1``. Default: 3.
+        backoff_factor: Base delay (in seconds) for the exponential backoff.
+            The delay before retry ``n`` (0-based) is ``backoff_factor * 2 ** n``,
+            clamped to ``max_backoff``. Default: 0.5.
+        max_backoff: Maximum delay (in seconds) between attempts. Default: 10.0.
+        jitter: If ``True``, apply full jitter to the computed backoff to avoid
+            thundering-herd retries. Default: ``True``.
+        retry_on_status: HTTP status codes that should trigger a retry (REST).
+            Default: ``(429, 502, 503, 504)``.
+        retry_on_timeout: If ``True``, retry on transient transport errors such
+            as connection errors and timeouts. Default: ``True``.
+        respect_retry_after: If ``True``, honour the server provided
+            ``Retry-After`` header (REST) instead of the computed backoff.
+            Default: ``True``.
+    """
+
+    max_retries: int = Field(default=3, ge=0)
+    backoff_factor: float = Field(default=0.5, ge=0.0)
+    max_backoff: float = Field(default=10.0, ge=0.0)
+    jitter: bool = True
+    retry_on_status: Tuple[int, ...] = DEFAULT_RETRY_ON_STATUS
+    retry_on_timeout: bool = True
+    respect_retry_after: bool = True
+
+
+RestSend = Callable[[httpx.Request], httpx.Response]
+RestSendAsync = Callable[[httpx.Request], Awaitable[httpx.Response]]
+
+
+def _compute_backoff(config: RetryConfig, attempt: int) -> float:
+    """Exponential backoff (with optional full jitter) for a 0-based attempt."""
+    delay = config.backoff_factor * (2**attempt)
+    delay = min(delay, config.max_backoff)
+    if config.jitter:
+        delay = random.uniform(0.0, delay)
+    return delay
+
+
+def _is_retryable_exception(exc: Optional[BaseException]) -> bool:
+    """Whether a transport-level exception is safe to retry.
+
+    ``httpx.TransportError`` is the base class for connection errors, timeouts,
+    network errors and protocol errors. Higher level errors (e.g. invalid URL,
+    too many redirects) are intentionally not retried.
+    """
+    return isinstance(exc, httpx.TransportError)
+
+
+def _retry_after_seconds(response: httpx.Response) -> Optional[float]:
+    """Parse the ``Retry-After`` header (delta-seconds or HTTP-date)."""
+    value = response.headers.get("Retry-After")
+    if not value:
+        return None
+    value = value.strip()
+    try:
+        return max(0.0, float(value))
+    except ValueError:
+        pass
+    try:
+        retry_date = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if retry_date is None:
+        return None
+    if retry_date.tzinfo is None:
+        retry_date = retry_date.replace(tzinfo=timezone.utc)
+    return max(0.0, (retry_date - datetime.now(timezone.utc)).total_seconds())
+
+
+def _next_delay(config: RetryConfig, attempt: int, response: Optional[httpx.Response]) -> float:
+    if response is not None and config.respect_retry_after:
+        retry_after = _retry_after_seconds(response)
+        if retry_after is not None:
+            return min(retry_after, config.max_backoff) if config.max_backoff else retry_after
+    return _compute_backoff(config, attempt)
+
+
+def retry_middleware(config: RetryConfig) -> Callable[[httpx.Request, RestSend], httpx.Response]:
+    """Build a synchronous REST middleware that retries transient failures."""
+
+    def middleware(request: httpx.Request, call_next: RestSend) -> httpx.Response:
+        response: Optional[httpx.Response] = None
+        for attempt in range(config.max_retries + 1):
+            is_last = attempt >= config.max_retries
+            try:
+                response = call_next(request)
+            except ResponseHandlingException as exc:
+                if (
+                    config.retry_on_timeout
+                    and not is_last
+                    and _is_retryable_exception(getattr(exc, "source", None))
+                ):
+                    time.sleep(_compute_backoff(config, attempt))
+                    continue
+                raise
+
+            if response.status_code in config.retry_on_status and not is_last:
+                time.sleep(_next_delay(config, attempt, response))
+                continue
+            return response
+
+        assert response is not None  # max_retries >= 0 guarantees at least one attempt
+        return response
+
+    return middleware
+
+
+def async_retry_middleware(
+    config: RetryConfig,
+) -> Callable[[httpx.Request, RestSendAsync], Awaitable[httpx.Response]]:
+    """Build an asynchronous REST middleware that retries transient failures."""
+
+    async def middleware(request: httpx.Request, call_next: RestSendAsync) -> httpx.Response:
+        response: Optional[httpx.Response] = None
+        for attempt in range(config.max_retries + 1):
+            is_last = attempt >= config.max_retries
+            try:
+                response = await call_next(request)
+            except ResponseHandlingException as exc:
+                if (
+                    config.retry_on_timeout
+                    and not is_last
+                    and _is_retryable_exception(getattr(exc, "source", None))
+                ):
+                    await asyncio.sleep(_compute_backoff(config, attempt))
+                    continue
+                raise
+
+            if response.status_code in config.retry_on_status and not is_last:
+                await asyncio.sleep(_next_delay(config, attempt, response))
+                continue
+            return response
+
+        assert response is not None
+        return response
+
+    return middleware
+
+
+def retry_to_grpc_options(config: RetryConfig) -> dict[str, Any]:
+    """Translate a :class:`RetryConfig` into native gRPC retry channel options.
+
+    gRPC core handles the backoff (with built-in jitter) once the channel is
+    configured with ``grpc.enable_retries`` and a ``grpc.service_config`` that
+    contains a ``retryPolicy``.
+    """
+    status_codes = ["UNAVAILABLE"]
+    if 429 in config.retry_on_status:
+        status_codes.append("RESOURCE_EXHAUSTED")
+    if config.retry_on_timeout:
+        status_codes.append("DEADLINE_EXCEEDED")
+
+    # gRPC requires 2 <= maxAttempts; the default hard cap in gRPC core is 5.
+    max_attempts = max(2, min(config.max_retries + 1, 5))
+    initial_backoff = max(config.backoff_factor, 0.001)
+    max_backoff = max(config.max_backoff, initial_backoff)
+
+    service_config = {
+        "methodConfig": [
+            {
+                "name": [{}],  # apply to every method on the channel
+                "retryPolicy": {
+                    "maxAttempts": max_attempts,
+                    "initialBackoff": f"{initial_backoff}s",
+                    "maxBackoff": f"{max_backoff}s",
+                    "backoffMultiplier": 2.0,
+                    "retryableStatusCodes": status_codes,
+                },
+            }
+        ]
+    }
+
+    return {
+        "grpc.enable_retries": 1,
+        "grpc.service_config": json.dumps(service_config),
+    }
+
+
+def coerce_retry_config(
+    retry: Union[RetryConfig, dict[str, Any], None],
+) -> Optional[RetryConfig]:
+    """Normalise the public ``retry`` argument into a :class:`RetryConfig`."""
+    if retry is None:
+        return None
+    if isinstance(retry, RetryConfig):
+        return retry
+    if isinstance(retry, dict):
+        return RetryConfig(**retry)
+    raise TypeError(f"`retry` must be a RetryConfig, dict or None, but got {type(retry)}")

--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -13,6 +13,7 @@ import numpy as np
 from qdrant_client import grpc as grpc
 from qdrant_client.client_base import QdrantBase
 from qdrant_client.common.client_warnings import show_warning_once
+from qdrant_client.common.retry import RetryConfig
 from qdrant_client.conversions import common_types as types
 from qdrant_client.embed.type_inspector import Inspector
 from qdrant_client.http import ApiClient, SyncApis
@@ -77,6 +78,10 @@ class QdrantClient(QdrantFastembedMixin):
         pool_size: connection pool size, Default: None. Default value for gRPC connection pool is 3, rest default is
             inherited from `httpx` (default: 100)
         headers: Custom headers to send with every request.
+        retry: Optional retry configuration with exponential backoff for transient
+            failures, applied to both REST and gRPC transports. Accepts a
+            :class:`qdrant_client.common.retry.RetryConfig` or an equivalent dict.
+            If `None` (default), no automatic retries are performed.
         **kwargs: Additional arguments passed directly into REST client initialization
     """
 
@@ -101,6 +106,7 @@ class QdrantClient(QdrantFastembedMixin):
         check_compatibility: bool = True,
         pool_size: int | None = None,
         headers: dict[str, str] | None = None,
+        retry: RetryConfig | dict[str, Any] | None = None,
         **kwargs: Any,
     ):
         # Saving the init options to facilitate building AsyncQdrantClient from QdrantClient and vice versa.
@@ -146,6 +152,7 @@ class QdrantClient(QdrantFastembedMixin):
                 check_compatibility=check_compatibility,
                 pool_size=pool_size,
                 headers=headers,
+                retry=retry,
                 **kwargs,
             )
 

--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -25,6 +25,12 @@ from qdrant_client import grpc as grpc
 from qdrant_client._pydantic_compat import construct
 from qdrant_client.auth import BearerAuth
 from qdrant_client.client_base import QdrantBase
+from qdrant_client.common.retry import (
+    RetryConfig,
+    coerce_retry_config,
+    retry_middleware,
+    retry_to_grpc_options,
+)
 from qdrant_client.common.version_check import is_compatible, get_server_version
 from qdrant_client.connection import get_channel
 from qdrant_client.conversions import common_types as types
@@ -62,12 +68,14 @@ class QdrantRemote(QdrantBase):
         check_compatibility: bool = True,
         pool_size: int | None = None,
         headers: dict[str, str] | None = None,
+        retry: RetryConfig | dict[str, Any] | None = None,
         **kwargs: Any,
     ):
         super().__init__(**kwargs)
         self._prefer_grpc = prefer_grpc
         self._grpc_port = grpc_port
         self._grpc_options = grpc_options or {}
+        self._retry = coerce_retry_config(retry)
         self._https = https if https is not None else api_key is not None
         self._scheme = "https" if self._https else "http"
 
@@ -191,6 +199,18 @@ class QdrantRemote(QdrantBase):
         self._rest_headers["User-Agent"] = user_agent
         self._grpc_options["grpc.primary_user_agent"] = user_agent
 
+        if self._retry is not None:
+            for option_name, option_value in retry_to_grpc_options(self._retry).items():
+                if option_name in self._grpc_options:
+                    show_warning_once(
+                        message=f"`{option_name}` has been passed in `grpc_options`, "
+                        f"the value derived from `retry` will be ignored.",
+                        category=UserWarning,
+                        stacklevel=4,
+                    )
+                    continue
+                self._grpc_options[option_name] = option_value
+
         # GRPC Channel-Level Compression
         grpc_compression: Compression | None = kwargs.pop("grpc_compression", None)
         if grpc_compression is not None and not isinstance(grpc_compression, Compression):
@@ -236,6 +256,11 @@ class QdrantRemote(QdrantBase):
         )
 
         self.openapi_client.client.add_middleware(rest_headers_middleware)
+
+        # The retry middleware is added last so that it wraps the headers
+        # middleware, ensuring headers are re-applied on every retried request.
+        if self._retry is not None:
+            self.openapi_client.client.add_middleware(retry_middleware(self._retry))
 
         self._grpc_channel_pool: list[grpc.Channel] = []
         self._grpc_points_client_pool: list[grpc.PointsStub] | None = None

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,186 @@
+import json
+
+import httpx
+import pytest
+
+from qdrant_client.common.retry import (
+    RetryConfig,
+    _compute_backoff,
+    _retry_after_seconds,
+    async_retry_middleware,
+    coerce_retry_config,
+    retry_middleware,
+    retry_to_grpc_options,
+)
+from qdrant_client.http.exceptions import ResponseHandlingException
+
+
+def _request() -> httpx.Request:
+    return httpx.Request("GET", "http://localhost:6333/collections")
+
+
+def _response(status_code: int, headers: dict | None = None) -> httpx.Response:
+    return httpx.Response(status_code=status_code, headers=headers or {})
+
+
+class _FlakyCallNext:
+    """Callable that fails a fixed number of times before succeeding."""
+
+    def __init__(self, outcomes: list):
+        self.outcomes = list(outcomes)
+        self.calls = 0
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.calls += 1
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    monkeypatch.setattr("qdrant_client.common.retry.time.sleep", lambda *_: None)
+    monkeypatch.setattr("qdrant_client.common.retry.asyncio.sleep", _async_noop)
+
+
+async def _async_noop(*_args, **_kwargs):
+    return None
+
+
+def test_retry_config_defaults():
+    config = RetryConfig()
+    assert config.max_retries == 3
+    assert config.retry_on_status == (429, 502, 503, 504)
+    assert config.retry_on_timeout is True
+
+
+def test_coerce_retry_config():
+    assert coerce_retry_config(None) is None
+    cfg = coerce_retry_config({"max_retries": 7})
+    assert isinstance(cfg, RetryConfig)
+    assert cfg.max_retries == 7
+    existing = RetryConfig(max_retries=1)
+    assert coerce_retry_config(existing) is existing
+    with pytest.raises(TypeError):
+        coerce_retry_config(42)
+
+
+def test_compute_backoff_is_bounded():
+    config = RetryConfig(backoff_factor=1.0, max_backoff=4.0, jitter=False)
+    assert _compute_backoff(config, 0) == 1.0
+    assert _compute_backoff(config, 1) == 2.0
+    assert _compute_backoff(config, 2) == 4.0
+    assert _compute_backoff(config, 10) == 4.0  # clamped to max_backoff
+
+
+def test_retry_after_parsing():
+    assert _retry_after_seconds(_response(429, {"Retry-After": "5"})) == 5.0
+    assert _retry_after_seconds(_response(429)) is None
+
+
+def test_rest_middleware_retries_then_succeeds():
+    config = RetryConfig(max_retries=3, jitter=False)
+    call_next = _FlakyCallNext([_response(503), _response(503), _response(200)])
+    middleware = retry_middleware(config)
+
+    response = middleware(_request(), call_next)
+
+    assert response.status_code == 200
+    assert call_next.calls == 3
+
+
+def test_rest_middleware_gives_up_and_returns_last_response():
+    config = RetryConfig(max_retries=2, jitter=False)
+    call_next = _FlakyCallNext([_response(503), _response(503), _response(503)])
+    middleware = retry_middleware(config)
+
+    response = middleware(_request(), call_next)
+
+    assert response.status_code == 503
+    assert call_next.calls == 3  # 1 initial + 2 retries
+
+
+def test_rest_middleware_does_not_retry_success():
+    config = RetryConfig(max_retries=3, jitter=False)
+    call_next = _FlakyCallNext([_response(200), _response(503)])
+    middleware = retry_middleware(config)
+
+    response = middleware(_request(), call_next)
+
+    assert response.status_code == 200
+    assert call_next.calls == 1
+
+
+def test_rest_middleware_retries_transient_exception():
+    config = RetryConfig(max_retries=2, jitter=False)
+    transient = ResponseHandlingException(httpx.ConnectError("boom"))
+    call_next = _FlakyCallNext([transient, _response(200)])
+    middleware = retry_middleware(config)
+
+    response = middleware(_request(), call_next)
+
+    assert response.status_code == 200
+    assert call_next.calls == 2
+
+
+def test_rest_middleware_reraises_exhausted_exception():
+    config = RetryConfig(max_retries=1, jitter=False)
+    transient = ResponseHandlingException(httpx.ConnectError("boom"))
+    call_next = _FlakyCallNext([transient, transient])
+    middleware = retry_middleware(config)
+
+    with pytest.raises(ResponseHandlingException):
+        middleware(_request(), call_next)
+    assert call_next.calls == 2
+
+
+def test_rest_middleware_does_not_retry_non_transient_exception():
+    config = RetryConfig(max_retries=3, retry_on_timeout=True, jitter=False)
+    # ValueError is not an httpx.TransportError -> must not be retried
+    non_transient = ResponseHandlingException(ValueError("nope"))
+    call_next = _FlakyCallNext([non_transient, _response(200)])
+    middleware = retry_middleware(config)
+
+    with pytest.raises(ResponseHandlingException):
+        middleware(_request(), call_next)
+    assert call_next.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_async_rest_middleware_retries_then_succeeds():
+    config = RetryConfig(max_retries=3, jitter=False)
+    outcomes = [_response(503), _response(200)]
+    calls = {"n": 0}
+
+    async def call_next(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return outcomes.pop(0)
+
+    middleware = async_retry_middleware(config)
+    response = await middleware(_request(), call_next)
+
+    assert response.status_code == 200
+    assert calls["n"] == 2
+
+
+def test_retry_to_grpc_options():
+    config = RetryConfig(max_retries=4, backoff_factor=0.5, max_backoff=10.0)
+    options = retry_to_grpc_options(config)
+
+    assert options["grpc.enable_retries"] == 1
+    service_config = json.loads(options["grpc.service_config"])
+    policy = service_config["methodConfig"][0]["retryPolicy"]
+    assert policy["maxAttempts"] == 5  # capped at gRPC default hard limit
+    assert "UNAVAILABLE" in policy["retryableStatusCodes"]
+    assert "RESOURCE_EXHAUSTED" in policy["retryableStatusCodes"]
+    assert "DEADLINE_EXCEEDED" in policy["retryableStatusCodes"]
+
+
+def test_retry_to_grpc_options_respects_status_set():
+    config = RetryConfig(retry_on_status=(502, 503), retry_on_timeout=False)
+    policy = json.loads(retry_to_grpc_options(config)["grpc.service_config"])["methodConfig"][0][
+        "retryPolicy"
+    ]
+    assert "RESOURCE_EXHAUSTED" not in policy["retryableStatusCodes"]
+    assert "DEADLINE_EXCEEDED" not in policy["retryableStatusCodes"]

--- a/tools/async_client_generator/remote_generator.py
+++ b/tools/async_client_generator/remote_generator.py
@@ -133,6 +133,7 @@ if __name__ == "__main__":
             "ApiClient": "AsyncApiClient",
             "SyncApis": "AsyncApis",
             "rest_headers_middleware": "async_rest_headers_middleware",
+            "retry_middleware": "async_retry_middleware",
         },
         exclude_methods=[
             "__del__",


### PR DESCRIPTION
## Add optional retry with exponential backoff (closes #1177)

### What this does

Right now, if a request to Qdrant fails because of a temporary problem (a network blip, a timeout, or the server being briefly busy), the client gives up immediately. This PR adds an **optional** retry mechanism so the client can wait a little and try again automatically.

Retries are **off by default**, so existing code behaves exactly as before. You turn them on by passing a `retry` config:

```python
from qdrant_client import QdrantClient, RetryConfig

client = QdrantClient(
    url="http://localhost:6333",
    retry=RetryConfig(max_retries=3, backoff_factor=0.5),
)

# a plain dict also works:
client = QdrantClient(url="http://localhost:6333", retry={"max_retries": 3, "backoff_factor": 0.5})
```

### How it works

- **REST (httpx):** a small retry middleware is added to the existing middleware chain. It re-sends the request on transient failures and waits longer between each attempt (exponential backoff + jitter). If the server sends a `Retry-After` header, we respect it.
- **gRPC:** we translate the same config into gRPC's built-in retry policy (`service_config`), so gRPC core handles the backoff for us.
- Both transports are driven by a single `RetryConfig` (or dict), so there's one consistent setting for the whole client.

### What gets retried (safe defaults)

Only transient errors are retried by default:
- REST: HTTP `429`, `502`, `503`, `504`, and connection/timeout errors.
- gRPC: `UNAVAILABLE`, `RESOURCE_EXHAUSTED`, `DEADLINE_EXCEEDED`.

Generic `500` errors are **not** retried by default to avoid re-sending a write that may have partly succeeded.

### Files of interest

- `qdrant_client/common/retry.py` — new `RetryConfig` model, REST middlewares, and the gRPC option builder.
- `qdrant_client/qdrant_remote.py` / `qdrant_client.py` — wire the `retry` option through (async client regenerated from the sync source).
- `README.md` — new "Retries" section.
- `tests/test_retry.py` — new tests.

---

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you installed `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?