### PR TITLE
fix: prevent file handle leak when portalocker.lock() fails in local mode

### DIFF
--- a/qdrant_client/local/async_qdrant_local.py
+++ b/qdrant_client/local/async_qdrant_local.py
@@ -137,7 +137,7 @@ class AsyncQdrantLocal(AsyncQdrantBase):
             self._flock_file = None
             raise RuntimeError(
                 f"Storage folder {self.location} is already accessed by another instance of Qdrant client. If you require concurrent access, use Qdrant server instead."
-            )
+            ) from None
         except Exception:
             self._flock_file.close()
             self._flock_file = None

--- a/qdrant_client/local/async_qdrant_local.py
+++ b/qdrant_client/local/async_qdrant_local.py
@@ -133,9 +133,15 @@ class AsyncQdrantLocal(AsyncQdrantBase):
                 portalocker.LockFlags.EXCLUSIVE | portalocker.LockFlags.NON_BLOCKING,
             )
         except portalocker.exceptions.LockException:
+            self._flock_file.close()
+            self._flock_file = None
             raise RuntimeError(
                 f"Storage folder {self.location} is already accessed by another instance of Qdrant client. If you require concurrent access, use Qdrant server instead."
             )
+        except Exception:
+            self._flock_file.close()
+            self._flock_file = None
+            raise
 
     def _save(self) -> None:
         if not self.persistent:

--- a/qdrant_client/local/qdrant_local.py
+++ b/qdrant_client/local/qdrant_local.py
@@ -151,7 +151,7 @@ class QdrantLocal(QdrantBase):
             raise RuntimeError(
                 f"Storage folder {self.location} is already accessed by another instance of Qdrant client."
                 f" If you require concurrent access, use Qdrant server instead."
-            )
+            ) from None
         except Exception:
             self._flock_file.close()
             self._flock_file = None

--- a/qdrant_client/local/qdrant_local.py
+++ b/qdrant_client/local/qdrant_local.py
@@ -146,10 +146,16 @@ class QdrantLocal(QdrantBase):
                 portalocker.LockFlags.EXCLUSIVE | portalocker.LockFlags.NON_BLOCKING,
             )
         except portalocker.exceptions.LockException:
+            self._flock_file.close()
+            self._flock_file = None
             raise RuntimeError(
                 f"Storage folder {self.location} is already accessed by another instance of Qdrant client."
                 f" If you require concurrent access, use Qdrant server instead."
             )
+        except Exception:
+            self._flock_file.close()
+            self._flock_file = None
+            raise
 
     def _save(self) -> None:
         if not self.persistent:


### PR DESCRIPTION
Resolves #1234.

### Description
In `QdrantLocal` and `AsyncQdrantLocal`, when starting the local storage client, a flock lock file is opened. If the directory is already locked (or another error occurs during `portalocker.lock()`), a `LockException` or other exception is raised, but the opened `self._flock_file` file descriptor is left open/leaked.

### Changes
- Added `except` blocks wrapping `portalocker.lock()` in both sync and async local client initializers to explicitly call `self._flock_file.close()` and clear the reference before re-raising the exceptions.
- Verified that existing persistence unit tests still pass successfully.