### PR TITLE
feat(upload): optional progress callback for upload_points and upload_collection

### DIFF
--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -20,6 +20,7 @@ from qdrant_client.local.qdrant_local import QdrantLocal
 from qdrant_client.migrate import migrate
 from qdrant_client.qdrant_fastembed import QdrantFastembedMixin
 from qdrant_client.qdrant_remote import QdrantRemote
+from qdrant_client.uploader.uploader import UploadProgress
 
 
 class QdrantClient(QdrantFastembedMixin):
@@ -1875,6 +1876,7 @@ class QdrantClient(QdrantFastembedMixin):
         shard_key_selector: types.ShardKeySelector | None = None,
         update_filter: types.Filter | None = None,
         update_mode: types.UpdateMode | None = None,
+        progress_callback: Callable[[UploadProgress], None] | None = None,
         **kwargs: Any,
     ) -> None:
         """Upload points to the collection
@@ -1900,6 +1902,10 @@ class QdrantClient(QdrantFastembedMixin):
                 This parameter overwrites shard keys written in the records.
             update_filter: If specified, only points that match this filter will be updated, others will be inserted
             update_mode: Allows to alter default upsert behavior, instead of inserting a point if it does not exist, or updating it if it does, can be set to insert-only or update-only strategies.
+            progress_callback: Optional callable invoked from the main process once per
+                successfully-uploaded batch with a `UploadProgress` snapshot carrying
+                `total_uploaded` (cumulative points) and `batch_count`. When `None`
+                (default), no callback runs. Invoked once per batch regardless of `parallel`.
 
         """
 
@@ -1935,6 +1941,7 @@ class QdrantClient(QdrantFastembedMixin):
             shard_key_selector=shard_key_selector,
             update_filter=update_filter,
             update_mode=update_mode,
+            progress_callback=progress_callback,
         )
 
     def upload_collection(
@@ -1951,6 +1958,7 @@ class QdrantClient(QdrantFastembedMixin):
         shard_key_selector: types.ShardKeySelector | None = None,
         update_filter: types.Filter | None = None,
         update_mode: types.UpdateMode | None = None,
+        progress_callback: Callable[[UploadProgress], None] | None = None,
         **kwargs: Any,
     ) -> None:
         """Upload vectors and payload to the collection.
@@ -1978,6 +1986,10 @@ class QdrantClient(QdrantFastembedMixin):
                 Only works for collections with `custom` sharding method.
             update_filter: If specified, only points that match this filter will be updated, others will be inserted
             update_mode: Allows to alter default upsert behavior, instead of inserting a point if it does not exist, or updating it if it does, can be set to insert-only or update-only strategies.
+            progress_callback: Optional callable invoked from the main process once per
+                successfully-uploaded batch with a `UploadProgress` snapshot carrying
+                `total_uploaded` (cumulative points) and `batch_count`. When `None`
+                (default), no callback runs. Invoked once per batch regardless of `parallel`.
         """
 
         def chain(*iterables: Iterable) -> Iterable:
@@ -2015,6 +2027,7 @@ class QdrantClient(QdrantFastembedMixin):
             shard_key_selector=shard_key_selector,
             update_filter=update_filter,
             update_mode=update_mode,
+            progress_callback=progress_callback,
         )
 
     def create_payload_index(

--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -39,7 +39,7 @@ from qdrant_client.context_headers import rest_headers_middleware
 from qdrant_client.parallel_processor import ParallelWorkerPool
 from qdrant_client.uploader.grpc_uploader import GrpcBatchUploader
 from qdrant_client.uploader.rest_uploader import RestBatchUploader
-from qdrant_client.uploader.uploader import BaseUploader
+from qdrant_client.uploader.uploader import BaseUploader, UploadProgress
 
 
 class QdrantRemote(QdrantBase):
@@ -2171,6 +2171,7 @@ class QdrantRemote(QdrantBase):
         shard_key_selector: types.ShardKeySelector | None = None,
         update_filter: types.Filter | None = None,
         update_mode: types.UpdateMode | None = None,
+        progress_callback: Callable[[UploadProgress], None] | None = None,
     ) -> None:
         if method is not None:
             if method in get_all_start_methods():
