### PR TITLE
Fix TypeError in check_match when MatchText is applied to a non-string value

### DIFF
--- a/qdrant_client/local/payload_filters.py
+++ b/qdrant_client/local/payload_filters.py
@@ -150,9 +150,9 @@ def check_match(condition: models.Match, value: Any) -> bool:
     if isinstance(condition, models.MatchValue):
         return value == condition.value
     if isinstance(condition, models.MatchText):
-        return value is not None and condition.text in value
+        return isinstance(value, str) and condition.text in value
     if isinstance(condition, models.MatchTextAny):
-        return value is not None and any(word in value for word in condition.text_any.split())
+        return isinstance(value, str) and any(word in value for word in condition.text_any.split())
     if isinstance(condition, models.MatchAny):
         return value in condition.any
     if isinstance(condition, models.MatchExcept):

--- a/tests/test_payload_filters.py
+++ b/tests/test_payload_filters.py
@@ -1,0 +1,18 @@
+from qdrant_client import models
+from qdrant_client.local.payload_filters import check_match
+
+
+def test_match_text_on_non_string_value_does_not_crash():
+    # Mixed payload types on the same key must not crash MatchText / MatchTextAny.
+    # https://github.com/qdrant/qdrant-client/issues/1221
+    assert check_match(models.MatchText(text="42"), 42) is False
+    assert check_match(models.MatchTextAny(text_any="42"), 42) is False
+    assert check_match(models.MatchText(text="x"), None) is False
+    assert check_match(models.MatchTextAny(text_any="x"), None) is False
+
+
+def test_match_text_still_matches_strings():
+    assert check_match(models.MatchText(text="ell"), "hello") is True
+    assert check_match(models.MatchText(text="zzz"), "hello") is False
+    assert check_match(models.MatchTextAny(text_any="foo hello"), "hello world") is True
+    assert check_match(models.MatchTextAny(text_any="foo bar"), "hello world") is False


### PR DESCRIPTION
Closes #1221.

`check_match` guarded the payload value with `value is not None` before evaluating `condition.text in value` for `MatchText` / `MatchTextAny`. On a key with mixed payload types (e.g. one point stores `count: 42`, another `count: "hello"`), a text filter over the integer value reaches `"42" in 42` and raises `TypeError: argument of type 'int' is not iterable`, crashing the query in local mode.

Text matching is only meaningful for strings, so this guards with `isinstance(value, str)`: a `MatchText`/`MatchTextAny` filter over a non-string value now simply does not match instead of crashing. String matching behavior is unchanged.

Reproducer from the issue:

```python
from qdrant_client import QdrantClient, models
c = QdrantClient(":memory:")
c.create_collection("t", vectors_config=models.VectorParams(size=2, distance=models.Distance.DOT))
c.upsert("t", points=[
    models.PointStruct(id=1, vector=[1.0, 0.0], payload={"count": 42}),
    models.PointStruct(id=2, vector=[0.0, 1.0], payload={"name": "hello"}),
])
c.query_points("t", query=[1.0, 0.0],
    query_filter=models.Filter(must=[models.FieldCondition(key="count", match=models.MatchText(text="42"))]))
# before: TypeError; after: returns without error
```

Added `tests/test_payload_filters.py` covering the non-string case (no crash) and confirming string matching still works.
