### PR TITLE
Decouple HTTP model imports from FastEmbed for lightweight clients

### DIFF
--- a/qdrant_client/__init__.py
+++ b/qdrant_client/__init__.py
@@ -1,2 +1,26 @@
-from .async_qdrant_client import AsyncQdrantClient as AsyncQdrantClient
-from .qdrant_client import QdrantClient as QdrantClient
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from qdrant_client.async_qdrant_client import AsyncQdrantClient
+    from qdrant_client.qdrant_client import QdrantClient
+
+_LAZY_EXPORTS: dict[str, str] = {
+    "QdrantClient": "qdrant_client.qdrant_client",
+    "AsyncQdrantClient": "qdrant_client.async_qdrant_client",
+}
+
+
+def __getattr__(name: str) -> object:
+    module_path = _LAZY_EXPORTS.get(name)
+    if module_path is not None:
+        from importlib import import_module
+
+        module = import_module(module_path)
+        result = getattr(module, name)
+        globals()[name] = result
+        return result
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)
+
+
+__all__ = ["AsyncQdrantClient", "QdrantClient"]

--- a/qdrant_client/async_qdrant_fastembed.py
+++ b/qdrant_client/async_qdrant_fastembed.py
@@ -41,7 +41,6 @@ class AsyncQdrantFastembedMixin(AsyncQdrantBase):
     _FASTEMBED_INSTALLED: bool
 
     def __init__(self, parser: ModelSchemaParser, is_local_mode: bool):
-        self.__class__._FASTEMBED_INSTALLED = FastEmbedMisc.is_installed()
         self._embedding_model_name: str | None = None
         self._sparse_embedding_model_name: str | None = None
         self._model_embedder = ModelEmbedder(parser=parser, is_local_mode=is_local_mode)

--- a/qdrant_client/embed/embedder.py
+++ b/qdrant_client/embed/embedder.py
@@ -1,20 +1,28 @@
 from collections import defaultdict
-from typing import Sequence, Any, TypeVar, Generic
+from typing import TYPE_CHECKING, Any, Generic, Sequence, TypeVar
 
 from pydantic import BaseModel
 
 from qdrant_client.http import models
 from qdrant_client.embed.models import NumericVector
-from qdrant_client.fastembed_common import (
-    OnnxProvider,
-    ImageInput,
-    TextEmbedding,
-    SparseTextEmbedding,
-    LateInteractionTextEmbedding,
-    LateInteractionMultimodalEmbedding,
-    ImageEmbedding,
-    FastEmbedMisc,
-)
+from qdrant_client.fastembed_common import FastEmbedMisc
+
+if TYPE_CHECKING:
+    from qdrant_client.fastembed_common import (
+        ImageEmbedding,
+        ImageInput,
+        LateInteractionMultimodalEmbedding,
+        LateInteractionTextEmbedding,
+        OnnxProvider,
+        SparseTextEmbedding,
+        TextEmbedding,
+    )
+
+
+def _fastembed_symbol(name: str) -> Any:
+    from qdrant_client import fastembed_common
+
+    return getattr(fastembed_common, name)
 
 
 T = TypeVar("T")
@@ -30,19 +38,15 @@ class Embedder:
     def __init__(
         self, threads: int | None = None, use_core_bm25: bool = True, **kwargs: Any
     ) -> None:
-        self.embedding_models: dict[str, list[ModelInstance[TextEmbedding]]] = defaultdict(list)
-        self.sparse_embedding_models: dict[str, list[ModelInstance[SparseTextEmbedding]]] = (
-            defaultdict(list)
-        )
-        self.late_interaction_embedding_models: dict[
-            str, list[ModelInstance[LateInteractionTextEmbedding]]
-        ] = defaultdict(list)
-        self.image_embedding_models: dict[str, list[ModelInstance[ImageEmbedding]]] = defaultdict(
+        self.embedding_models: dict[str, list[ModelInstance[Any]]] = defaultdict(list)
+        self.sparse_embedding_models: dict[str, list[ModelInstance[Any]]] = defaultdict(list)
+        self.late_interaction_embedding_models: dict[str, list[ModelInstance[Any]]] = defaultdict(
             list
         )
-        self.late_interaction_multimodal_embedding_models: dict[
-            str, list[ModelInstance[LateInteractionMultimodalEmbedding]]
-        ] = defaultdict(list)
+        self.image_embedding_models: dict[str, list[ModelInstance[Any]]] = defaultdict(list)
+        self.late_interaction_multimodal_embedding_models: dict[str, list[ModelInstance[Any]]] = (
+            defaultdict(list)
+        )
         self._threads = threads
         self._use_core_bm25 = use_core_bm25
 
@@ -56,7 +60,7 @@ class Embedder:
         device_ids: list[int] | None = None,
         deprecated: bool = False,
         **kwargs: Any,
-    ) -> TextEmbedding:
+    ) -> "TextEmbedding":
         if not FastEmbedMisc.is_supported_text_model(model_name):
             raise ValueError(
                 f"Unsupported embedding model: {model_name}. Supported models: {FastEmbedMisc.list_text_models()}"
@@ -75,8 +79,9 @@ class Embedder:
             ):
                 return instance.model
 
