### PR TITLE
Fix set_payload sharing a nested payload object across selected points (local mode)

### DIFF
--- a/qdrant_client/local/local_collection.py
+++ b/qdrant_client/local/local_collection.py
@@ -2737,12 +2737,16 @@ class LocalCollection:
         key: str | None = None,
     ) -> None:
         ids = self._selector_to_ids(selector)
-        jsonable_payload = deepcopy(to_jsonable_python(payload))
+        base_payload = to_jsonable_python(payload)
 
         keys: list[JsonPathItem] | None = parse_json_path(key) if key is not None else None
 
         for point_id in ids:
             idx = self.ids[point_id]
+            # Deep-copy per point: a shared object graph here would let a later,
+            # differently-scoped set_payload(key=...) call mutate other points'
+            # payloads in place via set_value_by_key's dict.update().
+            jsonable_payload = deepcopy(base_payload)
             if keys is None:
                 self.payload[idx] = {**self.payload[idx], **jsonable_payload}
             else:

--- a/tests/test_qdrant_client.py
+++ b/tests/test_qdrant_client.py
@@ -2512,5 +2512,9 @@ def test_local_set_payload_does_not_leak_across_points():
     by_id = {p.id: p.payload for p in points}
 
     assert by_id[1]["category"]["reviewed"] is True
-    assert by_id[2]["category"]["reviewed"] is False, "point 2 was never selected by the key-scoped call"
-    assert by_id[3]["category"]["reviewed"] is False, "point 3 was never selected by the key-scoped call"
+    assert by_id[2]["category"]["reviewed"] is False, (
+        "point 2 was never selected by the key-scoped call"
+    )
+    assert by_id[3]["category"]["reviewed"] is False, (
+        "point 3 was never selected by the key-scoped call"
+    )

--- a/tests/test_qdrant_client.py
+++ b/tests/test_qdrant_client.py
@@ -2477,3 +2477,40 @@ def test_create_payload_index_enable_hnsw(prefer_grpc: bool):
         "datetime_field",
     ]:
         assert info.payload_schema[field_name].params.enable_hnsw is False, field_name
+
+
+def test_local_set_payload_does_not_leak_across_points():
+    """Regression test: a single set_payload(..., points=[...]) call with a nested payload
+    must not leave sibling points sharing the same nested dict object. A later, differently
+    scoped set_payload(key=...) call on one point must not silently mutate the others."""
+    client = QdrantClient(":memory:")
+    collection_name = "test_set_payload_leak"
+    client.create_collection(
+        collection_name,
+        vectors_config=models.VectorParams(size=4, distance=models.Distance.COSINE),
+    )
+    client.upsert(
+        collection_name,
+        points=[
+            models.PointStruct(id=1, vector=[0.1, 0.2, 0.3, 0.4], payload={}),
+            models.PointStruct(id=2, vector=[0.1, 0.2, 0.3, 0.4], payload={}),
+            models.PointStruct(id=3, vector=[0.1, 0.2, 0.3, 0.4], payload={}),
+        ],
+    )
+
+    client.set_payload(
+        collection_name=collection_name,
+        payload={"category": {"name": "invoice", "reviewed": False}},
+        points=[1, 2, 3],
+    )
+
+    client.set_payload(
+        collection_name=collection_name, payload={"reviewed": True}, points=[1], key="category"
+    )
+
+    points = client.retrieve(collection_name, ids=[1, 2, 3], with_payload=True)
+    by_id = {p.id: p.payload for p in points}
+
+    assert by_id[1]["category"]["reviewed"] is True
+    assert by_id[2]["category"]["reviewed"] is False, "point 2 was never selected by the key-scoped call"
+    assert by_id[3]["category"]["reviewed"] is False, "point 3 was never selected by the key-scoped call"


### PR DESCRIPTION
Fixes #1271.

## What's wrong

`LocalCollection.set_payload` (`qdrant_client/local/local_collection.py`) computes `deepcopy(to_jsonable_python(payload))` once, before looping over the selected point ids, then assigns/merges that same object graph into every point's payload. Any nested dict/list in the payload becomes a shared object reference across all points touched by that call. `set_value_by_key` (`payload_value_setter.py`) mutates nested dicts in place via `.update()` when resolving a `key=...` path, so a later, differently-scoped `set_payload(key=...)` call on just one point silently mutates every other point that still holds a reference to that shared object, even though they were never selected.

`overwrite_payload`, right below `set_payload` in the same file, already does the `deepcopy` inside its loop and isn't affected, that's what pointed me at the fix.

## Fix

Move the `deepcopy` inside the per-point loop, so each point gets its own independent copy of the payload, matching `overwrite_payload`'s existing pattern.

## Testing

```python
client.set_payload(payload={"category": {"name": "invoice", "reviewed": False}}, points=[1, 2, 3])
client.set_payload(payload={"reviewed": True}, points=[1], key="category")
```

Before:
```
1 {'category': {'name': 'invoice', 'reviewed': True}}
2 {'category': {'name': 'invoice', 'reviewed': True}}   # corrupted, never selected
3 {'category': {'name': 'invoice', 'reviewed': True}}   # corrupted, never selected
```

After:
```
1 {'category': {'name': 'invoice', 'reviewed': True}}
2 {'category': {'name': 'invoice', 'reviewed': False}}
3 {'category': {'name': 'invoice', 'reviewed': False}}
```

Added `test_local_set_payload_does_not_leak_across_points` to `tests/test_qdrant_client.py`, verified it red (fails against the original code, `AssertionError: point 2 was never selected by the key-scoped call`) and green (passes with the fix).

I also ran the broader `-k payload` test slice for a regression check. 8 unrelated tests failed, all with `grpc._channel._InactiveRpcError: failed to connect to all addresses ... 127.0.0.1:6334`, they're parametrized to also run against a real Qdrant server, and there's no server running in my environment. Those aren't related to this change (confirmed by the error itself being a connection failure, not an assertion). The one purely local-mode test I added passes cleanly.
