### PR TITLE
docs: correct default gRPC timeout description

### DIFF
--- a/qdrant_client/async_qdrant_client.py
+++ b/qdrant_client/async_qdrant_client.py
@@ -63,7 +63,7 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
             Default: `None`
         timeout:
             Timeout for REST and gRPC API requests.
-            Default: 5 seconds for REST and unlimited for gRPC
+            Default: 5 seconds for both REST and gRPC (when timeout is None)
         host: Host name of Qdrant service. If url and host are None, set to 'localhost'.
             Default: `None`
         path: Persistence path for QdrantLocal. Default: `None`

--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -62,7 +62,7 @@ class QdrantClient(QdrantFastembedMixin):
             Default: `None`
         timeout:
             Timeout for REST and gRPC API requests.
-            Default: 5 seconds for REST and unlimited for gRPC
+            Default: 5 seconds for both REST and gRPC (when timeout is None)
         host: Host name of Qdrant service. If url and host are None, set to 'localhost'.
             Default: `None`
         path: Persistence path for QdrantLocal. Default: `None`


### PR DESCRIPTION
## Summary

Docstrings for `QdrantClient` / `AsyncQdrantClient` said the default timeout is \"5 seconds for REST and **unlimited** for gRPC\".

Implementation applies `QdrantRemote.DEFAULT_GRPC_TIMEOUT = 5` when `timeout=None`, so gRPC is also 5s by default.

## Fix

Update both client docstrings to state the default is 5 seconds for REST **and** gRPC.

Fixes #1023