### PR TITLE
fix: do not drop falsy shard keys in convert_points_update_operation

### DIFF
--- a/qdrant_client/conversions/conversion.py
+++ b/qdrant_client/conversions/conversion.py
@@ -4595,7 +4595,7 @@ class RestToGrpc:
         if isinstance(model, rest.UpsertOperation):
             shard_key_selector = (
                 cls.convert_shard_key_selector(model.upsert.shard_key)
-                if model.upsert.shard_key
+                if model.upsert.shard_key is not None
                 else None
             )
             update_filter = (
@@ -4619,7 +4619,7 @@ class RestToGrpc:
         elif isinstance(model, rest.DeleteOperation):
             shard_key_selector = (
                 cls.convert_shard_key_selector(model.delete.shard_key)
-                if model.delete.shard_key
+                if model.delete.shard_key is not None
                 else None
             )
             points_selector = cls.convert_points_selector(model.delete)
@@ -4640,7 +4640,7 @@ class RestToGrpc:
 
             shard_key_selector = (
                 cls.convert_shard_key_selector(model.set_payload.shard_key)
-                if model.set_payload.shard_key
+                if model.set_payload.shard_key is not None
                 else None
             )
 
@@ -4664,7 +4664,7 @@ class RestToGrpc:
 
             shard_key_selector = (
                 cls.convert_shard_key_selector(model.overwrite_payload.shard_key)
-                if model.overwrite_payload.shard_key
+                if model.overwrite_payload.shard_key is not None
                 else None
             )
 
@@ -4688,7 +4688,7 @@ class RestToGrpc:
 
             shard_key_selector = (
                 cls.convert_shard_key_selector(model.delete_payload.shard_key)
-                if model.delete_payload.shard_key
+                if model.delete_payload.shard_key is not None
                 else None
             )
 
@@ -4702,7 +4702,7 @@ class RestToGrpc:
         elif isinstance(model, rest.ClearPayloadOperation):
             shard_key_selector = (
                 cls.convert_shard_key_selector(model.clear_payload.shard_key)
-                if model.clear_payload.shard_key
+                if model.clear_payload.shard_key is not None
                 else None
             )
             points_selector = cls.convert_points_selector(model.clear_payload)
@@ -4716,7 +4716,7 @@ class RestToGrpc:
         elif isinstance(model, rest.UpdateVectorsOperation):
             shard_key_selector = (
                 cls.convert_shard_key_selector(model.update_vectors.shard_key)
-                if model.update_vectors.shard_key
+                if model.update_vectors.shard_key is not None
                 else None
             )
             update_filter = (
@@ -4745,7 +4745,7 @@ class RestToGrpc:
 
             shard_key_selector = (
                 cls.convert_shard_key_selector(model.delete_vectors.shard_key)
-                if model.delete_vectors.shard_key
+                if model.delete_vectors.shard_key is not None
                 else None
             )
 

--- a/tests/conversions/test_validate_conversions.py
+++ b/tests/conversions/test_validate_conversions.py
@@ -594,3 +594,52 @@ def test_optimizers_config_diff_max_threads():
     assert restored_grpc_opt_conf.max_optimization_threads == q_grpc.MaxOptimizationThreads(
         value=value
     )
+
+
+def test_convert_points_update_operation_falsy_shard_key():
+    from qdrant_client import models
+    from qdrant_client.conversions.conversion import GrpcToRest, RestToGrpc
+
+    point = models.PointStruct(id=1, vector=[1.0, 2.0], payload={"my_payload": 1})
+    point_vector = models.PointVectors(id=1, vector=[1.0, 2.0])
+
+    for shard_key in (0, ""):
+        operations = [
+            models.UpsertOperation(upsert=models.PointsList(points=[point], shard_key=shard_key)),
+            models.DeleteOperation(delete=models.PointIdsList(points=[1], shard_key=shard_key)),
+            models.SetPayloadOperation(
+                set_payload=models.SetPayload(
+                    payload={"my_payload": 1}, points=[1], shard_key=shard_key
+                )
+            ),
+            models.OverwritePayloadOperation(
+                overwrite_payload=models.SetPayload(
+                    payload={"my_payload": 1}, points=[1], shard_key=shard_key
+                )
+            ),
+            models.DeletePayloadOperation(
+                delete_payload=models.DeletePayload(
+                    keys=["my_payload"], points=[1], shard_key=shard_key
+                )
+            ),
+            models.ClearPayloadOperation(
+                clear_payload=models.PointIdsList(points=[1], shard_key=shard_key)
+            ),
+            models.UpdateVectorsOperation(
+                update_vectors=models.UpdateVectors(points=[point_vector], shard_key=shard_key)
+            ),
+            models.DeleteVectorsOperation(
+                delete_vectors=models.DeleteVectors(
+                    points=[1], vector=["image"], shard_key=shard_key
+                )
+            ),
+        ]
+
+        for operation in operations:
+            grpc_operation = RestToGrpc.convert_update_operation(operation)
+            inner = getattr(grpc_operation, grpc_operation.WhichOneof("operation"))
+
+            assert inner.HasField(
+                "shard_key_selector"
+            ), f"{type(operation).__name__} dropped shard_key={shard_key!r}"
+            assert GrpcToRest.convert_shard_key_selector(inner.shard_key_selector) == shard_key


### PR DESCRIPTION
### What's broken

All eight branches of `RestToGrpc.convert_points_update_operation` gate the shard key on truthiness:

```python
shard_key_selector = (
    cls.convert_shard_key_selector(model.upsert.shard_key)
    if model.upsert.shard_key
    else None
)
```

`ShardKey = Union[StrictInt, StrictStr]`, so `0` and `""` are valid shard keys that evaluate to `False`. They are silently replaced with `None`, and the operation gets routed by the default rules instead of to the requested shard. Nothing raises, so the write just lands somewhere else.

Repro against `dev`, converting each operation type with `shard_key=0`:

```
shard_key = 0

LOST UpsertOperation            shard_key_selector present=False keys=[]
LOST DeleteOperation            shard_key_selector present=False keys=[]
LOST SetPayloadOperation        shard_key_selector present=False keys=[]
LOST OverwritePayloadOperation  shard_key_selector present=False keys=[]
LOST DeletePayloadOperation     shard_key_selector present=False keys=[]
LOST ClearPayloadOperation      shard_key_selector present=False keys=[]
LOST UpdateVectorsOperation     shard_key_selector present=False keys=[]
LOST DeleteVectorsOperation     shard_key_selector present=False keys=[]

8/8 operations silently dropped the shard key
control, shard_key=1 -> [number: 1]
```

With this patch:

```
OK   UpsertOperation            shard_key_selector present=True keys=[number: 0]
OK   DeleteOperation            shard_key_selector present=True keys=[number: 0]
OK   SetPayloadOperation        shard_key_selector present=True keys=[number: 0]
OK   OverwritePayloadOperation  shard_key_selector present=True keys=[number: 0]
OK   DeletePayloadOperation     shard_key_selector present=True keys=[number: 0]
OK   ClearPayloadOperation      shard_key_selector present=True keys=[number: 0]
OK   UpdateVectorsOperation     shard_key_selector present=True keys=[number: 0]
OK   DeleteVectorsOperation     shard_key_selector present=True keys=[number: 0]

0/8 operations silently dropped the shard key
```

### Why it matters

This is on the write path. `QdrantRemote.batch_update_points` (and the async variant) call `RestToGrpc.convert_update_operation` for every operation when the client is constructed with `prefer_grpc=True`. A custom-sharded collection keyed on integers loses shard `0` on every batch update, and there is no signal that it happened.

### The fix

Switch the eight guards to `is not None`. The field is declared `Optional[ShardKeySelector]` with a `None` default, so `None` is the only value that should mean "not set". This is the idiom the rest of the file already uses, for example in `convert_query_request`:

```python
shard_key_selector=(
    cls.convert_shard_key_selector(model.shard_key)
    if model.shard_key is not None
    else None
),
```

so this only brings the update path in line with the read path. No behaviour changes for `None` or for any truthy key.

### Testing

`test_convert_points_update_operation_falsy_shard_key` builds each of the eight REST operation types with `shard_key=0` and `shard_key=""`, converts to gRPC, and asserts the selector survives and round-trips back to the original value.

```
$ pytest tests/conversions/test_validate_conversions.py -q
......................                                                   [100%]
22 passed in 1.16s
```

Reverting only the `conversion.py` hunk makes the new test fail on the first operation and leaves the other 21 tests passing, so nothing else in the file depended on the old behaviour. `ruff format --line-length=99` reports no changes.
