### PR TITLE
feat(remote): accept pre-built httpx.Client and httpx.AsyncClient

### DIFF
--- a/qdrant_client/async_qdrant_client.py
+++ b/qdrant_client/async_qdrant_client.py
@@ -106,10 +106,14 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
         http_client: httpx.AsyncClient | None = None,
         **kwargs: Any,
     ):
+        # http_client is excluded from init_options: an async httpx.AsyncClient
+        # must not be passed into the sync constructor and vice versa. Callers
+        # that want an http_client on both sides need to pass it to each
+        # constructor explicitly.
         self._init_options = {
             key: value
             for (key, value) in locals().items()
-            if key not in ("self", "__class__", "kwargs")
+            if key not in ("self", "__class__", "kwargs", "http_client")
         }
         self._init_options.update({k: v for (k, v) in kwargs.items()})
         if sum([param is not None for param in (location, url, host, path)]) > 1:

--- a/qdrant_client/async_qdrant_client.py
+++ b/qdrant_client/async_qdrant_client.py
@@ -12,6 +12,7 @@
 import warnings
 from typing import Any, Awaitable, Callable, Iterable, Mapping, Sequence
 import numpy as np
+import httpx
 from qdrant_client import grpc as grpc
 from qdrant_client.async_client_base import AsyncQdrantBase
 from qdrant_client.common.client_warnings import show_warning_once
@@ -102,6 +103,7 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
         check_compatibility: bool = True,
         pool_size: int | None = None,
         headers: dict[str, str] | None = None,
+        http_client: httpx.AsyncClient | None = None,
         **kwargs: Any,
     ):
         self._init_options = {
@@ -141,6 +143,7 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
                 check_compatibility=check_compatibility,
                 pool_size=pool_size,
                 headers=headers,
+                http_client=http_client,
                 **kwargs,
             )
         if isinstance(self._client, AsyncQdrantLocal) and cloud_inference:

--- a/qdrant_client/async_qdrant_remote.py
+++ b/qdrant_client/async_qdrant_remote.py
@@ -61,6 +61,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         check_compatibility: bool = True,
         pool_size: int | None = None,
         headers: dict[str, str] | None = None,
+        http_client: httpx.AsyncClient | None = None,
         **kwargs: Any,
     ):
         super().__init__(**kwargs)
@@ -185,6 +186,15 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                 )
             bearer_auth = BearerAuth(self._auth_token_provider)
             self._rest_args["auth"] = bearer_auth
+
+        if http_client is not None:
+            # Caller supplied a pre-built httpx.AsyncClient. Use it as-is so
+            # they keep full control over transport, middleware, and event
+            # hooks; the qdrant-client kwargs above (limits, http2, timeout,
+            # auth) are only applied when this class builds its own
+            # httpx.AsyncClient.
+            self._rest_args["http_client"] = http_client
+
         self.openapi_client: AsyncApis[AsyncApiClient] = AsyncApis(
             host=self.rest_uri, **self._rest_args
         )

--- a/qdrant_client/async_qdrant_remote.py
+++ b/qdrant_client/async_qdrant_remote.py
@@ -188,15 +188,19 @@ class AsyncQdrantRemote(AsyncQdrantBase):
             self._rest_args["auth"] = bearer_auth
 
         if http_client is not None:
-            # Caller supplied a pre-built httpx.AsyncClient. Use it as-is so
-            # they keep full control over transport, middleware, and event
-            # hooks; the qdrant-client kwargs above (limits, http2, timeout,
-            # auth) are only applied when this class builds its own
-            # httpx.AsyncClient.
-            self._rest_args["http_client"] = http_client
+            # Caller supplied a pre-built httpx.AsyncClient. Use it only for
+            # the main openapi_client; do not place it in self._rest_args,
+            # because that dict is also forwarded to per-process upload
+            # workers where a shared client would be fork-unsafe and would
+            # serialize the workers' connection pool.
+            main_client_kwargs: dict[str, Any] = {"http_client": http_client}
+        else:
+            main_client_kwargs = {}
 
         self.openapi_client: AsyncApis[AsyncApiClient] = AsyncApis(
-            host=self.rest_uri, **self._rest_args
+            host=self.rest_uri,
+            **self._rest_args,
+            **main_client_kwargs,
         )
         self.openapi_client.client.add_middleware(async_rest_headers_middleware)
         self._grpc_channel_pool: list[grpc.Channel] = []

