### PR TITLE
tests: extend inspector expression tests and local inference inspection coverage

### DIFF
--- a/tests/embed_tests/test_inspectors.py
+++ b/tests/embed_tests/test_inspectors.py
@@ -710,3 +710,169 @@ def test_inspect_update_operations():
     paths = inspector_embed.inspect([mixed_point_vectors_update_op])
     assert len(paths) == 1 and paths[0].as_str_list() == ["update_vectors.points.vector"]
     # endregion
+
+
+def test_inspect_formula_query_types():
+    # expressions can't contain objects requiring inference
+    # https://github.com/qdrant/qdrant-client/issues/963
+    inspector = Inspector()
+    inspector_embed = InspectorEmbed()
+
+    # region negative cases
+    constant_formula_query = models.FormulaQuery(formula=0.5)
+    assert not inspector.inspect(constant_formula_query)
+    assert inspector_embed.inspect(constant_formula_query) == []
+
+    payload_key_formula_query = models.FormulaQuery(formula="payload_key")
+    assert not inspector.inspect(payload_key_formula_query)
+    assert inspector_embed.inspect(payload_key_formula_query) == []
+
+    condition_formula_query = models.FormulaQuery(
+        formula=models.FieldCondition(key="key", range=models.Range(gt=0.5))
+    )
+    assert not inspector.inspect(condition_formula_query)
+    assert inspector_embed.inspect(condition_formula_query) == []
+
+    geo_distance_formula_query = models.FormulaQuery(
+        formula=models.GeoDistance(
+            geo_distance=models.GeoDistanceParams(
+                origin=models.GeoPoint(lon=13.4, lat=52.5), to="geo_key"
+            )
+        )
+    )
+    assert not inspector.inspect(geo_distance_formula_query)
+    assert inspector_embed.inspect(geo_distance_formula_query) == []
+
+    datetime_formula_query = models.FormulaQuery(
+        formula=models.DatetimeExpression(datetime="2024-01-01T00:00:00Z")
+    )
+    assert not inspector.inspect(datetime_formula_query)
+    assert inspector_embed.inspect(datetime_formula_query) == []
+
+    datetime_key_formula_query = models.FormulaQuery(
+        formula=models.DatetimeKeyExpression(datetime_key="datetime_key")
+    )
+    assert not inspector.inspect(datetime_key_formula_query)
+    assert inspector_embed.inspect(datetime_key_formula_query) == []
+
+    unary_expressions = [
+        models.NegExpression(neg="payload_key"),
+        models.AbsExpression(abs="payload_key"),
+        models.SqrtExpression(sqrt="payload_key"),
+        models.ExpExpression(exp="payload_key"),
+        models.Log10Expression(log10="payload_key"),
+        models.LnExpression(ln="payload_key"),
+    ]
+    for expression in unary_expressions:
+        unary_formula_query = models.FormulaQuery(formula=expression)
+        assert not inspector.inspect(unary_formula_query)
+        assert inspector_embed.inspect(unary_formula_query) == []
+
+    sum_formula_query = models.FormulaQuery(formula=models.SumExpression(sum=[0.5, "payload_key"]))
+    assert not inspector.inspect(sum_formula_query)
+    assert inspector_embed.inspect(sum_formula_query) == []
+
+    mult_formula_query = models.FormulaQuery(
+        formula=models.MultExpression(mult=[0.5, "payload_key"])
+    )
+    assert not inspector.inspect(mult_formula_query)
+    assert inspector_embed.inspect(mult_formula_query) == []
+
+    div_formula_query = models.FormulaQuery(
+        formula=models.DivExpression(
+            div=models.DivParams(left="payload_key", right=0.5, by_zero_default=0.0)
+        )
+    )
+    assert not inspector.inspect(div_formula_query)
+    assert inspector_embed.inspect(div_formula_query) == []
+
+    pow_formula_query = models.FormulaQuery(
+        formula=models.PowExpression(pow=models.PowParams(base="payload_key", exponent=2.0))
+    )
+    assert not inspector.inspect(pow_formula_query)
+    assert inspector_embed.inspect(pow_formula_query) == []
+
+    decay_params = models.DecayParamsExpression(
+        x=models.DatetimeKeyExpression(datetime_key="datetime_key"),
+        target=models.DatetimeExpression(datetime="2024-01-01T00:00:00Z"),
+        scale=86400.0,
+        midpoint=0.5,
+    )
+    decay_expressions = [
+        models.LinDecayExpression(lin_decay=decay_params),
+        models.ExpDecayExpression(exp_decay=decay_params),
+        models.GaussDecayExpression(gauss_decay=decay_params),
+    ]
+    for expression in decay_expressions:
+        decay_formula_query = models.FormulaQuery(formula=expression)
+        assert not inspector.inspect(decay_formula_query)
+        assert inspector_embed.inspect(decay_formula_query) == []
+
+    deep_nested_formula_query = models.FormulaQuery(
+        formula=models.SumExpression(
+            sum=[
+                0.5,
+                models.MultExpression(
+                    mult=[
+                        "payload_key",
+                        models.NegExpression(
+                            neg=models.AbsExpression(
+                                abs=models.DivExpression(
+                                    div=models.DivParams(
+                                        left=models.SqrtExpression(sqrt="payload_key"),
+                                        right=models.PowExpression(
+                                            pow=models.PowParams(base=2.0, exponent="payload_key")
+                                        ),
+                                    )
+                                )
+                            )
+                        ),
+                    ]
+                ),
+            ]
+        ),
+        defaults={"payload_key": 0.5},
+    )
+    assert not inspector.inspect(deep_nested_formula_query)
+    assert inspector_embed.inspect(deep_nested_formula_query) == []
+
+    formula_prefetch = models.Prefetch(query=deep_nested_formula_query)
+    assert not inspector.inspect(formula_prefetch)
+    assert inspector_embed.inspect(formula_prefetch) == []
+
+    formula_query_request = models.QueryRequest(query=deep_nested_formula_query)
+    assert not inspector.inspect(formula_query_request)
+    assert inspector_embed.inspect(formula_query_request) == []
+
+    formula_prefetch_request = models.QueryRequest(prefetch=formula_prefetch)
+    assert not inspector.inspect(formula_prefetch_request)
+    assert inspector_embed.inspect(formula_prefetch_request) == []
+
+    formula_query_groups_request = models.QueryGroupsRequest(
+        query=deep_nested_formula_query, group_by="k"
+    )
+    assert not inspector.inspect(formula_query_groups_request)
+    assert inspector_embed.inspect(formula_query_groups_request) == []
+
+    formula_query_batch_request = models.QueryRequestBatch(searches=[formula_query_request])
+    assert not inspector.inspect(formula_query_batch_request)
+    assert inspector_embed.inspect(formula_query_batch_request) == []
+    # endregion
+
+    # region positive cases
+    doc = models.Document(text="123", model="Qdrant/bm25")
+
+    formula_query_doc_prefetch_request = models.QueryRequest(
+        query=deep_nested_formula_query, prefetch=models.Prefetch(query=doc)
+    )
+    assert inspector.inspect(formula_query_doc_prefetch_request)
+    paths = inspector_embed.inspect(formula_query_doc_prefetch_request)
+    assert len(paths) == 1 and paths[0].as_str_list() == ["prefetch.query"]
+
+    formula_and_doc_query_batch_request = models.QueryRequestBatch(
+        searches=[formula_query_request, models.QueryRequest(query=doc)]
+    )
+    assert inspector.inspect(formula_and_doc_query_batch_request)
+    paths = inspector_embed.inspect(formula_and_doc_query_batch_request)
+    assert len(paths) == 1 and paths[0].as_str_list() == ["searches.query"]
+    # endregion