@@ -2209,14 +2210,56 @@ class QdrantRemote(QdrantBase):
                 **self._rest_args,
             }
 
+        if progress_callback is None:
+            if parallel == 1:
+                updater = self._updater_class.start(**updater_kwargs)
+                for _ in updater.process(batches_iterator):
+                    pass
+            else:
+                pool = ParallelWorkerPool(parallel, self._updater_class, start_method=start_method)
+                for _ in pool.unordered_map(batches_iterator, **updater_kwargs):
+                    pass
+            return
+
+        # When a callback is provided, materialize batch sizes once so we can pair each
+        # worker result with the corresponding batch size without re-iterating an
+        # iterator that may be single-pass or shared with worker processes.
+        # batches are (ids_batch, vectors_batch, payload_batch); size is rows in the batch.
+        sized_batches: list[tuple[int, tuple]] = []
+        for batch in batches_iterator:
+            ids_batch, vectors_batch, _payload_batch = batch
+            size = len(ids_batch) if ids_batch is not None else len(vectors_batch)
+            sized_batches.append((size, batch))
+
+        batch_sizes = [size for size, _batch in sized_batches]
+        raw_batches = [batch for _size, batch in sized_batches]
+
         if parallel == 1:
             updater = self._updater_class.start(**updater_kwargs)
-            for _ in updater.process(batches_iterator):
-                pass
+            total_uploaded = 0
+            batch_count = 0
+            for size, result in zip(
+                batch_sizes, updater.process(raw_batches)
+            ):
+                if result:
+                    total_uploaded += size
+                    batch_count += 1
+                    progress_callback(
+                        UploadProgress(total_uploaded=total_uploaded, batch_count=batch_count)
+                    )
         else:
             pool = ParallelWorkerPool(parallel, self._updater_class, start_method=start_method)