-        model = TextEmbedding(model_name=model_name, **options)
-        model_instance: ModelInstance[TextEmbedding] = ModelInstance(
+        text_embedding = _fastembed_symbol("TextEmbedding")
+        model = text_embedding(model_name=model_name, **options)
+        model_instance: ModelInstance[Any] = ModelInstance(
             model=model, options=options, deprecated=deprecated
         )
         self.embedding_models[model_name].append(model_instance)
@@ -92,7 +97,7 @@ class Embedder:
         device_ids: list[int] | None = None,
         deprecated: bool = False,
         **kwargs: Any,
-    ) -> SparseTextEmbedding:
+    ) -> "SparseTextEmbedding":
         if not FastEmbedMisc.is_supported_sparse_model(model_name):
             raise ValueError(
                 f"Unsupported embedding model: {model_name}. Supported models: {FastEmbedMisc.list_sparse_models()}"
@@ -113,8 +118,9 @@ class Embedder:
             ):
                 return instance.model
 
-        model = SparseTextEmbedding(model_name=model_name, **options)
-        model_instance: ModelInstance[SparseTextEmbedding] = ModelInstance(
+        sparse_text_embedding = _fastembed_symbol("SparseTextEmbedding")
+        model = sparse_text_embedding(model_name=model_name, **options)
+        model_instance: ModelInstance[Any] = ModelInstance(
             model=model, options=options, deprecated=deprecated
         )
         self.sparse_embedding_models[model_name].append(model_instance)
@@ -129,7 +135,7 @@ class Embedder:
         cuda: bool = False,
         device_ids: list[int] | None = None,
         **kwargs: Any,
-    ) -> LateInteractionTextEmbedding:
+    ) -> "LateInteractionTextEmbedding":
         if not FastEmbedMisc.is_supported_late_interaction_text_model(model_name):
             raise ValueError(
                 f"Unsupported embedding model: {model_name}. "
@@ -148,8 +154,9 @@ class Embedder:
             if instance.options == options:
                 return instance.model
 
-        model = LateInteractionTextEmbedding(model_name=model_name, **options)
-        model_instance: ModelInstance[LateInteractionTextEmbedding] = ModelInstance(
+        late_interaction_text_embedding = _fastembed_symbol("LateInteractionTextEmbedding")
+        model = late_interaction_text_embedding(model_name=model_name, **options)
+        model_instance: ModelInstance[Any] = ModelInstance(
             model=model, options=options
         )
         self.late_interaction_embedding_models[model_name].append(model_instance)
@@ -164,7 +171,7 @@ class Embedder:
         cuda: bool = False,
         device_ids: list[int] | None = None,
         **kwargs: Any,
-    ) -> LateInteractionMultimodalEmbedding:
+    ) -> "LateInteractionMultimodalEmbedding":
         if not FastEmbedMisc.is_supported_late_interaction_multimodal_model(model_name):
             raise ValueError(
                 f"Unsupported embedding model: {model_name}. "
@@ -183,8 +190,9 @@ class Embedder:
             if instance.options == options:
                 return instance.model
 
-        model = LateInteractionMultimodalEmbedding(model_name=model_name, **options)
-        model_instance: ModelInstance[LateInteractionMultimodalEmbedding] = ModelInstance(
+        late_interaction_multimodal_embedding = _fastembed_symbol("LateInteractionMultimodalEmbedding")
+        model = late_interaction_multimodal_embedding(model_name=model_name, **options)
+        model_instance: ModelInstance[Any] = ModelInstance(
             model=model, options=options
         )
         self.late_interaction_multimodal_embedding_models[model_name].append(model_instance)
@@ -199,7 +207,7 @@ class Embedder:
         cuda: bool = False,
         device_ids: list[int] | None = None,
         **kwargs: Any,
-    ) -> ImageEmbedding:
+    ) -> "ImageEmbedding":
         if not FastEmbedMisc.is_supported_image_model(model_name):
             raise ValueError(
                 f"Unsupported embedding model: {model_name}. Supported models: {FastEmbedMisc.list_image_models()}"
@@ -217,8 +225,9 @@ class Embedder:
             if instance.options == options:
                 return instance.model
 
-        model = ImageEmbedding(model_name=model_name, **options)
-        model_instance: ModelInstance[ImageEmbedding] = ModelInstance(model=model, options=options)
+        image_embedding = _fastembed_symbol("ImageEmbedding")
+        model = image_embedding(model_name=model_name, **options)
+        model_instance: ModelInstance[Any] = ModelInstance(model=model, options=options)
         self.image_embedding_models[model_name].append(model_instance)
         return model
 
@@ -226,7 +235,7 @@ class Embedder:
         self,
         model_name: str,
         texts: list[str] | None = None,
-        images: list[ImageInput] | None = None,
+        images: list[Any] | None = None,
         options: dict[str, Any] | None = None,
         is_query: bool = False,
         batch_size: int = 8,
@@ -367,7 +376,7 @@ class Embedder:
 
     def _embed_late_interaction_multimodal_image(
         self,
-        images: list[ImageInput],
+        images: list[Any],
         model_name: str,
         options: dict[str, Any] | None,
         batch_size: int,
@@ -382,7 +391,7 @@ class Embedder:
 
     def _embed_dense_image(
         self,
-        images: list[ImageInput],
+        images: list[Any],
         model_name: str,
         options: dict[str, Any] | None,
         batch_size: int,

--- a/qdrant_client/embed/model_embedder.py
+++ b/qdrant_client/embed/model_embedder.py
@@ -52,8 +52,14 @@ class ModelEmbedder:
         self._embed_storage: dict[str, list[NumericVector] | list[models.Document]] = {}
         self._embed_inspector = InspectorEmbed(parser=parser)
         self._is_builtin_embedder_available = not is_local_mode
-        self._fastembed_available = FastEmbedMisc.is_installed()
+        self._fastembed_available: bool | None = None
         self.embedder = Embedder(use_core_bm25=self._is_builtin_embedder_available, **kwargs)
+
+    @property
+    def fastembed_available(self) -> bool:
+        if self._fastembed_available is None:
+            self._fastembed_available = FastEmbedMisc.is_installed()
+        return self._fastembed_available
 
     def embed_models(
         self,

--- a/qdrant_client/fastembed_common.py
+++ b/qdrant_client/fastembed_common.py
@@ -5,23 +5,43 @@ from pydantic import BaseModel, Field
 from qdrant_client.conversions.common_types import SparseVector
 from qdrant_client.http import models
 
-try:
-    from fastembed import (
-        TextEmbedding,
-        SparseTextEmbedding,
-        ImageEmbedding,
-        LateInteractionTextEmbedding,
-        LateInteractionMultimodalEmbedding,
-    )
-    from fastembed.common import OnnxProvider, ImageInput
-except ImportError:
-    TextEmbedding = None
-    SparseTextEmbedding = None
-    ImageEmbedding = None
-    LateInteractionTextEmbedding = None
-    LateInteractionMultimodalEmbedding = None
-    OnnxProvider = None
-    ImageInput = None
+_FASTEMBED_CLASSES: dict[str, Any] = {}
+_FASTEMBED_CHECKED = False
+
+
+def _load_fastembed_classes() -> None:
+    global _FASTEMBED_CHECKED
+    if _FASTEMBED_CHECKED:
+        return
+    _FASTEMBED_CHECKED = True
+    try:
+        from fastembed import (
+            ImageEmbedding,
+            LateInteractionMultimodalEmbedding,
+            LateInteractionTextEmbedding,
+            SparseTextEmbedding,
+            TextEmbedding,
+        )
+        from fastembed.common import ImageInput, OnnxProvider
+
+        _FASTEMBED_CLASSES.update(
+            {
+                "TextEmbedding": TextEmbedding,
+                "SparseTextEmbedding": SparseTextEmbedding,
+                "ImageEmbedding": ImageEmbedding,
+                "LateInteractionTextEmbedding": LateInteractionTextEmbedding,
+                "LateInteractionMultimodalEmbedding": LateInteractionMultimodalEmbedding,
+                "OnnxProvider": OnnxProvider,
+                "ImageInput": ImageInput,
+            }
+        )
+    except ImportError:
+        pass
+
+
+def _fastembed_class(name: str) -> Any:
+    _load_fastembed_classes()
+    return _FASTEMBED_CLASSES.get(name)
 
 
 class QueryResponse(BaseModel, extra="forbid"):  # type: ignore
@@ -47,31 +67,19 @@ class FastEmbedMisc:
             return cls.IS_INSTALLED
 
         try:
-            from fastembed import (
-                SparseTextEmbedding,
-                TextEmbedding,
-                ImageEmbedding,
-                LateInteractionMultimodalEmbedding,
-                LateInteractionTextEmbedding,
-            )
-
-            assert len(SparseTextEmbedding.list_supported_models()) > 0
-            assert len(TextEmbedding.list_supported_models()) > 0
-            assert len(ImageEmbedding.list_supported_models()) > 0
-            assert len(LateInteractionTextEmbedding.list_supported_models()) > 0
-            assert len(LateInteractionMultimodalEmbedding.list_supported_models()) > 0
-            cls.IS_INSTALLED = True
+            import fastembed  # noqa: F401, PLC0415
         except ImportError:
             cls.IS_INSTALLED = False
+        else:
+            cls.IS_INSTALLED = True
 
         return cls.IS_INSTALLED
 
     @classmethod
     def import_fastembed(cls) -> None:
-        if cls.IS_INSTALLED:
+        if cls.is_installed():
             return
 
-        # If it's not, ask the user to install it
         raise ImportError(
             "fastembed is not installed."
             " Please install it to compute embedding for document implicitly with `pip install fastembed`."
@@ -79,111 +87,58 @@ class FastEmbedMisc:
 
     @classmethod
     def list_text_models(cls) -> dict[str, tuple[int, models.Distance]]:
-        """Lists the supported dense text models.
-
-        Requires invocation of TextEmbedding.list_supported_models() to support custom models.
-
-        Returns:
-            dict[str, tuple[int, models.Distance]]: A dict of model names, their dimensions and distance metrics.
-        """
-        return (
-            {
-                model["model"]: (model["dim"], models.Distance.COSINE)
-                for model in TextEmbedding.list_supported_models()
-            }
-            if TextEmbedding
-            else {}
-        )
+        text_embedding = _fastembed_class("TextEmbedding")
+        if text_embedding is None:
+            return {}
+        return {
+            model["model"]: (model["dim"], models.Distance.COSINE)
+            for model in text_embedding.list_supported_models()
+        }
 
     @classmethod
     def list_image_models(cls) -> dict[str, tuple[int, models.Distance]]:
-        """Lists the supported image dense models.
-
-        Custom image models are not supported yet, but calls to ImageEmbedding.list_supported_models() is done each
-        time in order for preserving the same style as with TextEmbedding.
-
-        Returns:
-            dict[str, tuple[int, models.Distance]]: A dict of model names, their dimensions and distance metrics.
-        """
-        return (
-            {
-                model["model"]: (model["dim"], models.Distance.COSINE)
-                for model in ImageEmbedding.list_supported_models()
-            }
-            if ImageEmbedding
-            else {}
-        )
+        image_embedding = _fastembed_class("ImageEmbedding")
+        if image_embedding is None:
+            return {}
+        return {
+            model["model"]: (model["dim"], models.Distance.COSINE)
+            for model in image_embedding.list_supported_models()
+        }
 
     @classmethod
     def list_late_interaction_text_models(cls) -> dict[str, tuple[int, models.Distance]]:
-        """Lists the supported late interaction text models.
-
-        Custom late interaction models are not supported yet, but calls to
-        LateInteractionTextEmbedding.list_supported_models()
-        is done each time in order for preserving the same style as with TextEmbedding.
-
-        Returns:
-            dict[str, tuple[int, models.Distance]]: A dict of model names, their dimensions and distance metrics.
-        """
-        return (
-            {
-                model["model"]: (model["dim"], models.Distance.COSINE)
-                for model in LateInteractionTextEmbedding.list_supported_models()
-            }
-            if LateInteractionTextEmbedding
-            else {}
-        )
+        late_interaction = _fastembed_class("LateInteractionTextEmbedding")
+        if late_interaction is None:
+            return {}
+        return {
+            model["model"]: (model["dim"], models.Distance.COSINE)
+            for model in late_interaction.list_supported_models()
+        }
 
     @classmethod
     def list_late_interaction_multimodal_models(cls) -> dict[str, tuple[int, models.Distance]]:
-        """Lists the supported late interaction multimodal models.
-
-        Custom late interaction multimodal models are not supported yet, but calls to
-        LateInteractionMultimodalEmbedding.list_supported_models()
-        is done each time in order for preserving the same style as with TextEmbedding.
-
-        Returns:
-            dict[str, tuple[int, models.Distance]]: A dict of model names, their dimensions and distance metrics.
-        """
-        return (
-            {
-                model["model"]: (model["dim"], models.Distance.COSINE)
-                for model in LateInteractionMultimodalEmbedding.list_supported_models()
-            }
-            if LateInteractionMultimodalEmbedding
-            else {}
-        )
+        late_interaction = _fastembed_class("LateInteractionMultimodalEmbedding")
+        if late_interaction is None:
+            return {}
+        return {
+            model["model"]: (model["dim"], models.Distance.COSINE)
+            for model in late_interaction.list_supported_models()
+        }
 
     @classmethod
     def list_sparse_models(cls) -> dict[str, dict[str, Any]]:
-        """Lists the supported sparse models.
-
-        Custom sparse models are not supported yet, but calls to
-        SparseTextEmbedding.list_supported_models()
-        is done each time in order for preserving the same style as with TextEmbedding.
-
-        Returns:
-            dict[str, dict[str, Any]]: A dict of model names and their descriptions.
-        """
-        descriptions = {}
-        if SparseTextEmbedding:
-            for description in SparseTextEmbedding.list_supported_models():
-                descriptions[description.pop("model")] = description
+        sparse_embedding = _fastembed_class("SparseTextEmbedding")
+        if sparse_embedding is None:
+            return {}
+        descriptions: dict[str, dict[str, Any]] = {}
+        for description in sparse_embedding.list_supported_models():
+            descriptions[description.pop("model")] = description
         return descriptions
 
     @classmethod
     def is_supported_text_model(cls, model_name: str) -> bool:
-        """Checks if the model is supported by fastembed.
-
-        Args:
-            model_name (str): The name of the model to check.
-
-        Returns:
-            bool: True if the model is supported, False otherwise.
-        """
         if model_name.lower() in cls._TEXT_MODELS:
             return True
-        # update cached list in case custom models were added
         cls._TEXT_MODELS = {model.lower() for model in cls.list_text_models()}
         if model_name.lower() in cls._TEXT_MODELS:
             return True
@@ -191,17 +146,8 @@ class FastEmbedMisc:
 
     @classmethod
     def is_supported_image_model(cls, model_name: str) -> bool:
-        """Checks if the model is supported by fastembed.
-
-        Args:
-            model_name (str): The name of the model to check.
-
-        Returns:
-            bool: True if the model is supported, False otherwise.
-        """
         if model_name.lower() in cls._IMAGE_MODELS:
             return True
-        # update cached list in case custom models were added
         cls._IMAGE_MODELS = {model.lower() for model in cls.list_image_models()}
         if model_name.lower() in cls._IMAGE_MODELS:
             return True
@@ -209,17 +155,8 @@ class FastEmbedMisc:
 
     @classmethod
     def is_supported_late_interaction_text_model(cls, model_name: str) -> bool:
-        """Checks if the model is supported by fastembed.
-
-        Args:
-            model_name (str): The name of the model to check.
-
-        Returns:
-            bool: True if the model is supported, False otherwise.
-        """
         if model_name.lower() in cls._LATE_INTERACTION_TEXT_MODELS:
             return True
-        # update cached list in case custom models were added
         cls._LATE_INTERACTION_TEXT_MODELS = {
             model.lower() for model in cls.list_late_interaction_text_models()
         }
@@ -229,17 +166,8 @@ class FastEmbedMisc:
 
     @classmethod
     def is_supported_late_interaction_multimodal_model(cls, model_name: str) -> bool:
-        """Checks if the model is supported by fastembed.
-
-        Args:
-            model_name (str): The name of the model to check.
-
-        Returns:
-            bool: True if the model is supported, False otherwise.
-        """
         if model_name.lower() in cls._LATE_INTERACTION_MULTIMODAL_MODELS:
             return True
-        # update cached list in case custom models were added
         cls._LATE_INTERACTION_MULTIMODAL_MODELS = {
             model.lower() for model in cls.list_late_interaction_multimodal_models()
         }
@@ -249,17 +177,8 @@ class FastEmbedMisc:
 
     @classmethod
     def is_supported_sparse_model(cls, model_name: str) -> bool:
-        """Checks if the model is supported by fastembed.
-
-        Args:
-            model_name (str): The name of the model to check.
-
-        Returns:
-            bool: True if the model is supported, False otherwise.
-        """
         if model_name.lower() in cls._SPARSE_MODELS:
             return True
-        # update cached list in case custom models were added
         cls._SPARSE_MODELS = {model.lower() for model in cls.list_sparse_models()}
         if model_name.lower() in cls._SPARSE_MODELS:
             return True
@@ -269,55 +188,67 @@ class FastEmbedMisc:
 # region deprecated
 # prefer using methods builtin into QdrantClient, e.g. list_supported_text_models, list_supported_idf_models, etc.
 
-SUPPORTED_EMBEDDING_MODELS: dict[str, tuple[int, models.Distance]] = (
-    {
-        model["model"]: (model["dim"], models.Distance.COSINE)
-        for model in TextEmbedding.list_supported_models()
-    }
-    if TextEmbedding
-    else {}
-)
 
-SUPPORTED_SPARSE_EMBEDDING_MODELS: dict[str, dict[str, Any]] = (
-    {model["model"]: model for model in SparseTextEmbedding.list_supported_models()}
-    if SparseTextEmbedding
-    else {}
-)
+def _supported_embedding_models() -> dict[str, tuple[int, models.Distance]]:
+    return FastEmbedMisc.list_text_models()
 
-IDF_EMBEDDING_MODELS: set[str] = (
-    {
+
+def _supported_sparse_embedding_models() -> dict[str, dict[str, Any]]:
+    sparse_embedding = _fastembed_class("SparseTextEmbedding")
+    if sparse_embedding is None:
+        return {}
+    return {model["model"]: model for model in sparse_embedding.list_supported_models()}
+
+
+def _idf_embedding_models() -> set[str]:
+    sparse_embedding = _fastembed_class("SparseTextEmbedding")
+    if sparse_embedding is None:
+        return set()
+    return {
         model_config["model"]
-        for model_config in SparseTextEmbedding.list_supported_models()
+        for model_config in sparse_embedding.list_supported_models()
         if model_config.get("requires_idf", None)
     }
-    if SparseTextEmbedding
-    else set()
-)
 
-_LATE_INTERACTION_EMBEDDING_MODELS: dict[str, tuple[int, models.Distance]] = (
-    {
-        model["model"]: (model["dim"], models.Distance.COSINE)
-        for model in LateInteractionTextEmbedding.list_supported_models()
-    }
-    if LateInteractionTextEmbedding
-    else {}
-)
 
-_IMAGE_EMBEDDING_MODELS: dict[str, tuple[int, models.Distance]] = (
-    {
-        model["model"]: (model["dim"], models.Distance.COSINE)
-        for model in ImageEmbedding.list_supported_models()
-    }
-    if ImageEmbedding
-    else {}
-)
+def _late_interaction_embedding_models() -> dict[str, tuple[int, models.Distance]]:
+    return FastEmbedMisc.list_late_interaction_text_models()
 
-_LATE_INTERACTION_MULTIMODAL_EMBEDDING_MODELS: dict[str, tuple[int, models.Distance]] = (
-    {
-        model["model"]: (model["dim"], models.Distance.COSINE)
-        for model in LateInteractionMultimodalEmbedding.list_supported_models()
-    }
-    if LateInteractionMultimodalEmbedding
-    else {}
-)
+
+def _image_embedding_models() -> dict[str, tuple[int, models.Distance]]:
+    return FastEmbedMisc.list_image_models()
+
+
+def _late_interaction_multimodal_embedding_models() -> dict[str, tuple[int, models.Distance]]:
+    return FastEmbedMisc.list_late_interaction_multimodal_models()
+
+
+_LAZY_MODULE_ATTRS: dict[str, Any] = {
+    "TextEmbedding": lambda: _fastembed_class("TextEmbedding"),
+    "SparseTextEmbedding": lambda: _fastembed_class("SparseTextEmbedding"),
+    "ImageEmbedding": lambda: _fastembed_class("ImageEmbedding"),
+    "LateInteractionTextEmbedding": lambda: _fastembed_class("LateInteractionTextEmbedding"),
+    "LateInteractionMultimodalEmbedding": lambda: _fastembed_class(
+        "LateInteractionMultimodalEmbedding"
+    ),
+    "OnnxProvider": lambda: _fastembed_class("OnnxProvider"),
+    "ImageInput": lambda: _fastembed_class("ImageInput"),
+    "SUPPORTED_EMBEDDING_MODELS": _supported_embedding_models,
+    "SUPPORTED_SPARSE_EMBEDDING_MODELS": _supported_sparse_embedding_models,
+    "IDF_EMBEDDING_MODELS": _idf_embedding_models,
+    "_LATE_INTERACTION_EMBEDDING_MODELS": _late_interaction_embedding_models,
+    "_IMAGE_EMBEDDING_MODELS": _image_embedding_models,
+    "_LATE_INTERACTION_MULTIMODAL_EMBEDDING_MODELS": _late_interaction_multimodal_embedding_models,
+}
+
+
+def __getattr__(name: str) -> object:
+    factory = _LAZY_MODULE_ATTRS.get(name)
+    if factory is not None:
+        result = factory()
+        globals()[name] = result
+        return result
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)
+
 # endregion

--- a/qdrant_client/models/__init__.py
+++ b/qdrant_client/models/__init__.py
@@ -1,3 +1,6 @@
 from qdrant_client.http.models import *
-from qdrant_client.fastembed_common import *
 from qdrant_client.embed.models import *
+
+# FastEmbed / inference symbols live in qdrant_client.fastembed_common and are
+# intentionally not re-exported here so HTTP-only clients (filters, upsert with
+# precomputed vectors) stay lightweight when fastembed is installed transitively.

--- a/qdrant_client/qdrant_fastembed.py
+++ b/qdrant_client/qdrant_fastembed.py
@@ -1,6 +1,6 @@
 import uuid
 from itertools import tee
-from typing import Any, Iterable, Sequence, get_args
+from typing import Any, Iterable, Sequence, TYPE_CHECKING, get_args
 from copy import deepcopy
 
 import numpy as np
@@ -17,16 +17,10 @@ from qdrant_client.conversions.conversion import GrpcToRest
 from qdrant_client.embed.common import INFERENCE_OBJECT_TYPES
 from qdrant_client.embed.schema_parser import ModelSchemaParser
 from qdrant_client.hybrid.fusion import reciprocal_rank_fusion
-from qdrant_client.fastembed_common import FastEmbedMisc, OnnxProvider
+from qdrant_client.fastembed_common import FastEmbedMisc, QueryResponse
 
-# region imports used in deprecated methods
-from qdrant_client.fastembed_common import (
-    QueryResponse,
-    TextEmbedding,
-    SparseTextEmbedding,
-    IDF_EMBEDDING_MODELS,
-)
-# endregion
+if TYPE_CHECKING:
+    from qdrant_client.fastembed_common import OnnxProvider, SparseTextEmbedding, TextEmbedding
 
 
 class QdrantFastembedMixin(QdrantBase):
@@ -34,8 +28,13 @@ class QdrantFastembedMixin(QdrantBase):
     DEFAULT_BATCH_SIZE = 8
     _FASTEMBED_INSTALLED: bool
 
+    @staticmethod
+    def _idf_embedding_models() -> set[str]:
+        from qdrant_client.fastembed_common import IDF_EMBEDDING_MODELS
+
+        return IDF_EMBEDDING_MODELS
+
     def __init__(self, parser: ModelSchemaParser, is_local_mode: bool):
-        self.__class__._FASTEMBED_INSTALLED = FastEmbedMisc.is_installed()
         self._embedding_model_name: str | None = None
         self._sparse_embedding_model_name: str | None = None
 
@@ -430,7 +429,7 @@ class QdrantFastembedMixin(QdrantBase):
             assert (
                 sparse_vector_field_name in collection_info.config.params.sparse_vectors
             ), f"Collection have incompatible vector params: {collection_info.config.params.vectors}"
-            if self.sparse_embedding_model_name in IDF_EMBEDDING_MODELS:
+            if self.sparse_embedding_model_name in self._idf_embedding_models():
                 modifier = collection_info.config.params.sparse_vectors[
                     sparse_vector_field_name
                 ].modifier
@@ -502,7 +501,7 @@ class QdrantFastembedMixin(QdrantBase):
             Configuration for `vectors_config` argument in `create_collection` method.
         """
         vector_field_name = self.get_sparse_vector_field_name()
-        if self.sparse_embedding_model_name in IDF_EMBEDDING_MODELS:
+        if self.sparse_embedding_model_name in self._idf_embedding_models():
             modifier = models.Modifier.IDF if modifier is None else modifier
 
         if vector_field_name is None:

--- a/tests/test_import_lightweight.py
+++ b/tests/test_import_lightweight.py
@@ -1,0 +1,50 @@
+"""Regression tests: HTTP-only imports must stay lightweight when fastembed is installed."""
+
+import subprocess
+import sys
+
+
+def _run_import_snippet(snippet: str) -> set[str]:
+    code = f"""
+import sys
+{snippet}
+heavy = [m for m in ("fastembed", "onnxruntime", "torch") if m in sys.modules]
+print(",".join(heavy))
+"""
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    loaded = proc.stdout.strip()
+    return set(loaded.split(",")) if loaded else set()
+
+
+def test_http_models_import_is_lightweight() -> None:
+    loaded = _run_import_snippet(
+        """
+from qdrant_client.http import models as qmodels
+_ = qmodels.Filter(must=[])
+"""
+    )
+    assert loaded == set()
+
+
+def test_models_import_is_lightweight() -> None:
+    loaded = _run_import_snippet(
+        """
+from qdrant_client import models as qmodels
+_ = qmodels.Filter(must=[])
+"""
+    )
+    assert loaded == set()
+
+
+def test_package_submodule_import_without_client() -> None:
+    loaded = _run_import_snippet(
+        """
+import qdrant_client.http.models as _models
+"""
+    )
+    assert loaded == set()


### PR DESCRIPTION
## Summary

Fixes #1252 — HTTP-only usages (filters, upsert with precomputed vectors) no longer load `fastembed`/ONNX at import time when FastEmbed is installed transitively.

## Changes

- Remove `fastembed_common` re-export from `qdrant_client.models`
- Lazy-load FastEmbed classes and deprecated constants in `fastembed_common.py`
- Defer `QdrantClient` / `AsyncQdrantClient` exports via `__getattr__` in package `__init__.py`
- Stop calling `FastEmbedMisc.is_installed()` in client mixin `__init__`
- Lazy FastEmbed symbol access in `embed/embedder.py`
- Subprocess regression tests (`tests/test_import_lightweight.py`)

## Measurements (WellChat prod-like env, fastembed installed)

| Import | Before (1.18.0) | After |
|--------|-----------------|-------|
| `qdrant_client.http.models` | +111 MiB, fastembed loaded | +45 MiB, no fastembed |
| `from qdrant_client import models` | +111 MiB, fastembed loaded | +45 MiB, no fastembed |
| `QdrantClient(...)` | +113 MiB, fastembed loaded | +79 MiB, no fastembed |

## Breaking change (soft)

Deprecated FastEmbed constants (`SUPPORTED_EMBEDDING_MODELS`, etc.) are no longer re-exported from `qdrant_client.models`. Import from `qdrant_client.fastembed_common` or use client list methods.

Continues work started in #994.

## Test plan

- [x] `pytest tests/test_import_lightweight.py`
- [ ] Full upstream CI

Made with [Cursor](https://cursor.com)