--- a/tests/embed_tests/test_inspectors.py
+++ b/tests/embed_tests/test_inspectors.py
@@ -875,4 +875,13 @@ def test_inspect_formula_query_types():
     assert inspector.inspect(formula_and_doc_query_batch_request)
     paths = inspector_embed.inspect(formula_and_doc_query_batch_request)
     assert len(paths) == 1 and paths[0].as_str_list() == ["searches.query"]
+
+    formula_query_groups_doc_prefetch_request = models.QueryGroupsRequest(
+        query=deep_nested_formula_query,
+        group_by="k",
+        prefetch=models.Prefetch(query=doc),
+    )
+    assert inspector.inspect(formula_query_groups_doc_prefetch_request)
+    paths = inspector_embed.inspect(formula_query_groups_doc_prefetch_request)
+    assert len(paths) == 1 and paths[0].as_str_list() == ["prefetch.query"]
     # endregion

--- a/tests/embed_tests/test_local_inference.py
+++ b/tests/embed_tests/test_local_inference.py
@@ -1777,3 +1777,118 @@ def test_bm25_core():
             local_client.upsert(COLLECTION_NAME, points)
     else:
         local_client.upsert(COLLECTION_NAME, points)
+
+
+def _client_with_plain_collection(num_points: int = 0) -> QdrantClient:
+    local_client = QdrantClient(":memory:")
+    local_client.create_collection(
+        COLLECTION_NAME,
+        vectors_config=models.VectorParams(size=2, distance=models.Distance.COSINE),
+    )
+    if num_points:
+        local_client.upsert(
+            COLLECTION_NAME,
+            [models.PointStruct(id=i, vector=[0.1, 0.2]) for i in range(num_points)],
+        )
+    return local_client
+
+
+def _inspect_spy(client: QdrantBase):
+    return patch.object(
+        client._inference_inspector, "inspect", wraps=client._inference_inspector.inspect
+    )
+
+
+def test_upsert_runs_inspection_once():
+    # inspection is invoked once per call, not per vector value
+    # https://github.com/qdrant/qdrant-client/issues/969
+    local_client = _client_with_plain_collection()
+    num_points = 100
+
+    points = [models.PointStruct(id=i, vector=[0.1, 0.2]) for i in range(num_points)]
+    with _inspect_spy(local_client) as spy:
+        local_client.upsert(COLLECTION_NAME, points)
+    assert spy.call_count == 1
+    assert spy.call_args.args[0] is points
+
+    batch = models.Batch(ids=list(range(num_points)), vectors=[[0.1, 0.2]] * num_points)
+    with _inspect_spy(local_client) as spy:
+        local_client.upsert(COLLECTION_NAME, batch)
+    assert spy.call_count == 1
+    assert spy.call_args.args[0] is batch
+
+
+def test_upload_points_inspects_only_first_point():
+    # lazy iterables are inspected by their first element only and are not exhausted
+    # https://github.com/qdrant/qdrant-client/issues/969
+    local_client = _client_with_plain_collection()
+    num_points = 100
+
+    points = (models.PointStruct(id=i, vector=[0.1, 0.2]) for i in range(num_points))
+    with _inspect_spy(local_client) as spy:
+        local_client.upload_points(COLLECTION_NAME, points, wait=True)
+    assert spy.call_count == 1
+    inspected = spy.call_args.args[0]
+    assert isinstance(inspected, models.PointStruct) and inspected.id == 0
+    assert local_client.count(COLLECTION_NAME).count == num_points
+
+
+def test_upload_collection_inspects_only_first_vector():
+    # https://github.com/qdrant/qdrant-client/issues/969
+    local_client = _client_with_plain_collection()
+    num_points = 100
+
+    vectors = ([0.1, 0.2] for _ in range(num_points))
+    with _inspect_spy(local_client) as spy:
+        local_client.upload_collection(
+            COLLECTION_NAME, vectors, ids=list(range(num_points)), wait=True
+        )
+    assert spy.call_count == 1
+    assert spy.call_args.args[0] == [0.1, 0.2]
+    assert local_client.count(COLLECTION_NAME).count == num_points
+
+
+def test_query_runs_inspection_once_per_argument():
+    # https://github.com/qdrant/qdrant-client/issues/969
+    local_client = _client_with_plain_collection(num_points=10)
+
+    with _inspect_spy(local_client) as spy:
+        local_client.query_points(COLLECTION_NAME, query=[0.1, 0.2])
+    assert spy.call_count == 2  # query and prefetch are inspected separately
+
+    with _inspect_spy(local_client) as spy:
+        local_client.query_points(
+            COLLECTION_NAME,
+            query=[0.1, 0.2],
+            prefetch=[models.Prefetch(query=[0.3, 0.4]) for _ in range(10)],
+        )
+    assert spy.call_count == 2
+
+    requests = [models.QueryRequest(query=[0.1, 0.2]) for _ in range(10)]
+    with _inspect_spy(local_client) as spy:
+        local_client.query_batch_points(COLLECTION_NAME, requests)
+    assert spy.call_count == 1
+    assert len(spy.call_args.args[0]) == len(requests)
+
+
+def test_update_operations_run_inspection_once():
+    # https://github.com/qdrant/qdrant-client/issues/969
+    local_client = _client_with_plain_collection(num_points=100)
+
+    point_vectors = [models.PointVectors(id=i, vector=[0.3, 0.4]) for i in range(100)]
+    with _inspect_spy(local_client) as spy:
+        local_client.update_vectors(COLLECTION_NAME, point_vectors)
+    assert spy.call_count == 1
+    assert spy.call_args.args[0] is point_vectors
+
+    operations = [
+        models.UpsertOperation(
+            upsert=models.PointsList(
+                points=[models.PointStruct(id=i, vector=[0.5, 0.6]) for i in range(100)]
+            )
+        )
+    ]
+    with _inspect_spy(local_client) as spy:
+        local_client.batch_update_points(COLLECTION_NAME, operations)
+    assert spy.call_count == 1
+    assert spy.call_args.args[0] is operations