-            for _ in pool.unordered_map(batches_iterator, **updater_kwargs):
-                pass
+            total_uploaded = 0
+            batch_count = 0
+            for size, result in zip(
+                batch_sizes, pool.unordered_map(raw_batches, **updater_kwargs)
+            ):
+                if result:
+                    total_uploaded += size
+                    batch_count += 1
+                    progress_callback(
+                        UploadProgress(total_uploaded=total_uploaded, batch_count=batch_count)
+                    )
 
     def upload_points(
         self,
@@ -2230,6 +2273,7 @@ class QdrantRemote(QdrantBase):
         shard_key_selector: types.ShardKeySelector | None = None,
         update_filter: types.Filter | None = None,
         update_mode: types.UpdateMode | None = None,
+        progress_callback: Callable[[UploadProgress], None] | None = None,
         **kwargs: Any,
     ) -> None:
         batches_iterator = self._updater_class.iterate_records_batches(
@@ -2246,6 +2290,7 @@ class QdrantRemote(QdrantBase):
             shard_key_selector=shard_key_selector,
             update_filter=update_filter,
             update_mode=update_mode,
+            progress_callback=progress_callback,
         )
 
     def upload_collection(
@@ -2262,6 +2307,7 @@ class QdrantRemote(QdrantBase):
         shard_key_selector: types.ShardKeySelector | None = None,
         update_filter: types.Filter | None = None,
         update_mode: types.UpdateMode | None = None,
+        progress_callback: Callable[[UploadProgress], None] | None = None,
         **kwargs: Any,
     ) -> None:
         batches_iterator = self._updater_class.iterate_batches(
@@ -2281,6 +2327,7 @@ class QdrantRemote(QdrantBase):
             shard_key_selector=shard_key_selector,
             update_filter=update_filter,
             update_mode=update_mode,
+            progress_callback=progress_callback,
         )
 
     def create_payload_index(

--- a/qdrant_client/uploader/uploader.py
+++ b/qdrant_client/uploader/uploader.py
@@ -1,4 +1,5 @@
 from abc import ABC
+from dataclasses import dataclass
 from itertools import count, islice
 from typing import Any, Generator, Iterable
 
@@ -8,6 +9,19 @@ from qdrant_client.conversions import common_types as types
 from qdrant_client.conversions.common_types import Record
 from qdrant_client.http.models import ExtendedPointId
 from qdrant_client.parallel_processor import Worker
+
+
+@dataclass(frozen=True, slots=True)
+class UploadProgress:
+    """Snapshot of upload progress reported to an optional progress callback.
+
+    Attributes:
+        total_uploaded: cumulative number of points accepted by the server.
+        batch_count: number of batches that have completed so far.
+    """
+
+    total_uploaded: int
+    batch_count: int
 
 
 def iter_batch(iterable: Iterable | Generator, size: int) -> Iterable:

--- a/tests/test_upload_progress.py
+++ b/tests/test_upload_progress.py
@@ -1,0 +1,214 @@
+"""Tests for the optional progress_callback parameter on
+QdrantRemote._upload_collection and the public QdrantClient uploaders.
+
+The progress callback only fires when the underlying client is a
+QdrantRemote (i.e. when uploads go through _upload_collection).
+QdrantLocal handles uploads directly and does not invoke the callback.
+"""
+
+from typing import Any, Iterable
+
+import numpy as np
+import pytest
+
+from qdrant_client import QdrantClient, models
+from qdrant_client.qdrant_remote import QdrantRemote
+from qdrant_client.uploader.uploader import UploadProgress
+
+
+def _make_remote_client(prefer_grpc: bool = False) -> QdrantClient:
+    """Construct a QdrantClient whose _client is a QdrantRemote aimed at
+    a non-existent host. Used to exercise the callback plumbing without
+    actually sending any network traffic.
+    """
+    client = QdrantClient(
+        host="127.0.0.1",
+        port=1,
+        grpc_port=1,
+        prefer_grpc=prefer_grpc,
+        check_compatibility=False,
+    )
+    client._client = QdrantRemote(host="127.0.0.1", port=1, prefer_grpc=prefer_grpc)
+    return client
+
+
+class _FakeUploaderCls:
+    """Stateful stand-in for GrpcBatchUploader / RestBatchUploader.
+
+    The class is patched in for QdrantRemote._updater_class via
+    monkeypatch. Each test stages a `results` queue; the queue is
+    consumed (in order) by every batch the fake uploader emits.
+    """
+
+    results: list[bool] = []
+
+    @classmethod
+    def start(cls, **_kwargs: Any) -> "_FakeUploaderInst":
+        return _FakeUploaderInst()
+
+
+class _FakeUploaderInst:
+    def process(self, items: Iterable[Any]) -> Iterable[bool]:
+        # Yield the staged results in order; if more items than staged,
+        # default to True so callers don't see surprising drops.
+        staged = list(_FakeUploaderCls.results) or [True]
+        yield from staged
+
+
+class _FakePool:
+    def __init__(self, num_workers, worker_class, start_method):
+        pass
+
+    def unordered_map(self, stream, **_kwargs):
+        updater_cls = _FakeUploaderCls
+        updater = updater_cls.start()
+        for result in updater.process(stream):
+            yield result
+
+
+def _patch_uploader(monkeypatch, results: list[bool]):
+    """Replace QdrantRemote._updater_class with _FakeUploaderCls and
+    optionally swap in _FakePool for parallel mode.
+    """
+    _FakeUploaderCls.results = list(results)
+    # _updater_class is a @property: assign a new property to the class.
+    monkeypatch.setattr(
+        QdrantRemote,
+        "_updater_class",
+        property(lambda _self: _FakeUploaderCls),
+    )
+
+
+def _make_batches(sizes: list[int]) -> list[tuple]:
+    """Build batches of the (ids_batch, vectors_batch, payload_batch)
+    shape consumed by _upload_collection.
+    """
+    batches: list[tuple] = []
+    for size in sizes:
+        batches.append(
+            (
+                list(range(size)),
+                [[float(i)] * 4 for i in range(size)],
+                [{} for _ in range(size)],
+            )
+        )
+    return batches
+
+
+def test_upload_progress_dataclass_is_frozen_and_hashable():
+    p = UploadProgress(total_uploaded=10, batch_count=1)
+    assert p.total_uploaded == 10
+    assert p.batch_count == 1
+    assert hash(p)  # frozen + slots => hashable
+    with pytest.raises(Exception):
+        p.total_uploaded = 5  # type: ignore[misc]
+
+
+def test_progress_callback_default_none_does_not_break_signature():
+    client = _make_remote_client()
+    client.upload_points(
+        collection_name="noop",
+        points=[],
+        progress_callback=None,
+    )
+
+
+def test_progress_callback_fires_once_per_batch(monkeypatch):
+    _patch_uploader(monkeypatch, [True, True, True, True])
+    client = _make_remote_client()
+    batches = _make_batches([64, 64, 64, 58])  # 4 batches
+
+    progress: list[UploadProgress] = []
+    client._client._upload_collection(
+        batches_iterator=batches,
+        collection_name="test",
+        max_retries=1,
+        progress_callback=lambda p: progress.append(p),
+    )
+
+    assert len(progress) == 4, f"expected 4 callbacks, got {len(progress)}"
+    assert [p.batch_count for p in progress] == [1, 2, 3, 4]
+    assert [p.total_uploaded for p in progress] == [64, 128, 192, 250]
+
+
+def test_progress_callback_skips_failed_batches(monkeypatch):
+    _patch_uploader(monkeypatch, [True, False, True, True])
+    client = _make_remote_client()
+    batches = _make_batches([10, 10, 10, 10])
+
+    progress: list[UploadProgress] = []
+    client._client._upload_collection(
+        batches_iterator=batches,
+        collection_name="test",
+        max_retries=1,
+        progress_callback=lambda p: progress.append(p),
+    )
+
+    assert [p.batch_count for p in progress] == [1, 2, 3]
+    assert [p.total_uploaded for p in progress] == [10, 20, 30]  # failed batch at idx 1 is skipped
+
+
+def test_progress_callback_parallel_path(monkeypatch):
+    _patch_uploader(monkeypatch, [True, True, True])
+    monkeypatch.setattr(
+        "qdrant_client.qdrant_remote.ParallelWorkerPool", _FakePool
+    )
+    client = _make_remote_client(prefer_grpc=True)
+    batches = _make_batches([5, 5, 5])
+
+    progress: list[UploadProgress] = []
+    client._client._upload_collection(
+        batches_iterator=batches,
+        collection_name="test",
+        max_retries=1,
+        parallel=2,
+        progress_callback=lambda p: progress.append(p),
+    )
+
+    assert len(progress) == 3
+    assert [p.batch_count for p in progress] == [1, 2, 3]
+    assert [p.total_uploaded for p in progress] == [5, 10, 15]
+
+
+def test_qdrant_client_local_mode_accepts_kwarg_without_crash():
+    """Local mode does not invoke the callback (it doesn't go through
+    _upload_collection) but must accept the kwarg without a TypeError.
+    """
+    client = QdrantClient(":memory:")
+    received: list[UploadProgress] = []
+
+    def cb(p: UploadProgress) -> None:
+        received.append(p)
+
+    client.create_collection(
+        collection_name="noop",
+        vectors_config=models.VectorParams(size=4, distance=models.Distance.COSINE),
+    )
+    client.upload_points(
+        collection_name="noop",
+        points=[
+            models.PointStruct(id=i, vector=[0.1, 0.2, 0.3, 0.4])
+            for i in range(3)
+        ],
+        batch_size=2,
+        progress_callback=cb,
+    )
+
+    assert received == []  # local mode does not invoke the callback
+
+
+def test_signature_accepts_progress_callback_kwarg():
+    """Both upload_points and upload_collection on the public facade must
+    accept progress_callback as a keyword argument.
+    """
+    client = _make_remote_client()
+    client.upload_points(
+        collection_name="t",
+        points=[],
+        progress_callback=lambda p: None,
+    )
+    client.upload_collection(
+        collection_name="t",
+        vectors=np.zeros((0, 4), dtype=np.float32),
+        progress_callback=lambda p: None,
+    )


### PR DESCRIPTION
Fixes #1262.

Adds an optional `progress_callback` keyword argument to `QdrantClient.upload_points` and `upload_collection` (and to the underlying `QdrantRemote._upload_collection`). When provided, the callback is invoked from the main process once per successfully-uploaded batch with a small `UploadProgress` dataclass that carries `total_uploaded` (cumulative points accepted) and `batch_count`. When `None` (default) the existing behavior is unchanged.

### Why

Users uploading large collections have no visibility into upload progress today. `BaseUploader.process()` already yields a `bool` per batch internally, but the public path discards it. This is the smallest surface that exposes it without changing the uploader interface.

### Usage

```python
from qdrant_client.uploader.uploader import UploadProgress

def on_progress(p: UploadProgress) -> None:
    print(f"uploaded {p.total_uploaded} points ({p.batch_count} batches)")

client.upload_points(
    collection_name="my_collection",
    points=points,
    batch_size=64,
    progress_callback=on_progress,
)
```

### Implementation notes

- `UploadProgress` is a `frozen=True, slots=True` dataclass with two `int` fields, importable from `qdrant_client.uploader.uploader`.
- `_upload_collection` materializes batch sizes once from the source iterator and zips them with the worker's results, so the callback is invoked from the main process regardless of `parallel`.
- The callback fires once per successful batch; failed batches (`result == False`) are silently skipped. Order is unordered in `parallel > 1` mode (matches existing behavior).
- Local mode (`QdrantLocal`) accepts the keyword argument for API consistency but does not invoke the callback (it doesn't go through `_upload_collection`).
- `BaseUploader` is intentionally left unchanged so the autogenerated async mirror does not need to be regenerated as part of this PR.

### Files changed

- `qdrant_client/uploader/uploader.py` — `UploadProgress` dataclass.
- `qdrant_client/qdrant_remote.py` — `_upload_collection`, `upload_points`, `upload_collection` accept `progress_callback`.
- `qdrant_client/qdrant_client.py` — public facade forwards `progress_callback` to remote.
- `tests/test_upload_progress.py` — seven tests covering dataclass invariants, default-`None` signature, sync path, failure handling, parallel path, local-mode signature acceptance, and public facade signature.

### Verification

- `pytest tests/test_upload_progress.py tests/test_in_memory.py` — 11 passed locally (Python 3.11).
- `ruff check` against touched files reports no new violations (two pre-existing F541 warnings remain on master around `qdrant_remote.py:90-91`).
- Smoke import: `from qdrant_client.uploader.uploader import UploadProgress` and `QdrantRemote._upload_collection(... progress_callback=...)` accepted via `inspect.signature`.

### Out of scope (intentional)

- `tqdm` integration, abort signal wiring, per-batch error aggregation callbacks. These are reasonable follow-ups but were not requested and would expand the surface meaningfully.

### Commits

1. `feat(uploader): add UploadProgress dataclass`
2. `feat(remote): thread progress_callback through _upload_collection`
3. `feat(client): expose progress_callback on QdrantClient uploaders`
4. `test(client): cover progress_callback across sync, parallel, and local modes`
