### PR TITLE
ci: add package sanity check and stop shipping test files (#958)

### DIFF
--- a/.github/workflows/package-sanity.yml
+++ b/.github/workflows/package-sanity.yml
@@ -1,0 +1,27 @@
+name: package-sanity
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    name: Check built package contents
+
+    steps:
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+
+      - name: Set up Python
+        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip poetry
+
+      - name: Build package
+        run: poetry build
+
+      - name: Check package contents
+        run: python tools/check_package_contents.py dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,13 @@ authors = ["Andrey Vasnetsov <andrey@qdrant.tech>"]
 packages = [
     {include = "qdrant_client"}
 ]
+# Test-only code must not ship in the published wheel/sdist. It stays in the
+# source tree (and is still collected by pytest), but importing the client in a
+# clean environment must never pull in pytest. See tools/check_package_contents.py.
+exclude = [
+    "qdrant_client/**/tests",
+    "qdrant_client/**/test_*.py",
+]
 license = "Apache-2.0"
 readme = "README.md"
 homepage = "https://github.com/qdrant/qdrant-client"

--- a/tools/check_package_contents.py
+++ b/tools/check_package_contents.py
@@ -1,0 +1,127 @@
+"""Sanity check for built distributions.
+
+Guards against test-only code (and its dependencies, e.g. ``pytest``) leaking
+into the published ``qdrant_client`` package. This has previously caused broken
+releases where importing the client in a clean environment failed because a
+shipped module tried to ``import pytest``.
+
+The check inspects the built wheel and sdist in a distribution directory
+(default: ``dist``) and fails if any shipped Python module either:
+
+* lives in a test location (a ``tests`` package or a ``test_*.py`` module), or
+* imports a test-only dependency such as ``pytest``.
+
+Run it after ``poetry build``::
+
+    python tools/check_package_contents.py
+
+Optionally pass one or more distribution directories or files as arguments.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+from typing import Iterable, Iterator
+
+# Modules that must never be importable from the published package.
+FORBIDDEN_IMPORTS: tuple[str, ...] = ("pytest", "_pytest")
+
+# Match ``import pytest`` / ``from pytest import ...`` at the start of a line.
+_IMPORT_RE = re.compile(
+    r"^\s*(?:import|from)\s+(" + "|".join(map(re.escape, FORBIDDEN_IMPORTS)) + r")\b",
+    re.MULTILINE,
+)
+
+
+def _is_test_module(path: str) -> bool:
+    """Return True if a shipped file path looks like test-only code."""
+    parts = path.split("/")
+    if any(part == "tests" for part in parts):
+        return True
+    name = parts[-1]
+    return name.startswith("test_") and name.endswith(".py")
+
+
+def _forbidden_import(source: str) -> str | None:
+    """Return the first forbidden import found in the source, if any."""
+    match = _IMPORT_RE.search(source)
+    return match.group(1) if match else None
+
+
+def _iter_python_files(dist: Path) -> Iterator[tuple[str, str]]:
+    """Yield ``(member_path, source)`` for every ``.py`` file in a distribution."""
+    if dist.suffix == ".whl":
+        with zipfile.ZipFile(dist) as archive:
+            for name in archive.namelist():
+                if name.endswith(".py"):
+                    yield name, archive.read(name).decode("utf-8", "replace")
+    elif dist.name.endswith(".tar.gz"):
+        with tarfile.open(dist, "r:gz") as archive:
+            for member in archive.getmembers():
+                if member.isfile() and member.name.endswith(".py"):
+                    handle = archive.extractfile(member)
+                    if handle is not None:
+                        yield member.name, handle.read().decode("utf-8", "replace")
+
+
+def _resolve_distributions(targets: Iterable[str]) -> list[Path]:
+    """Expand the given paths into a list of wheel/sdist files."""
+    dists: list[Path] = []
+    for target in targets:
+        path = Path(target)
+        if path.is_dir():
+            dists.extend(sorted(path.glob("*.whl")))
+            dists.extend(sorted(path.glob("*.tar.gz")))
+        elif path.is_file():
+            dists.append(path)
+        else:
+            raise SystemExit(f"error: no such file or directory: {target}")
+    return dists
+
+
+def check_distribution(dist: Path) -> list[str]:
+    """Return a list of problems found in a single distribution."""
+    problems: list[str] = []
+    for name, source in _iter_python_files(dist):
+        if _is_test_module(name):
+            problems.append(f"{dist.name}: ships test module '{name}'")
+        forbidden = _forbidden_import(source)
+        if forbidden is not None:
+            problems.append(f"{dist.name}: '{name}' imports '{forbidden}'")
+    return problems
+
+
+def main(argv: list[str]) -> int:
+    targets = argv[1:] or ["dist"]
+    dists = _resolve_distributions(targets)
+    if not dists:
+        raise SystemExit(
+            "error: no distributions found; run 'poetry build' first "
+            "or pass a path to a wheel/sdist"
+        )
+
+    problems: list[str] = []
+    for dist in dists:
+        problems.extend(check_distribution(dist))
+
+    if problems:
+        print("Package sanity check failed:")
+        for problem in problems:
+            print(f"  - {problem}")
+        print(
+            "\nTest-only code must not ship in the published package. "
+            "Exclude it via the 'exclude' key in pyproject.toml."
+        )
+        return 1
+
+    checked = ", ".join(dist.name for dist in dists)
+    print(f"Package sanity check passed ({checked}).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION


Closes #958.

The published wheel/sdist currently ship test modules that live inside the `qdrant_client` package. Building `1.18.0` locally and inspecting the wheel, I see:

- `qdrant_client/local/tests/*` (7 files)
- `qdrant_client/hybrid/test_reranking.py`

Three of these `import pytest` at module level, which is what makes `pytest` an effective import-time dependency of the package and causes the broken releases mentioned in the issue.

Root cause: `packages = [{include = "qdrant_client"}]` includes the whole tree, and there's no `exclude`, so anything named like a test that happens to live under `qdrant_client/` gets packaged.

### Changes

1. **Stop shipping test-only code** — added an `exclude` to `[tool.poetry]` in `pyproject.toml` for `qdrant_client/**/tests` and `qdrant_client/**/test_*.py`. This only affects the built artifacts; the files stay in the source tree and are still collected/run by `pytest`, so nothing changes for local dev or CI test runs.

2. **Guard against regressions** — the issue asks for a CI check, so I added:
   - `tools/check_package_contents.py` — stdlib-only, builds nothing itself; it inspects the wheel + sdist and fails if any shipped module is a test file or imports `pytest`/`_pytest`.
   - `.github/workflows/package-sanity.yml` — runs `poetry build` and then the check on push/PR.

A check on its own would have gone red immediately because the leak is live today, so both parts are needed together.

### Testing

- `poetry build`, then ran the checker against the resulting `dist/`:
  - Against the **current** (leaky) build → fails, listing all 7 test files + the 3 pytest imports.
  - Against the build **with the exclude** → passes.
- Confirmed the excluded files remain in the source tree and that real modules (e.g. `qdrant_client/hybrid/fusion.py`, the `qdrant_client/local` implementation) still ship — 91 Python modules in the wheel, only the test files removed.
- Interestingly the checker also flagged `qdrant_client/hybrid/test_reranking.py`, which sits outside `local/tests`; the broader exclude pattern covers it too.

Happy to adjust the exclude patterns or the workflow triggers to match your preferences.

> Note: @glenlouis8 mentioned interest in the issue a while back — apologies for any overlap, happy to defer or collaborate if they already have work in progress.
