### PR TITLE
test: add unit tests for local distance functions

### DIFF
--- a/tests/test_distances.py
+++ b/tests/test_distances.py
@@ -1,0 +1,62 @@
+import numpy as np
+import pytest
+
+from qdrant_client.http import models
+from qdrant_client.local.distances import (
+    DistanceOrder,
+    distance_to_order,
+    dot_product,
+    euclidean_distance,
+    fast_sigmoid,
+    manhattan_distance,
+    scaled_fast_sigmoid,
+)
+
+
+def _query():
+    return np.array([1.0, 0.0], dtype=np.float32)
+
+
+def _vectors():
+    return np.array([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]], dtype=np.float32)
+
+
+def test_dot_product():
+    assert dot_product(_query(), _vectors()).tolist() == [1.0, 0.0, 1.0]
+
+
+def test_euclidean_distance():
+    result = euclidean_distance(_query(), _vectors())
+    assert result == pytest.approx([0.0, np.sqrt(2), 1.0], abs=1e-5)
+
+
+def test_manhattan_distance():
+    assert manhattan_distance(_query(), _vectors()).tolist() == [0.0, 2.0, 1.0]
+
+
+def test_distance_to_order():
+    assert distance_to_order(models.Distance.COSINE) == DistanceOrder.BIGGER_IS_BETTER
+    assert distance_to_order(models.Distance.DOT) == DistanceOrder.BIGGER_IS_BETTER
+    assert distance_to_order(models.Distance.EUCLID) == DistanceOrder.SMALLER_IS_BETTER
+    assert (
+        distance_to_order(models.Distance.MANHATTAN) == DistanceOrder.SMALLER_IS_BETTER
+    )
+
+
+def test_fast_sigmoid_maps_to_open_interval():
+    assert fast_sigmoid(np.float32(0.0)) == 0.0
+    assert fast_sigmoid(np.float32(1.0)) == pytest.approx(0.5)
+    assert fast_sigmoid(np.float32(-1.0)) == pytest.approx(-0.5)
+
+
+def test_fast_sigmoid_passes_non_finite_through():
+    # NaN/inf are returned unchanged to avoid invalid divisions.
+    assert np.isnan(fast_sigmoid(np.float32("nan")))
+    assert fast_sigmoid(np.float32("inf")) == np.float32("inf")
+
+
+def test_scaled_fast_sigmoid_shifts_into_unit_range():
+    # 0.5 * (fast_sigmoid(x) + 1): x=0 -> 0.5, and stays within (0, 1).
+    assert scaled_fast_sigmoid(np.float32(0.0)) == pytest.approx(0.5)
+    assert 0.0 < scaled_fast_sigmoid(np.float32(5.0)) < 1.0
+    assert 0.0 < scaled_fast_sigmoid(np.float32(-5.0)) < 1.0


### PR DESCRIPTION
## Description

`qdrant_client/local/distances.py` had no dedicated test module. This adds `tests/test_distances.py` covering the pure distance/scoring helpers:

- `dot_product`, `euclidean_distance`, `manhattan_distance` against hand-computed values
- `distance_to_order` mapping each `Distance` to bigger/smaller-is-better
- `fast_sigmoid` mapping into (-1, 1), passing NaN/inf through unchanged
- `scaled_fast_sigmoid` shifting into (0, 1)

(`cosine_similarity` normalises its inputs in place, so each helper is exercised with fresh arrays.) No source changes.

## Verification

`pytest tests/test_distances.py` - 7 passed. `ruff check` / `ruff format --check` clean.