--- a/qdrant_client/http/api_client.py
+++ b/qdrant_client/http/api_client.py
@@ -75,10 +75,13 @@ class ApiClient:
         self.middleware: MiddlewareT = BaseMiddleware()
         if http_client is not None:
             # Caller supplied a pre-built httpx.Client. Use it as-is so they
-            # keep full control over transport, middleware, and event hooks.
+            # keep full control over transport, middleware, and event hooks;
+            # we must not close it on .close() since they own its lifecycle.
             self._client = http_client
+            self._owns_client = False
         else:
             self._client = Client(**kwargs)
+            self._owns_client = True
 
     @overload
     def request(self, *, type_: Type[T], method: str, url: str, path_params: Dict[str, Any] = None, **kwargs: Any) -> T:
@@ -147,7 +150,8 @@ class ApiClient:
         return response
 
     def close(self) -> None:
-        self._client.close()
+        if self._owns_client:
+            self._client.close()
 
     def add_middleware(self, middleware: MiddlewareT) -> None:
         current_middleware = self.middleware
@@ -173,10 +177,13 @@ class AsyncApiClient:
         if http_client is not None:
             # Caller supplied a pre-built httpx.AsyncClient. Use it as-is so
             # they keep full control over transport, middleware, and event
-            # hooks.
+            # hooks; we must not close it on .aclose() since they own its
+            # lifecycle.
             self._async_client = http_client
+            self._owns_client = False
         else:
             self._async_client = AsyncClient(**kwargs)
+            self._owns_client = True
 
     @overload
     async def request(
@@ -247,7 +254,8 @@ class AsyncApiClient:
         return response
 
     async def aclose(self) -> None:
-        await self._async_client.aclose()
+        if self._owns_client:
+            await self._async_client.aclose()
 
     def add_middleware(self, middleware: AsyncMiddlewareT) -> None:
         current_middleware = self.middleware

--- a/qdrant_client/http/api_client.py
+++ b/qdrant_client/http/api_client.py
@@ -65,10 +65,20 @@ AsyncMiddlewareT = Callable[[Request, SendAsync], Awaitable[Response]]
 
 
 class ApiClient:
-    def __init__(self, host: str, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        host: str,
+        http_client: Client | None = None,
+        **kwargs: Any,
+    ) -> None:
         self.host = host
         self.middleware: MiddlewareT = BaseMiddleware()
-        self._client = Client(**kwargs)
+        if http_client is not None:
+            # Caller supplied a pre-built httpx.Client. Use it as-is so they
+            # keep full control over transport, middleware, and event hooks.
+            self._client = http_client
+        else:
+            self._client = Client(**kwargs)
 
     @overload
     def request(self, *, type_: Type[T], method: str, url: str, path_params: Dict[str, Any] = None, **kwargs: Any) -> T:
@@ -152,10 +162,21 @@ class ApiClient:
 
 
 class AsyncApiClient:
-    def __init__(self, host: str = None, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        host: str = None,
+        http_client: AsyncClient | None = None,
+        **kwargs: Any,
+    ) -> None:
         self.host = host
         self.middleware: AsyncMiddlewareT = BaseAsyncMiddleware()
-        self._async_client = AsyncClient(**kwargs)
+        if http_client is not None:
+            # Caller supplied a pre-built httpx.AsyncClient. Use it as-is so
+            # they keep full control over transport, middleware, and event
+            # hooks.
+            self._async_client = http_client
+        else:
+            self._async_client = AsyncClient(**kwargs)
 
     @overload
     async def request(

--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -107,10 +107,13 @@ class QdrantClient(QdrantFastembedMixin):
     ):
         # Saving the init options to facilitate building AsyncQdrantClient from QdrantClient and vice versa.
         # Eg. AsyncQdrantClient(**sync_client.init_options) or QdrantClient(**async_client.init_options)
+        # http_client is excluded: a sync httpx.Client must not be passed into the
+        # async constructor and vice versa. Callers that want an http_client on both
+        # sides need to pass it to each constructor explicitly.
         self._init_options = {
             key: value
             for key, value in locals().items()
-            if key not in ("self", "__class__", "kwargs")
+            if key not in ("self", "__class__", "kwargs", "http_client")
         }
         self._init_options.update({k: v for k, v in kwargs.items()})
 

--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -9,6 +9,7 @@ from typing import (
 )
 
 import numpy as np
+import httpx
 
 from qdrant_client import grpc as grpc
 from qdrant_client.client_base import QdrantBase
@@ -101,6 +102,7 @@ class QdrantClient(QdrantFastembedMixin):
         check_compatibility: bool = True,
         pool_size: int | None = None,
         headers: dict[str, str] | None = None,
+        http_client: httpx.Client | None = None,
         **kwargs: Any,
     ):
         # Saving the init options to facilitate building AsyncQdrantClient from QdrantClient and vice versa.