--- a/tests/embed_tests/test_local_inference.py
+++ b/tests/embed_tests/test_local_inference.py
@@ -1793,7 +1793,7 @@ def _client_with_plain_collection(num_points: int = 0) -> QdrantClient:
     return local_client
 
 
-def _inspect_spy(client: QdrantBase):
+def _inspect_spy(client: QdrantClient):
     return patch.object(
         client._inference_inspector, "inspect", wraps=client._inference_inspector.inspect
     )


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you installed `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`?

---

This adds the tests requested in #963 and #969. Tests only, no production code touched.

**#963:** new `test_inspect_formula_query_types` in `tests/embed_tests/test_inspectors.py`. It runs FormulaQuery through every Expression type (constants, payload keys, conditions, geo distance, datetime, the unary ops, sum/mult/div/pow and the three decay expressions), checks them standalone and nested inside Prefetch, QueryRequest, QueryGroupsRequest and QueryRequestBatch, and verifies both inspectors return nothing for all of them. It also covers the mixed cases: a Document placed next to a formula query (in a prefetch, or in another request of the same batch) still gets found at the right path.

**#969:** five tests in `tests/embed_tests/test_local_inference.py` that wrap `Inspector.inspect` with a mock spy and assert inspection does not scale with the number of vector values:

- `upsert` (points list and Batch) inspects once per call
- `upload_points` and `upload_collection` inspect only the first element of a lazy iterable and don't exhaust it, all points still get uploaded
- `query_points` inspects exactly twice (query and prefetch) no matter how many prefetches are passed
- `query_batch_points`, `update_vectors` and `batch_update_points` inspect once each

Everything runs against `QdrantClient(":memory:")` with plain vectors, so no fastembed and no model downloads are needed in CI.

Closes #963
Closes #969