### PR TITLE
docs(client): correct gRPC default timeout in QdrantClient docstring

### DIFF
--- a/qdrant_client/async_qdrant_client.py
+++ b/qdrant_client/async_qdrant_client.py
@@ -63,7 +63,7 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
             Default: `None`
         timeout:
             Timeout for REST and gRPC API requests.
-            Default: 5 seconds for REST and unlimited for gRPC
+            Default: 5 seconds for both REST and gRPC
         host: Host name of Qdrant service. If url and host are None, set to 'localhost'.
             Default: `None`
         path: Persistence path for QdrantLocal. Default: `None`

--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -62,7 +62,7 @@ class QdrantClient(QdrantFastembedMixin):
             Default: `None`
         timeout:
             Timeout for REST and gRPC API requests.
-            Default: 5 seconds for REST and unlimited for gRPC
+            Default: 5 seconds for both REST and gRPC
         host: Host name of Qdrant service. If url and host are None, set to 'localhost'.
             Default: `None`
         path: Persistence path for QdrantLocal. Default: `None`

--- a/tests/test_default_grpc_timeout.py
+++ b/tests/test_default_grpc_timeout.py
@@ -1,0 +1,69 @@
+"""Tests for the gRPC default-timeout contract.
+
+Covers:
+
+* ``QdrantRemote.DEFAULT_GRPC_TIMEOUT`` and ``AsyncQdrantRemote.DEFAULT_GRPC_TIMEOUT``
+  are finite seconds (currently 5s) — guards against the legacy "unlimited" wording.
+* The ``timeout`` parameter block in the ``QdrantClient`` and ``AsyncQdrantClient``
+  source docstrings no longer claims gRPC is unlimited by default and does not
+  reintroduce that wording.
+
+Regression coverage for https://github.com/qdrant/qdrant-client/issues/1023.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from qdrant_client.async_qdrant_remote import AsyncQdrantRemote
+from qdrant_client.qdrant_remote import QdrantRemote
+
+
+EXPECTED_DEFAULT_GRPC_TIMEOUT_SECONDS = 5
+MISLEADING_PHRASE = "unlimited for gRPC"
+
+
+class TestDefaultGrpcTimeoutConstant:
+    def test_sync_default_is_five_seconds(self) -> None:
+        assert QdrantRemote.DEFAULT_GRPC_TIMEOUT == EXPECTED_DEFAULT_GRPC_TIMEOUT_SECONDS
+
+    def test_async_default_is_five_seconds(self) -> None:
+        assert AsyncQdrantRemote.DEFAULT_GRPC_TIMEOUT == EXPECTED_DEFAULT_GRPC_TIMEOUT_SECONDS
+
+
+@pytest.mark.parametrize(
+    "source_path, class_name",
+    [
+        (
+            Path(__file__).resolve().parents[1] / "qdrant_client" / "qdrant_client.py",
+            "QdrantClient",
+        ),
+        (
+            Path(__file__).resolve().parents[1]
+            / "qdrant_client"
+            / "async_qdrant_client.py",
+            "AsyncQdrantClient",
+        ),
+    ],
+    ids=["sync", "async"],
+)
+class TestTimeoutDocstring:
+    def test_timeout_block_documents_finite_default(
+        self, source_path: Path, class_name: str
+    ) -> None:
+        full = ast.parse(source_path.read_text())
+        block = None
+        for node in ast.walk(full):
+            if isinstance(node, ast.ClassDef) and node.name == class_name:
+                block = ast.get_docstring(node) or ""
+                break
+        assert block, f"{class_name} docstring is empty"
+        assert MISLEADING_PHRASE not in block, (
+            f"Outdated gRPC-default wording resurfaced in {class_name}"
+        )
+        assert "5 seconds" in block, (
+            f"Expected explicit '5 seconds' default in {class_name} docstring"
+        )


### PR DESCRIPTION
## Summary

The `timeout` parameter on `QdrantClient.__init__` (and its async mirror) claimed the gRPC default was unlimited, but the runtime uses `QdrantRemote.DEFAULT_GRPC_TIMEOUT = 5` seconds. This PR brings the docstring in line with the code.

## Problem

The current docstring reads:

```
Default: 5 seconds for REST and unlimited for gRPC
```

That conflicts with the `QdrantRemote.DEFAULT_GRPC_TIMEOUT = 5` constant mirrored in `qdrant_client/async_qdrant_remote.py:45`. Users following the doc hit unexpected gRPC deadline-exceeded errors after 5s. Maintainer @joein confirmed the correct value in https://github.com/qdrant/qdrant-client/issues/1023 on 2025-09-11.

## Changes

- `qdrant_client/qdrant_client.py`: replace `unlimited for gRPC` with `both REST and gRPC` in the `timeout` parameter docstring.
- `qdrant_client/async_qdrant_client.py`: same one-line edit. This file is autogenerated from the sync source via `tools/generate_async_client.sh`; the same edit is mirrored by hand. Future regeneration carries the corrected text automatically.
- `tests/test_default_grpc_timeout.py`: new test module covering:
  - `QdrantRemote.DEFAULT_GRPC_TIMEOUT` and `AsyncQdrantRemote.DEFAULT_GRPC_TIMEOUT` both equal 5 seconds.
  - The `QdrantClient` and `AsyncQdrantClient` class docstrings no longer contain `unlimited for gRPC` and still document the 5-second default.

## Testing

- `pytest tests/test_default_grpc_timeout.py` — 4 tests pass.
- Mutation check: restoring the old sync-side wording on a throwaway stash makes the docstring test fail with the offending phrase still in the source, which confirms the regression guard fires.
- `ruff check` on the three touched files — clean.
- `pytest tests/test_common.py tests/test_tracing.py tests/test_default_grpc_timeout.py` — 41 server-independent tests pass.

## Risk

Very low. Docstring-only change plus a runtime-constant regression test. No public API change, no behavior change.

Fixes #1023