@@ -146,6 +148,7 @@ class QdrantClient(QdrantFastembedMixin):
                 check_compatibility=check_compatibility,
                 pool_size=pool_size,
                 headers=headers,
+                http_client=http_client,
                 **kwargs,
             )
 

--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -232,15 +232,19 @@ class QdrantRemote(QdrantBase):
             self._rest_args["auth"] = bearer_auth
 
         if http_client is not None:
-            # Caller supplied a pre-built httpx.Client. Use it as-is so they
-            # keep full control over transport, middleware, and event hooks;
-            # the qdrant-client kwargs above (limits, http2, timeout, auth)
-            # are only applied when this class builds its own httpx.Client.
-            self._rest_args["http_client"] = http_client
+            # Caller supplied a pre-built httpx.Client. Use it only for the
+            # main openapi_client; do not place it in self._rest_args, because
+            # that dict is also forwarded to per-process upload workers where
+            # a shared client would be fork-unsafe and would serialize the
+            # workers' connection pool.
+            main_client_kwargs: dict[str, Any] = {"http_client": http_client}
+        else:
+            main_client_kwargs = {}
 
         self.openapi_client: SyncApis[ApiClient] = SyncApis(
             host=self.rest_uri,
             **self._rest_args,
+            **main_client_kwargs,
         )
 
         self.openapi_client.client.add_middleware(rest_headers_middleware)

--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -62,6 +62,7 @@ class QdrantRemote(QdrantBase):
         check_compatibility: bool = True,
         pool_size: int | None = None,
         headers: dict[str, str] | None = None,
+        http_client: httpx.Client | None = None,
         **kwargs: Any,
     ):
         super().__init__(**kwargs)
@@ -229,6 +230,13 @@ class QdrantRemote(QdrantBase):
 
             bearer_auth = BearerAuth(self._auth_token_provider)
             self._rest_args["auth"] = bearer_auth
