### PR TITLE
fix: return None instead of crashing on out-of-range negative array index in value_by_key

### DIFF
--- a/qdrant_client/local/payload_value_extractor.py
+++ b/qdrant_client/local/payload_value_extractor.py
@@ -50,7 +50,7 @@ def value_by_key(payload: dict[str, Any], key: str, flat: bool = True) -> list[A
                 elif current_key.item_type == JsonPathItemType.INDEX:
                     assert current_key.index is not None
 
-                    if current_key.index < len(data):
+                    if -len(data) <= current_key.index < len(data):
                         result.append(data[current_key.index])
 
         elif current_key.item_type == JsonPathItemType.KEY:
@@ -66,7 +66,7 @@ def value_by_key(payload: dict[str, Any], key: str, flat: bool = True) -> list[A
             if not isinstance(data, list):
                 return
 
-            if current_key.index < len(data):
+            if -len(data) <= current_key.index < len(data):
                 _get_value(data[current_key.index], k_list.copy())
 
         elif current_key.item_type == JsonPathItemType.WILDCARD_INDEX:

--- a/qdrant_client/local/tests/test_payload_utils.py
+++ b/qdrant_client/local/tests/test_payload_utils.py
@@ -223,6 +223,16 @@ def test_value_by_key() -> None:
     assert value_by_key(payload, "double-nest-array[0][0]") == [1]
     assert value_by_key(payload, "double-nest-array[0][0]") == [1]
     assert value_by_key(payload, "double-nest-array[][1]") == [2, 4, 6]
+
+    # Out-of-range indices return None instead of raising, in both directions.
+    # A negative index that is out of range previously raised IndexError while
+    # a positive one already returned None (see location[2] above).
+    assert value_by_key(payload, "counts[-1]") == [3]
+    assert value_by_key(payload, "counts[-3]") == [1]
+    assert value_by_key(payload, "counts[-4]") is None
+    assert value_by_key(payload, "counts[-100]") is None
+    assert value_by_key(payload, "location[-1].name") == ["work"]
+    assert value_by_key(payload, "location[-5].name") is None
     # endregion
 
     # region flat=False


### PR DESCRIPTION
## Problem

`value_by_key` (used by the local-mode filter and count paths) crashes with `IndexError` for an out-of-range **negative** array index, even though an out-of-range **positive** index already returns `None`:

```python
from qdrant_client.local.payload_value_extractor import value_by_key

value_by_key({"a": [1, 2, 3]}, "a[10]")   # None       (already fine)
value_by_key({"a": [1, 2, 3]}, "a[-5]")   # IndexError: list index out of range
```

The two index guards only check the upper bound:

```python
if current_key.index < len(data):
    ...
```

For a negative index this is always true (`-5 < 3`), so `data[-5]` is evaluated and raises. The path parser accepts negative indices incidentally (`int("-5")`), so a filter/count on a user-supplied path like `field[-5]` takes down the whole local query instead of matching nothing.

## Change

Guard both bounds in both index branches:

```python
if -len(data) <= current_key.index < len(data):
    ...
```

- Out-of-range negative indices now return `None`, matching the existing behaviour for out-of-range positive indices.
- In-range negative indices keep working (`a[-1]` -> last element), unchanged.
- Positive indices are unchanged.

## Tests

Extended `test_value_by_key` with the negative-index cases (in-range returns the element, out-of-range returns `None`, including a nested `location[-5].name`). The out-of-range assertions raise `IndexError` on `main` and pass with this change; the full `test_payload_utils.py` suite passes and `ruff check` is clean.

An AI assistant helped spot and implement this fix; I reviewed the change and ran the tests locally.