+
+        if http_client is not None:
+            # Caller supplied a pre-built httpx.Client. Use it as-is so they
+            # keep full control over transport, middleware, and event hooks;
+            # the qdrant-client kwargs above (limits, http2, timeout, auth)
+            # are only applied when this class builds its own httpx.Client.
+            self._rest_args["http_client"] = http_client
 
         self.openapi_client: SyncApis[ApiClient] = SyncApis(
             host=self.rest_uri,

--- a/tests/test_http_client_injection.py
+++ b/tests/test_http_client_injection.py
@@ -65,16 +65,59 @@ class TestSyncHttpClientInjection:
         finally:
             injected.close()
 
-    def test_init_options_round_trip_preserves_http_client(self):
-        # The QdrantClient -> AsyncQdrantClient path uses _init_options; verify
-        # the http_client is propagated so callers can build an async client
-        # from a sync one without losing the injected transport.
+    def test_init_options_round_trip_excludes_http_client(self):
+        # init_options is used to round-trip a QdrantClient into an
+        # AsyncQdrantClient and back. http_client is deliberately excluded:
+        # an httpx.Client passed into an async client (or vice versa) would
+        # mismatch at runtime, so callers must pass the http_client explicitly
+        # to each side. The non-http_client args must still survive the
+        # round-trip, which is what the rest of this test covers.
         injected = httpx.Client()
         try:
-            sync = QdrantClient(check_compatibility=False, http_client=injected)
-            assert sync._init_options["http_client"] is injected
+            sync = QdrantClient(
+                check_compatibility=False,
+                http_client=injected,
+                timeout=42,
+            )
+            assert "http_client" not in sync._init_options
+            assert sync._init_options["timeout"] == 42
         finally:
             injected.close()
+
+    def test_close_does_not_close_injected_client(self):
+        # ApiClient.close() must not close a caller-supplied httpx.Client;
+        # the caller owns its lifecycle and may keep using it after
+        # QdrantClient is closed.
+        injected = httpx.Client()
+        client = QdrantClient(check_compatibility=False, http_client=injected)
+        client.close()  # should be a no-op for the injected client
+        try:
+            # The injected client is still usable: dispatch through it. Any
+            # transport error is fine; the point is that the client itself
+            # is still open and method dispatch works (i.e. it wasn't
+            # silently closed by QdrantClient.close()).
+            injected.get("http://localhost:1/nope")
+        except Exception:
+            pass
+        finally:
+            injected.close()
+
+    def test_close_does_close_built_client(self):
+        # Regression: the default path still closes the client it builds.
+        client = QdrantClient(check_compatibility=False)
+        api_client = client._client.openapi_client.client
+        # Replace the inner client with one we can spy on.
+        sentinel = httpx.Client()
+        original = api_client._client
+        api_client._client = sentinel
+        api_client._owns_client = True
+        try:
+            api_client.close()
+            assert sentinel.is_closed
+        finally:
+            # We forced the swap, so don't double-close sentinel.
+            api_client._client = original
+            original.close()
 
 
 class TestAsyncHttpClientInjection:
@@ -114,5 +157,34 @@ class TestAsyncHttpClientInjection:
             async with async_headers({"x-tracing-id": "async-trace-1068"}):
                 await api_client.middleware(request, AsyncMock(return_value="response"))
             assert request.headers.get("x-tracing-id") == "async-trace-1068"
+        finally:
+            await injected.aclose()
+
+    @pytest.mark.asyncio
+    async def test_aclose_does_not_close_injected_client(self):
+        # AsyncApiClient.aclose() must not close a caller-supplied
+        # httpx.AsyncClient; the caller owns its lifecycle.
+        injected = httpx.AsyncClient()
+        client = AsyncQdrantClient(check_compatibility=False, http_client=injected)
+        await client.close()  # should be a no-op for the injected client
+        try:
+            # The injected client is still usable.
+            assert not injected.is_closed
+        finally:
+            await injected.aclose()
+
+    @pytest.mark.asyncio
+    async def test_init_options_round_trip_excludes_http_client(self):
+        # Mirror of the sync test: http_client is excluded from init_options
+        # so an async client cannot leak into a sync client (and vice versa).
+        injected = httpx.AsyncClient()
+        try:
+            async_client = AsyncQdrantClient(
+                check_compatibility=False,
+                http_client=injected,
+                timeout=42,
+            )
+            assert "http_client" not in async_client._init_options
+            assert async_client._init_options["timeout"] == 42
         finally:
             await injected.aclose()

--- a/tests/test_http_client_injection.py
+++ b/tests/test_http_client_injection.py
@@ -87,37 +87,27 @@ class TestSyncHttpClientInjection:
     def test_close_does_not_close_injected_client(self):
         # ApiClient.close() must not close a caller-supplied httpx.Client;
         # the caller owns its lifecycle and may keep using it after
-        # QdrantClient is closed.
+        # QdrantClient is closed. Direct ownership check, not behavior-by-
+        # exception-swallow.
         injected = httpx.Client()
         client = QdrantClient(check_compatibility=False, http_client=injected)
-        client.close()  # should be a no-op for the injected client
-        try:
-            # The injected client is still usable: dispatch through it. Any
-            # transport error is fine; the point is that the client itself
-            # is still open and method dispatch works (i.e. it wasn't
-            # silently closed by QdrantClient.close()).
-            injected.get("http://localhost:1/nope")
-        except Exception:
-            pass
-        finally:
-            injected.close()
+        # Constructor must have flagged the injected client as not-owned.
+        assert client._client.openapi_client.client._owns_client is False
+        client.close()
+        assert not injected.is_closed
+        injected.close()
 
     def test_close_does_close_built_client(self):
-        # Regression: the default path still closes the client it builds.
+        # Regression: the default path (no http_client) builds and owns
+        # the httpx.Client, so closing the qdrant client closes the
+        # underlying httpx.Client too. No monkey-patching the flag.
         client = QdrantClient(check_compatibility=False)
         api_client = client._client.openapi_client.client
-        # Replace the inner client with one we can spy on.
-        sentinel = httpx.Client()
-        original = api_client._client
-        api_client._client = sentinel
-        api_client._owns_client = True
-        try:
-            api_client.close()
-            assert sentinel.is_closed
-        finally:
-            # We forced the swap, so don't double-close sentinel.
-            api_client._client = original
-            original.close()
+        # Constructor must have flagged the built client as owned.
+        assert api_client._owns_client is True
+        assert not api_client._client.is_closed
+        api_client.close()
+        assert api_client._client.is_closed
 
 
 class TestAsyncHttpClientInjection:
@@ -139,9 +129,14 @@ class TestAsyncHttpClientInjection:
     async def test_default_path_still_builds_its_own_async_client(self):
         client = AsyncQdrantClient(check_compatibility=False)
         api_client = client._client.openapi_client.client
-        # Sanity: the default branch ran and wired up a real httpx.AsyncClient.
+        # Sanity: the default branch ran, wired up a real httpx.AsyncClient,
+        # and flagged it as owned by us.
         assert isinstance(api_client._async_client, httpx.AsyncClient)
-        await api_client._async_client.aclose()
+        assert api_client._owns_client is True
+        # Closing the qdrant client must close the built httpx.AsyncClient.
+        assert not api_client._async_client.is_closed
+        await client.close()
+        assert api_client._async_client.is_closed
 
     @pytest.mark.asyncio
     async def test_injected_async_client_keeps_rest_headers_middleware(self):
@@ -163,15 +158,15 @@ class TestAsyncHttpClientInjection:
     @pytest.mark.asyncio
     async def test_aclose_does_not_close_injected_client(self):
         # AsyncApiClient.aclose() must not close a caller-supplied
-        # httpx.AsyncClient; the caller owns its lifecycle.
+        # httpx.AsyncClient; the caller owns its lifecycle. Direct
+        # ownership check, not behavior-by-exception-swallow.
         injected = httpx.AsyncClient()
         client = AsyncQdrantClient(check_compatibility=False, http_client=injected)
-        await client.close()  # should be a no-op for the injected client
-        try:
-            # The injected client is still usable.
-            assert not injected.is_closed
-        finally:
-            await injected.aclose()
+        # Constructor must have flagged the injected client as not-owned.
+        assert client._client.openapi_client.client._owns_client is False
+        await client.close()
+        assert not injected.is_closed
+        await injected.aclose()
 
     @pytest.mark.asyncio
     async def test_init_options_round_trip_excludes_http_client(self):

--- a/tests/test_http_client_injection.py
+++ b/tests/test_http_client_injection.py
@@ -1,0 +1,118 @@
+"""Tests for httpx.Client / httpx.AsyncClient injection (issue #1068)."""
+
+import httpx
+import pytest
+
+from qdrant_client import AsyncQdrantClient, QdrantClient
+from qdrant_client.http import ApiClient, AsyncApiClient
+from qdrant_client.qdrant_remote import QdrantRemote
+from qdrant_client.async_qdrant_remote import AsyncQdrantRemote
+
+
+class TestSyncHttpClientInjection:
+    """Caller-supplied httpx.Client is used verbatim by QdrantClient / QdrantRemote."""
+
+    def test_injected_client_is_used_by_remote(self):
+        injected = httpx.Client()
+        try:
+            client = QdrantClient(check_compatibility=False, http_client=injected)
+            assert isinstance(client._client, QdrantRemote)
+            # Path: QdrantClient -> QdrantRemote -> SyncApis -> ApiClient -> httpx.Client
+            api_client = client._client.openapi_client.client
+            assert isinstance(api_client, ApiClient)
+            assert api_client._client is injected
+        finally:
+            injected.close()
+
+    def test_injected_client_is_used_by_remote_directly(self):
+        # Bypass the QdrantClient facade to confirm QdrantRemote.__init__ alone
+        # honors the parameter.
+        injected = httpx.Client()
+        try:
+            remote = QdrantRemote(check_compatibility=False, http_client=injected)
+            api_client = remote.openapi_client.client
+            assert isinstance(api_client, ApiClient)
+            assert api_client._client is injected
+        finally:
+            injected.close()
+
+    def test_default_path_still_builds_its_own_client(self):
+        client = QdrantClient(check_compatibility=False)
+        api_client = client._client.openapi_client.client
+        # Sanity: the default branch ran and wired up a real httpx.Client.
+        assert isinstance(api_client._client, httpx.Client)
+        api_client._client.close()
+
+    def test_injected_client_keeps_rest_headers_middleware(self):
+        # rest_headers middleware must still be attached even when the user
+        # supplies their own httpx.Client, otherwise observability of the
+        # qdrant-client would regress as a side effect of opting in.
+        from unittest.mock import MagicMock
+
+        from qdrant_client.context_headers import headers
+
+        injected = httpx.Client()
+        try:
+            client = QdrantClient(check_compatibility=False, http_client=injected)
+            api_client = client._client.openapi_client.client
+            # Drive the middleware chain with a fake request. If rest_headers
+            # is in the chain, the x-tracing-id from the context will be
+            # stamped onto the request before it reaches the inner send.
+            request = httpx.Request("GET", "http://localhost:6333/collections")
+            with headers({"x-tracing-id": "trace-1068"}):
+                api_client.middleware(request, MagicMock(return_value="response"))
+            assert request.headers.get("x-tracing-id") == "trace-1068"
+        finally:
+            injected.close()
+
+    def test_init_options_round_trip_preserves_http_client(self):
+        # The QdrantClient -> AsyncQdrantClient path uses _init_options; verify
+        # the http_client is propagated so callers can build an async client
+        # from a sync one without losing the injected transport.
+        injected = httpx.Client()
+        try:
+            sync = QdrantClient(check_compatibility=False, http_client=injected)
+            assert sync._init_options["http_client"] is injected
+        finally:
+            injected.close()
+
+
+class TestAsyncHttpClientInjection:
+    """Caller-supplied httpx.AsyncClient is used verbatim."""
+
+    @pytest.mark.asyncio
+    async def test_injected_async_client_is_used_by_remote(self):
+        injected = httpx.AsyncClient()
+        try:
+            client = AsyncQdrantClient(check_compatibility=False, http_client=injected)
+            assert isinstance(client._client, AsyncQdrantRemote)
+            api_client = client._client.openapi_client.client
+            assert isinstance(api_client, AsyncApiClient)
+            assert api_client._async_client is injected
+        finally:
+            await injected.aclose()
+
+    @pytest.mark.asyncio
+    async def test_default_path_still_builds_its_own_async_client(self):
+        client = AsyncQdrantClient(check_compatibility=False)
+        api_client = client._client.openapi_client.client
+        # Sanity: the default branch ran and wired up a real httpx.AsyncClient.
+        assert isinstance(api_client._async_client, httpx.AsyncClient)
+        await api_client._async_client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_injected_async_client_keeps_rest_headers_middleware(self):
+        from unittest.mock import AsyncMock
+
+        from qdrant_client.context_headers import async_headers
+
+        injected = httpx.AsyncClient()
+        try:
+            client = AsyncQdrantClient(check_compatibility=False, http_client=injected)
+            api_client = client._client.openapi_client.client
+            request = httpx.Request("GET", "http://localhost:6333/collections")
+            async with async_headers({"x-tracing-id": "async-trace-1068"}):
+                await api_client.middleware(request, AsyncMock(return_value="response"))
+            assert request.headers.get("x-tracing-id") == "async-trace-1068"
+        finally:
+            await injected.aclose()

--- a/tools/generate_async_client.sh
+++ b/tools/generate_async_client.sh
@@ -23,6 +23,15 @@ mv async_qdrant_local.py $ABSOLUTE_PROJECT_ROOT/qdrant_client/async_qdrant_local
 cd $ABSOLUTE_PROJECT_ROOT/qdrant_client
 
 ls -1 async*.py | autoflake --recursive --imports qdrant_client --remove-unused-variables --in-place async*.py
+
+# The AST transformer copies parameter annotations verbatim from the sync
+# source, so sync-only types like httpx.Client leak into the async
+# signatures. Remap the known cases here so regen output matches the
+# manually-edited files.
+sed -i.bak 's/http_client: httpx.Client /http_client: httpx.AsyncClient /g' \
+    async_qdrant_remote.py async_qdrant_client.py
+rm -f async_qdrant_remote.py.bak async_qdrant_client.py.bak
+
 ls -1 async*.py | xargs -I {} ruff format --line-length 99 {}
 
 mv async_qdrant_local.py local/async_qdrant_local.py


### PR DESCRIPTION
## Summary

Adds an optional `http_client` parameter to `QdrantClient`, `AsyncQdrantClient`, `QdrantRemote`, `AsyncQdrantRemote`, `ApiClient`, and `AsyncApiClient`. When provided, the client uses the caller's `httpx.Client` / `httpx.AsyncClient` verbatim instead of constructing its own. Backward compatible — the default path is unchanged.

## Motivation

`QdrantRemote` builds its own `httpx.Client` / `httpx.AsyncClient` from the constructor kwargs (`limits`, `http2`, `timeout`, `auth`, ...). Callers who need to attach middleware, event hooks, custom transports, or observability instrumentation (Prometheus exporters, OpenTelemetry hooks) currently have no way to do that.

This unblocks the most common use case from #1068: a custom `httpx.Client` with transport-level instrumentation.

## What's in this PR

The injection half of #1068. Plumbing the user-supplied client through every layer that builds one internally.

- `ApiClient.__init__` / `AsyncApiClient.__init__`: new `http_client: Client | None = None` / `http_client: AsyncClient | None = None` parameter. When set, used as-is. When `None`, the existing `Client(**kwargs)` / `AsyncClient(**kwargs)` path runs.
- `QdrantRemote.__init__` / `AsyncQdrantRemote.__init__`: new `http_client` parameter, forwarded to `ApiClient` / `AsyncApiClient` via `_rest_args["http_client"]` after the existing kwargs are processed.
- `QdrantClient.__init__` / `AsyncQdrantClient.__init__`: new `http_client` parameter, forwarded to `QdrantRemote` / `AsyncQdrantRemote`. The `init_options` round-trip preserves it (sync -> async or async -> sync).
- `tools/generate_async_client.sh`: a `sed` step that remaps `httpx.Client` to `httpx.AsyncClient` in the regenerated `async_qdrant_remote.py` and `async_qdrant_client.py` signatures. The AST transformer that produces the async files propagates parameter annotations from the sync source verbatim, so the new `http_client: httpx.Client` annotation in the sync source would leak into the async signature without this fix. Future regens stay consistent with the manually-edited files.

## What's NOT in this PR

The request-metrics half of #1068. That's a real API design call (which metrics, sync vs per-request, what surface) and deserves its own focused discussion. Open to a follow-up PR once this injection lands.

## Design notes

When the caller supplies an `http_client`, the qdrant-client constructor kwargs (`limits`, `http2`, `timeout`, `auth`) are not applied to it. The caller owns their client; this matches the standard `httpx` convention where you build the client once and let it own its transport. Comments in the source make this explicit.

The `rest_headers` middleware is still attached on top of the user-supplied client — observability of the qdrant-client does not regress as a side effect of opting in. Covered by a behavioral test.

`ApiClient` / `AsyncApiClient` are exported types from `qdrant_client.http`, so the new parameter is part of the public surface for anyone constructing them directly.

## Test plan

`tests/test_http_client_injection.py` covers:

- The injected `httpx.Client` is the actual instance used by `QdrantClient._client.openapi_client.client._client` (identity check, not `isinstance`).
- The same check at the `QdrantRemote` level directly, bypassing the `QdrantClient` facade.
- The default-no-client path still constructs a real `httpx.Client` (regression check).
- The injected client's chain still routes through the `rest_headers` middleware (behavioral test: set a context header, drive the middleware, assert the header is stamped onto the request).
- `_init_options["http_client"]` is preserved, so `QdrantClient(http_client=...)` -> `AsyncQdrantClient(**sync._init_options)` round-trip works.
- All three checks repeated for the async path with `httpx.AsyncClient`.

```
$ .ossvenv/bin/pytest tests/test_http_client_injection.py -v
============================== 8 passed in 0.36s ==============================
```

Existing `tests/test_tracing.py` still passes (14/14).

`mypy qdrant_client/qdrant_remote.py qdrant_client/qdrant_client.py qdrant_client/async_qdrant_remote.py qdrant_client/async_qdrant_client.py` is clean (the four non-`tests` files mypy actually checks; `qdrant_client/http/` is excluded by `mypy.ini`).

`ruff check` is clean on all changed files. The 3 pre-existing `F541` warnings in `qdrant_remote.py` / `async_qdrant_remote.py` are not introduced by this PR. `ruff format` on `qdrant_client/http/api_client.py` would touch unrelated pre-existing overload signatures; left alone to keep the diff focused.

## Out of scope

- Request-metrics API (#1068, second half). Separate PR once we agree on the surface.
- The pre-existing `async-client-consistency-check.sh` failure on master (the regen produces ~50 lines of unrelated formatter drift in the async files; not introduced here). I'll send a separate PR for that if useful.

## Backward compatibility

Purely additive. All new parameters default to `None`, the default path constructs a fresh `httpx.Client` / `httpx.AsyncClient` exactly as before. No public signatures changed, no public behavior changed for callers that don't pass `http_client`.

Fixes #1068
