### PR TITLE
fix(remote): propagate gRPC timeout fallback to the protobuf field

### DIFF
--- a/qdrant_client/async_qdrant_remote.py
+++ b/qdrant_client/async_qdrant_remote.py
@@ -45,6 +45,13 @@ class AsyncQdrantRemote(AsyncQdrantBase):
     DEFAULT_GRPC_TIMEOUT = 5
     DEFAULT_GRPC_POOL_SIZE = 3
 
+    def _effective_timeout(self, timeout: int | None) -> int:
+        # Single source of truth for the per-call / global fallback rule.
+        # Every gRPC call site in this file uses this so a future
+        # method that takes a `timeout=` arg cannot accidentally bypass
+        # `self._timeout` again. See issue #948.
+        return timeout if timeout is not None else self._timeout
+
     def __init__(
         self,
         url: str | None = None,
@@ -430,7 +437,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.QueryResponse:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if query is not None:
                 query = RestToGrpc.convert_query(query)
             if isinstance(prefetch, models.Prefetch):
@@ -518,7 +525,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> list[types.QueryResponse]:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             requests = [
                 RestToGrpc.convert_query_request(r, collection_name)
                 if isinstance(r, models.QueryRequest)
@@ -585,7 +592,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.GroupsResult:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if query is not None:
                 query = RestToGrpc.convert_query(query)
             if isinstance(prefetch, models.Prefetch):
@@ -685,7 +692,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.SearchMatrixPairsResponse:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if isinstance(query_filter, models.Filter):
                 query_filter = RestToGrpc.convert_filter(model=query_filter)
             if isinstance(shard_key_selector, get_args_subscribed(models.ShardKeySelector)):
@@ -738,7 +745,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.SearchMatrixOffsetsResponse:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if isinstance(query_filter, models.Filter):
                 query_filter = RestToGrpc.convert_filter(model=query_filter)
             if isinstance(shard_key_selector, get_args_subscribed(models.ShardKeySelector)):
@@ -793,7 +800,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> tuple[list[types.Record], types.PointId | None]:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if isinstance(offset, get_args_subscribed(models.ExtendedPointId)):
                 offset = RestToGrpc.convert_extended_point_id(offset)
             if isinstance(scroll_filter, models.Filter):
@@ -868,7 +875,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.CountResult:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if isinstance(count_filter, models.Filter):
                 count_filter = RestToGrpc.convert_filter(model=count_filter)
             if isinstance(shard_key_selector, get_args_subscribed(models.ShardKeySelector)):
@@ -917,7 +924,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.FacetResponse:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if isinstance(facet_filter, models.Filter):
                 facet_filter = RestToGrpc.convert_filter(model=facet_filter)
             if isinstance(shard_key_selector, get_args_subscribed(models.ShardKeySelector)):
@@ -972,7 +979,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if isinstance(points, models.Batch):
                 vectors_batch: list[grpc.Vectors] = RestToGrpc.convert_batch_vector_struct(
                     points.vectors, len(points.ids)
@@ -1066,7 +1073,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             points = [RestToGrpc.convert_point_vectors(point) for point in points]
             if isinstance(ordering, models.WriteOrdering):
                 ordering = RestToGrpc.convert_write_ordering(ordering)
@@ -1117,7 +1124,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             (points_selector, opt_shard_key_selector) = self._try_argument_to_grpc_selector(points)
             shard_key_selector = shard_key_selector or opt_shard_key_selector
             if isinstance(ordering, models.WriteOrdering):
@@ -1170,7 +1177,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> list[types.Record]:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if isinstance(with_payload, get_args_subscribed(models.WithPayloadInterface)):
                 with_payload = RestToGrpc.convert_with_payload_interface(with_payload)
             ids = [
@@ -1339,7 +1346,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             (points_selector, opt_shard_key_selector) = self._try_argument_to_grpc_selector(
                 points_selector
             )
@@ -1392,7 +1399,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             (points_selector, opt_shard_key_selector) = self._try_argument_to_grpc_selector(points)
             shard_key_selector = shard_key_selector or opt_shard_key_selector
             if isinstance(ordering, models.WriteOrdering):
@@ -1448,7 +1455,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             (points_selector, opt_shard_key_selector) = self._try_argument_to_grpc_selector(points)
             shard_key_selector = shard_key_selector or opt_shard_key_selector
             if isinstance(ordering, models.WriteOrdering):
@@ -1502,7 +1509,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             (points_selector, opt_shard_key_selector) = self._try_argument_to_grpc_selector(points)
             shard_key_selector = shard_key_selector or opt_shard_key_selector
             if isinstance(ordering, models.WriteOrdering):
@@ -1552,7 +1559,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             (points_selector, opt_shard_key_selector) = self._try_argument_to_grpc_selector(
                 points_selector
             )
@@ -1602,7 +1609,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> list[types.UpdateResult]:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             update_operations = [
                 RestToGrpc.convert_update_operation(operation) for operation in update_operations
             ]
@@ -1643,7 +1650,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> bool:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             change_aliases_operation = [
                 RestToGrpc.convert_alias_operations(operation)
                 if not isinstance(operation, grpc.AliasOperations)
@@ -1677,7 +1684,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         self, collection_name: str, **kwargs: Any
     ) -> types.CollectionsAliasesResponse:
         if self._prefer_grpc:
-            effective_timeout = self._timeout
+            effective_timeout = self._effective_timeout(None)
             response = (
                 await self.grpc_collections.ListCollectionAliases(
                     grpc.ListCollectionAliasesRequest(collection_name=collection_name),
@@ -1734,7 +1741,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
 
     async def get_collection(self, collection_name: str, **kwargs: Any) -> types.CollectionInfo:
         if self._prefer_grpc:
-            effective_timeout = self._timeout
+            effective_timeout = self._effective_timeout(None)
             return GrpcToRest.convert_collection_info(
                 (
                     await self.grpc_collections.Get(
@@ -1751,7 +1758,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
 
     async def collection_exists(self, collection_name: str, **kwargs: Any) -> bool:
         if self._prefer_grpc:
-            effective_timeout = self._timeout
+            effective_timeout = self._effective_timeout(None)
             return (
                 await self.grpc_collections.CollectionExists(
                     grpc.CollectionExistsRequest(collection_name=collection_name),
@@ -1779,7 +1786,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> bool:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if isinstance(optimizers_config, models.OptimizersConfigDiff):
                 optimizers_config = RestToGrpc.convert_optimizers_config_diff(optimizers_config)
             if isinstance(collection_params, models.CollectionParamsDiff):
@@ -1850,7 +1857,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         self, collection_name: str, timeout: int | None = None, **kwargs: Any
     ) -> bool:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             return (
                 await self.grpc_collections.Delete(
                     grpc.DeleteCollection(collection_name=collection_name, timeout=effective_timeout),
@@ -1883,6 +1890,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> bool:
         if self._prefer_grpc:
+            effective_timeout = self._effective_timeout(timeout)
             if isinstance(vectors_config, (models.VectorParams, dict)):
                 vectors_config = RestToGrpc.convert_vectors_config(vectors_config)
             if isinstance(hnsw_config, models.HnswConfigDiff):
@@ -1910,7 +1918,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                 optimizers_config=optimizers_config,
                 shard_number=shard_number,
                 on_disk_payload=on_disk_payload,
-                timeout=timeout,
+                timeout=effective_timeout,
                 vectors_config=vectors_config,
                 replication_factor=replication_factor,
                 write_consistency_factor=write_consistency_factor,
@@ -1921,7 +1929,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                 metadata=metadata,
             )
             return (
-                await self.grpc_collections.Create(create_collection, timeout=self._timeout)
+                await self.grpc_collections.Create(create_collection, timeout=effective_timeout)
             ).result
         if isinstance(hnsw_config, grpc.HnswConfigDiff):
             hnsw_config = GrpcToRest.convert_hnsw_config_diff(hnsw_config)
@@ -2137,6 +2145,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
             )
             field_schema = field_type
         if self._prefer_grpc:
+            effective_timeout = self._effective_timeout(timeout)
             field_index_params = None
             if isinstance(field_schema, models.PayloadSchemaType):
                 field_schema = RestToGrpc.convert_payload_schema_type(field_schema)
@@ -2175,10 +2184,10 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                 field_index_params=field_index_params,
                 wait=wait,
                 ordering=ordering,
-                timeout=timeout,
+                timeout=effective_timeout,
             )
             return GrpcToRest.convert_update_result(
-                (await self.grpc_points.CreateFieldIndex(request, timeout=self._timeout)).result
+                (await self.grpc_points.CreateFieldIndex(request, timeout=effective_timeout)).result
             )
         if isinstance(field_schema, int):
             field_schema = GrpcToRest.convert_payload_schema_type(field_schema)
@@ -2208,15 +2217,16 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
+            effective_timeout = self._effective_timeout(timeout)
             request = grpc.DeleteFieldIndexCollection(
                 collection_name=collection_name,
                 field_name=field_name,
                 wait=wait,
                 ordering=ordering,
-                timeout=timeout,
+                timeout=effective_timeout,
             )
             return GrpcToRest.convert_update_result(
-                (await self.grpc_points.DeleteFieldIndex(request, timeout=self._timeout)).result
+                (await self.grpc_points.DeleteFieldIndex(request, timeout=effective_timeout)).result
             )
         result: types.UpdateResult | None = (
             await self.openapi_client.indexes_api.delete_field_index(
@@ -2241,6 +2251,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
+            effective_timeout = self._effective_timeout(timeout)
             dense_config = None
             sparse_config = None
             if isinstance(vector_name_config, models.DenseVectorNameConfig):
@@ -2278,11 +2289,11 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                 vector_name=vector_name,
                 dense_config=dense_config,
                 sparse_config=sparse_config,
-                timeout=timeout,
+                timeout=effective_timeout,
                 ordering=grpc_ordering,
             )
             return GrpcToRest.convert_update_result(
-                (await self.grpc_points.CreateVectorName(request, timeout=self._timeout)).result
+                (await self.grpc_points.CreateVectorName(request, timeout=effective_timeout)).result
             )
         result: types.UpdateResult | None = (
             await self.http.collections_api.create_vector_name(
@@ -2307,6 +2318,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
+            effective_timeout = self._effective_timeout(timeout)
             grpc_ordering = (
                 RestToGrpc.convert_write_ordering(ordering)
                 if isinstance(ordering, models.WriteOrdering)
@@ -2316,11 +2328,11 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                 collection_name=collection_name,
                 wait=wait,
                 vector_name=vector_name,
-                timeout=timeout,
+                timeout=effective_timeout,
                 ordering=grpc_ordering,
             )
             return GrpcToRest.convert_update_result(
-                (await self.grpc_points.DeleteVectorName(request, timeout=self._timeout)).result
+                (await self.grpc_points.DeleteVectorName(request, timeout=effective_timeout)).result
             )
         result: types.UpdateResult | None = (
             await self.openapi_client.collections_api.delete_vector_name(
@@ -2338,7 +2350,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         self, collection_name: str, **kwargs: Any
     ) -> list[types.SnapshotDescription]:
         if self._prefer_grpc:
-            effective_timeout = self._timeout
+            effective_timeout = self._effective_timeout(None)
             snapshots = (
                 await self.grpc_snapshots.List(
                     grpc.ListSnapshotsRequest(collection_name=collection_name),
@@ -2356,7 +2368,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         self, collection_name: str, wait: bool = True, **kwargs: Any
     ) -> types.SnapshotDescription | None:
         if self._prefer_grpc:
-            effective_timeout = self._timeout
+            effective_timeout = self._effective_timeout(None)
             snapshot = (
                 await self.grpc_snapshots.Create(
                     grpc.CreateSnapshotRequest(collection_name=collection_name),
@@ -2374,7 +2386,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         self, collection_name: str, snapshot_name: str, wait: bool = True, **kwargs: Any
     ) -> bool | None:
         if self._prefer_grpc:
-            effective_timeout = self._timeout
+            effective_timeout = self._effective_timeout(None)
             await self.grpc_snapshots.Delete(
                 grpc.DeleteSnapshotRequest(
                     collection_name=collection_name, snapshot_name=snapshot_name
@@ -2517,7 +2529,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> bool:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if isinstance(shard_key, get_args_subscribed(models.ShardKey)):
                 shard_key = RestToGrpc.convert_shard_key(shard_key)
             if isinstance(initial_state, models.ReplicaState):
@@ -2563,7 +2575,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> bool:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if isinstance(shard_key, get_args_subscribed(models.ShardKey)):
                 shard_key = RestToGrpc.convert_shard_key(shard_key)
             return (
@@ -2605,7 +2617,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> bool:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             cluster_operation = RestToGrpc.convert_cluster_operations(cluster_operation)
             grpc_operation = {}
             if isinstance(cluster_operation, grpc.MoveShard):
@@ -2667,7 +2679,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
 
     async def collection_cluster_info(self, collection_name: str) -> types.CollectionClusterInfo:
         if self._prefer_grpc:
-            effective_timeout = self._timeout
+            effective_timeout = self._effective_timeout(None)
             collection_info = await self.grpc_collections.CollectionClusterInfo(
                 grpc.CollectionClusterInfoRequest(collection_name=collection_name),
                 timeout=effective_timeout,

--- a/qdrant_client/async_qdrant_remote.py
+++ b/qdrant_client/async_qdrant_remote.py
@@ -430,6 +430,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.QueryResponse:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if query is not None:
                 query = RestToGrpc.convert_query(query)
             if isinstance(prefetch, models.Prefetch):
@@ -467,11 +468,11 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                     score_threshold=score_threshold,
                     using=using,
                     lookup_from=lookup_from,
-                    timeout=timeout,
+                    timeout=effective_timeout,
                     shard_key_selector=shard_key_selector,
                     read_consistency=consistency,
                 ),
-                timeout=timeout if timeout is not None else self._timeout,
+                timeout=effective_timeout,
             )
             scored_points = [GrpcToRest.convert_scored_point(hit) for hit in res.result]
             return models.QueryResponse(points=scored_points)
@@ -517,6 +518,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> list[types.QueryResponse]:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             requests = [
                 RestToGrpc.convert_query_request(r, collection_name)
                 if isinstance(r, models.QueryRequest)
@@ -530,9 +532,9 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                     collection_name=collection_name,
                     query_points=requests,
                     read_consistency=consistency,
-                    timeout=timeout,
+                    timeout=effective_timeout,
                 ),
-                timeout=timeout if timeout is not None else self._timeout,
+                timeout=effective_timeout,
             )
             return [
                 models.QueryResponse(
@@ -583,6 +585,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.GroupsResult:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if query is not None:
                 query = RestToGrpc.convert_query(query)
             if isinstance(prefetch, models.Prefetch):
@@ -627,11 +630,11 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                         group_size=group_size,
                         with_lookup=with_lookup,
                         lookup_from=lookup_from,
-                        timeout=timeout,
+                        timeout=effective_timeout,
                         shard_key_selector=shard_key_selector,
                         read_consistency=consistency,
                     ),
-                    timeout=timeout if timeout is not None else self._timeout,
+                    timeout=effective_timeout,
                 )
             ).result
             return GrpcToRest.convert_groups_result(result)
@@ -682,6 +685,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.SearchMatrixPairsResponse:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if isinstance(query_filter, models.Filter):
                 query_filter = RestToGrpc.convert_filter(model=query_filter)
             if isinstance(shard_key_selector, get_args_subscribed(models.ShardKeySelector)):
@@ -695,11 +699,11 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                     sample=sample,
                     limit=limit,
                     using=using,
-                    timeout=timeout,
+                    timeout=effective_timeout,
                     read_consistency=consistency,
                     shard_key_selector=shard_key_selector,
                 ),
-                timeout=timeout if timeout is not None else self._timeout,
+                timeout=effective_timeout,
             )
             return GrpcToRest.convert_search_matrix_pairs(response.result)
         if isinstance(query_filter, grpc.Filter):
@@ -734,6 +738,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.SearchMatrixOffsetsResponse:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if isinstance(query_filter, models.Filter):
                 query_filter = RestToGrpc.convert_filter(model=query_filter)
             if isinstance(shard_key_selector, get_args_subscribed(models.ShardKeySelector)):
@@ -747,11 +752,11 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                     sample=sample,
                     limit=limit,
                     using=using,
-                    timeout=timeout,
+                    timeout=effective_timeout,
                     read_consistency=consistency,
                     shard_key_selector=shard_key_selector,
                 ),
-                timeout=timeout if timeout is not None else self._timeout,
+                timeout=effective_timeout,
             )
             return GrpcToRest.convert_search_matrix_offsets(response.result)
         if isinstance(query_filter, grpc.Filter):
@@ -788,6 +793,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> tuple[list[types.Record], types.PointId | None]:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if isinstance(offset, get_args_subscribed(models.ExtendedPointId)):
                 offset = RestToGrpc.convert_extended_point_id(offset)
             if isinstance(scroll_filter, models.Filter):
@@ -813,9 +819,9 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                     limit=limit,
                     read_consistency=consistency,
                     shard_key_selector=shard_key_selector,
-                    timeout=timeout,
+                    timeout=effective_timeout,
                 ),
-                timeout=timeout if timeout is not None else self._timeout,
+                timeout=effective_timeout,
             )
             return (
                 [GrpcToRest.convert_retrieved_point(point) for point in res.result],
@@ -862,6 +868,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.CountResult:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if isinstance(count_filter, models.Filter):
                 count_filter = RestToGrpc.convert_filter(model=count_filter)
             if isinstance(shard_key_selector, get_args_subscribed(models.ShardKeySelector)):
@@ -875,10 +882,10 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                         filter=count_filter,
                         exact=exact,
                         shard_key_selector=shard_key_selector,
-                        timeout=timeout,
+                        timeout=effective_timeout,
                         read_consistency=consistency,
                     ),
-                    timeout=timeout if timeout is not None else self._timeout,
+                    timeout=effective_timeout,
                 )
             ).result
             return GrpcToRest.convert_count_result(response)
@@ -910,6 +917,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.FacetResponse:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if isinstance(facet_filter, models.Filter):
                 facet_filter = RestToGrpc.convert_filter(model=facet_filter)
             if isinstance(shard_key_selector, get_args_subscribed(models.ShardKeySelector)):
@@ -923,11 +931,11 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                     filter=facet_filter,
                     limit=limit,
                     exact=exact,
-                    timeout=timeout,
+                    timeout=effective_timeout,
                     read_consistency=consistency,
                     shard_key_selector=shard_key_selector,
                 ),
-                timeout=timeout if timeout is not None else self._timeout,
+                timeout=effective_timeout,
             )
             return types.FacetResponse(
                 hits=[GrpcToRest.convert_facet_value_hit(hit) for hit in response.hits]
@@ -964,6 +972,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if isinstance(points, models.Batch):
                 vectors_batch: list[grpc.Vectors] = RestToGrpc.convert_batch_vector_struct(
                     points.vectors, len(points.ids)
@@ -1002,10 +1011,10 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                         ordering=ordering,
                         shard_key_selector=shard_key_selector,
                         update_filter=update_filter,
-                        timeout=timeout,
+                        timeout=effective_timeout,
                         update_mode=update_mode,
                     ),
-                    timeout=self._timeout,
+                    timeout=effective_timeout,
                 )
             ).result
             assert grpc_result is not None, "Upsert returned None result"
@@ -1057,6 +1066,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             points = [RestToGrpc.convert_point_vectors(point) for point in points]
             if isinstance(ordering, models.WriteOrdering):
                 ordering = RestToGrpc.convert_write_ordering(ordering)
@@ -1073,9 +1083,9 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                         ordering=ordering,
                         shard_key_selector=shard_key_selector,
                         update_filter=update_filter,
-                        timeout=timeout,
+                        timeout=effective_timeout,
                     ),
-                    timeout=self._timeout,
+                    timeout=effective_timeout,
                 )
             ).result
             assert grpc_result is not None, "Upsert returned None result"
@@ -1107,6 +1117,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             (points_selector, opt_shard_key_selector) = self._try_argument_to_grpc_selector(points)
             shard_key_selector = shard_key_selector or opt_shard_key_selector
             if isinstance(ordering, models.WriteOrdering):
@@ -1122,9 +1133,9 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                         points_selector=points_selector,
                         ordering=ordering,
                         shard_key_selector=shard_key_selector,
-                        timeout=timeout,
+                        timeout=effective_timeout,
                     ),
-                    timeout=self._timeout,
+                    timeout=effective_timeout,
                 )
             ).result
             assert grpc_result is not None, "Delete vectors returned None result"
@@ -1159,6 +1170,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> list[types.Record]:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if isinstance(with_payload, get_args_subscribed(models.WithPayloadInterface)):
                 with_payload = RestToGrpc.convert_with_payload_interface(with_payload)
             ids = [
@@ -1181,9 +1193,9 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                         with_vectors=with_vectors,
                         read_consistency=consistency,
                         shard_key_selector=shard_key_selector,
-                        timeout=timeout,
+                        timeout=effective_timeout,
                     ),
-                    timeout=timeout if timeout is not None else self._timeout,
+                    timeout=effective_timeout,
                 )
             ).result
             assert result is not None, "Retrieve returned None result"
@@ -1327,6 +1339,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             (points_selector, opt_shard_key_selector) = self._try_argument_to_grpc_selector(
                 points_selector
             )
@@ -1344,9 +1357,9 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                             points=points_selector,
                             ordering=ordering,
                             shard_key_selector=shard_key_selector,
-                            timeout=timeout,
+                            timeout=effective_timeout,
                         ),
-                        timeout=self._timeout,
+                        timeout=effective_timeout,
                     )
                 ).result
             )
@@ -1379,6 +1392,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             (points_selector, opt_shard_key_selector) = self._try_argument_to_grpc_selector(points)
             shard_key_selector = shard_key_selector or opt_shard_key_selector
             if isinstance(ordering, models.WriteOrdering):
@@ -1396,9 +1410,9 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                             ordering=ordering,
                             shard_key_selector=shard_key_selector,
                             key=key,
-                            timeout=timeout,
+                            timeout=effective_timeout,
                         ),
-                        timeout=self._timeout,
+                        timeout=effective_timeout,
                     )
                 ).result
             )
@@ -1434,6 +1448,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             (points_selector, opt_shard_key_selector) = self._try_argument_to_grpc_selector(points)
             shard_key_selector = shard_key_selector or opt_shard_key_selector
             if isinstance(ordering, models.WriteOrdering):
@@ -1450,9 +1465,9 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                             points_selector=points_selector,
                             ordering=ordering,
                             shard_key_selector=shard_key_selector,
-                            timeout=timeout,
+                            timeout=effective_timeout,
                         ),
-                        timeout=self._timeout,
+                        timeout=effective_timeout,
                     )
                 ).result
             )
@@ -1487,6 +1502,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             (points_selector, opt_shard_key_selector) = self._try_argument_to_grpc_selector(points)
             shard_key_selector = shard_key_selector or opt_shard_key_selector
             if isinstance(ordering, models.WriteOrdering):
@@ -1503,9 +1519,9 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                             points_selector=points_selector,
                             ordering=ordering,
                             shard_key_selector=shard_key_selector,
-                            timeout=timeout,
+                            timeout=effective_timeout,
                         ),
-                        timeout=self._timeout,
+                        timeout=effective_timeout,
                     )
                 ).result
             )
@@ -1536,6 +1552,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             (points_selector, opt_shard_key_selector) = self._try_argument_to_grpc_selector(
                 points_selector
             )
@@ -1553,9 +1570,9 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                             points=points_selector,
                             ordering=ordering,
                             shard_key_selector=shard_key_selector,
-                            timeout=timeout,
+                            timeout=effective_timeout,
                         ),
-                        timeout=self._timeout,
+                        timeout=effective_timeout,
                     )
                 ).result
             )
@@ -1585,6 +1602,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> list[types.UpdateResult]:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             update_operations = [
                 RestToGrpc.convert_update_operation(operation) for operation in update_operations
             ]
@@ -1599,9 +1617,9 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                             wait=wait,
                             operations=update_operations,
                             ordering=ordering,
-                            timeout=timeout,
+                            timeout=effective_timeout,
                         ),
-                        timeout=self._timeout,
+                        timeout=effective_timeout,
                     )
                 ).result
             ]
@@ -1625,6 +1643,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> bool:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             change_aliases_operation = [
                 RestToGrpc.convert_alias_operations(operation)
                 if not isinstance(operation, grpc.AliasOperations)
@@ -1633,8 +1652,8 @@ class AsyncQdrantRemote(AsyncQdrantBase):
             ]
             return (
                 await self.grpc_collections.UpdateAliases(
-                    grpc.ChangeAliases(timeout=timeout, actions=change_aliases_operation),
-                    timeout=timeout if timeout is not None else self._timeout,
+                    grpc.ChangeAliases(timeout=effective_timeout, actions=change_aliases_operation),
+                    timeout=effective_timeout,
                 )
             ).result
         change_aliases_operation = [
@@ -1658,10 +1677,11 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         self, collection_name: str, **kwargs: Any
     ) -> types.CollectionsAliasesResponse:
         if self._prefer_grpc:
+            effective_timeout = self._timeout
             response = (
                 await self.grpc_collections.ListCollectionAliases(
                     grpc.ListCollectionAliasesRequest(collection_name=collection_name),
-                    timeout=self._timeout,
+                    timeout=effective_timeout,
                 )
             ).aliases
             return types.CollectionsAliasesResponse(
@@ -1714,11 +1734,12 @@ class AsyncQdrantRemote(AsyncQdrantBase):
 
     async def get_collection(self, collection_name: str, **kwargs: Any) -> types.CollectionInfo:
         if self._prefer_grpc:
+            effective_timeout = self._timeout
             return GrpcToRest.convert_collection_info(
                 (
                     await self.grpc_collections.Get(
                         grpc.GetCollectionInfoRequest(collection_name=collection_name),
-                        timeout=self._timeout,
+                        timeout=effective_timeout,
                     )
                 ).result
             )
@@ -1730,10 +1751,11 @@ class AsyncQdrantRemote(AsyncQdrantBase):
 
     async def collection_exists(self, collection_name: str, **kwargs: Any) -> bool:
         if self._prefer_grpc:
+            effective_timeout = self._timeout
             return (
                 await self.grpc_collections.CollectionExists(
                     grpc.CollectionExistsRequest(collection_name=collection_name),
-                    timeout=self._timeout,
+                    timeout=effective_timeout,
                 )
             ).result.exists
         result: models.CollectionExistence | None = (
@@ -1757,6 +1779,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> bool:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if isinstance(optimizers_config, models.OptimizersConfigDiff):
                 optimizers_config = RestToGrpc.convert_optimizers_config_diff(optimizers_config)
             if isinstance(collection_params, models.CollectionParamsDiff):
@@ -1788,10 +1811,10 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                         quantization_config=quantization_config,
                         sparse_vectors_config=sparse_vectors_config,
                         strict_mode_config=strict_mode_config,
-                        timeout=timeout,
+                        timeout=effective_timeout,
                         metadata=metadata,
                     ),
-                    timeout=timeout if timeout is not None else self._timeout,
+                    timeout=effective_timeout,
                 )
             ).result
         if isinstance(optimizers_config, grpc.OptimizersConfigDiff):
@@ -1827,10 +1850,11 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         self, collection_name: str, timeout: int | None = None, **kwargs: Any
     ) -> bool:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             return (
                 await self.grpc_collections.Delete(
-                    grpc.DeleteCollection(collection_name=collection_name, timeout=timeout),
-                    timeout=timeout if timeout is not None else self._timeout,
+                    grpc.DeleteCollection(collection_name=collection_name, timeout=effective_timeout),
+                    timeout=effective_timeout,
                 )
             ).result
         result: bool | None = (
@@ -2314,10 +2338,11 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         self, collection_name: str, **kwargs: Any
     ) -> list[types.SnapshotDescription]:
         if self._prefer_grpc:
+            effective_timeout = self._timeout
             snapshots = (
                 await self.grpc_snapshots.List(
                     grpc.ListSnapshotsRequest(collection_name=collection_name),
-                    timeout=self._timeout,
+                    timeout=effective_timeout,
                 )
             ).snapshot_descriptions
             return [GrpcToRest.convert_snapshot_description(snapshot) for snapshot in snapshots]
@@ -2331,10 +2356,11 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         self, collection_name: str, wait: bool = True, **kwargs: Any
     ) -> types.SnapshotDescription | None:
         if self._prefer_grpc:
+            effective_timeout = self._timeout
             snapshot = (
                 await self.grpc_snapshots.Create(
                     grpc.CreateSnapshotRequest(collection_name=collection_name),
-                    timeout=self._timeout,
+                    timeout=effective_timeout,
                 )
             ).snapshot_description
             return GrpcToRest.convert_snapshot_description(snapshot)
@@ -2348,11 +2374,12 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         self, collection_name: str, snapshot_name: str, wait: bool = True, **kwargs: Any
     ) -> bool | None:
         if self._prefer_grpc:
+            effective_timeout = self._timeout
             await self.grpc_snapshots.Delete(
                 grpc.DeleteSnapshotRequest(
                     collection_name=collection_name, snapshot_name=snapshot_name
                 ),
-                timeout=self._timeout,
+                timeout=effective_timeout,
             )
             return True
         return (
@@ -2490,6 +2517,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> bool:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if isinstance(shard_key, get_args_subscribed(models.ShardKey)):
                 shard_key = RestToGrpc.convert_shard_key(shard_key)
             if isinstance(initial_state, models.ReplicaState):
@@ -2498,7 +2526,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                 await self.grpc_collections.CreateShardKey(
                     grpc.CreateShardKeyRequest(
                         collection_name=collection_name,
-                        timeout=timeout,
+                        timeout=effective_timeout,
                         request=grpc.CreateShardKey(
                             shard_key=shard_key,
                             shards_number=shards_number,
@@ -2507,7 +2535,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                             initial_state=initial_state,
                         ),
                     ),
-                    timeout=timeout if timeout is not None else self._timeout,
+                    timeout=effective_timeout,
                 )
             ).result
         else:
@@ -2535,16 +2563,17 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> bool:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if isinstance(shard_key, get_args_subscribed(models.ShardKey)):
                 shard_key = RestToGrpc.convert_shard_key(shard_key)
             return (
                 await self.grpc_collections.DeleteShardKey(
                     grpc.DeleteShardKeyRequest(
                         collection_name=collection_name,
-                        timeout=timeout,
+                        timeout=effective_timeout,
                         request=grpc.DeleteShardKey(shard_key=shard_key),
                     ),
-                    timeout=timeout if timeout is not None else self._timeout,
+                    timeout=effective_timeout,
                 )
             ).result
         else:
@@ -2576,6 +2605,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         **kwargs: Any,
     ) -> bool:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             cluster_operation = RestToGrpc.convert_cluster_operations(cluster_operation)
             grpc_operation = {}
             if isinstance(cluster_operation, grpc.MoveShard):
@@ -2599,9 +2629,9 @@ class AsyncQdrantRemote(AsyncQdrantBase):
             return (
                 await self.grpc_collections.UpdateCollectionClusterSetup(
                     grpc.UpdateCollectionClusterSetupRequest(
-                        collection_name=collection_name, timeout=timeout, **grpc_operation
+                        collection_name=collection_name, timeout=effective_timeout, **grpc_operation
                     ),
-                    timeout=timeout if timeout is not None else self._timeout,
+                    timeout=effective_timeout,
                 )
             ).result
         update_result = (
@@ -2637,9 +2667,10 @@ class AsyncQdrantRemote(AsyncQdrantBase):
 
     async def collection_cluster_info(self, collection_name: str) -> types.CollectionClusterInfo:
         if self._prefer_grpc:
+            effective_timeout = self._timeout
             collection_info = await self.grpc_collections.CollectionClusterInfo(
                 grpc.CollectionClusterInfoRequest(collection_name=collection_name),
-                timeout=self._timeout,
+                timeout=effective_timeout,
             )
             return GrpcToRest.convert_collection_cluster_info(collection_info)
         collection_info = (

--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -44,6 +44,13 @@ from qdrant_client.uploader.uploader import BaseUploader
 
 class QdrantRemote(QdrantBase):
     DEFAULT_GRPC_TIMEOUT = 5  # seconds
+
+    def _effective_timeout(self, timeout: int | None) -> int:
+        # Single source of truth for the per-call / global fallback rule.
+        # Every gRPC call site in this file uses this so a future
+        # method that takes a `timeout=` arg cannot accidentally bypass
+        # `self._timeout` again. See issue #948.
+        return timeout if timeout is not None else self._timeout
     DEFAULT_GRPC_POOL_SIZE = 3
 
     def __init__(
@@ -497,7 +504,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.QueryResponse:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if query is not None:
                 query = RestToGrpc.convert_query(query)
 
@@ -603,7 +610,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> list[types.QueryResponse]:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             requests = [
                 (
                     RestToGrpc.convert_query_request(r, collection_name)
@@ -673,7 +680,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.GroupsResult:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if query is not None:
                 query = RestToGrpc.convert_query(query)
 
@@ -788,7 +795,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.SearchMatrixPairsResponse:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if isinstance(query_filter, models.Filter):
                 query_filter = RestToGrpc.convert_filter(model=query_filter)
 
@@ -845,7 +852,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.SearchMatrixOffsetsResponse:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if isinstance(query_filter, models.Filter):
                 query_filter = RestToGrpc.convert_filter(model=query_filter)
 
@@ -904,7 +911,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> tuple[list[types.Record], types.PointId | None]:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if isinstance(offset, get_args_subscribed(models.ExtendedPointId)):
                 offset = RestToGrpc.convert_extended_point_id(offset)
 
@@ -991,7 +998,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.CountResult:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if isinstance(count_filter, models.Filter):
                 count_filter = RestToGrpc.convert_filter(model=count_filter)
 
@@ -1043,7 +1050,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.FacetResponse:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if isinstance(facet_filter, models.Filter):
                 facet_filter = RestToGrpc.convert_filter(model=facet_filter)
 
@@ -1103,7 +1110,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if isinstance(points, models.Batch):
                 vectors_batch: list[grpc.Vectors] = RestToGrpc.convert_batch_vector_struct(
                     points.vectors, len(points.ids)
@@ -1209,7 +1216,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             points = [RestToGrpc.convert_point_vectors(point) for point in points]
 
             if isinstance(ordering, models.WriteOrdering):
@@ -1263,7 +1270,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             points_selector, opt_shard_key_selector = self._try_argument_to_grpc_selector(points)
             shard_key_selector = shard_key_selector or opt_shard_key_selector
 
@@ -1319,7 +1326,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> list[types.Record]:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if isinstance(with_payload, get_args_subscribed(models.WithPayloadInterface)):
                 with_payload = RestToGrpc.convert_with_payload_interface(with_payload)
 
@@ -1505,7 +1512,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             points_selector, opt_shard_key_selector = self._try_argument_to_grpc_selector(
                 points_selector
             )
@@ -1557,7 +1564,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             points_selector, opt_shard_key_selector = self._try_argument_to_grpc_selector(points)
             shard_key_selector = shard_key_selector or opt_shard_key_selector
 
@@ -1612,7 +1619,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             points_selector, opt_shard_key_selector = self._try_argument_to_grpc_selector(points)
             shard_key_selector = shard_key_selector or opt_shard_key_selector
 
@@ -1665,7 +1672,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             points_selector, opt_shard_key_selector = self._try_argument_to_grpc_selector(points)
             shard_key_selector = shard_key_selector or opt_shard_key_selector
             if isinstance(ordering, models.WriteOrdering):
@@ -1716,7 +1723,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             points_selector, opt_shard_key_selector = self._try_argument_to_grpc_selector(
                 points_selector
             )
@@ -1765,7 +1772,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> list[types.UpdateResult]:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             update_operations = [
                 RestToGrpc.convert_update_operation(operation) for operation in update_operations
             ]
@@ -1804,7 +1811,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> bool:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             change_aliases_operation = [
                 (
                     RestToGrpc.convert_alias_operations(operation)
@@ -1842,7 +1849,7 @@ class QdrantRemote(QdrantBase):
         self, collection_name: str, **kwargs: Any
     ) -> types.CollectionsAliasesResponse:
         if self._prefer_grpc:
-            effective_timeout = self._timeout
+            effective_timeout = self._effective_timeout(None)
             response = self.grpc_collections.ListCollectionAliases(
                 grpc.ListCollectionAliasesRequest(collection_name=collection_name),
                 timeout=effective_timeout,
@@ -1895,7 +1902,7 @@ class QdrantRemote(QdrantBase):
 
     def get_collection(self, collection_name: str, **kwargs: Any) -> types.CollectionInfo:
         if self._prefer_grpc:
-            effective_timeout = self._timeout
+            effective_timeout = self._effective_timeout(None)
             return GrpcToRest.convert_collection_info(
                 self.grpc_collections.Get(
                     grpc.GetCollectionInfoRequest(collection_name=collection_name),
@@ -1910,7 +1917,7 @@ class QdrantRemote(QdrantBase):
 
     def collection_exists(self, collection_name: str, **kwargs: Any) -> bool:
         if self._prefer_grpc:
-            effective_timeout = self._timeout
+            effective_timeout = self._effective_timeout(None)
             return self.grpc_collections.CollectionExists(
                 grpc.CollectionExistsRequest(collection_name=collection_name),
                 timeout=effective_timeout,
@@ -1937,7 +1944,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> bool:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if isinstance(optimizers_config, models.OptimizersConfigDiff):
                 optimizers_config = RestToGrpc.convert_optimizers_config_diff(optimizers_config)
 
@@ -2018,7 +2025,7 @@ class QdrantRemote(QdrantBase):
         self, collection_name: str, timeout: int | None = None, **kwargs: Any
     ) -> bool:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             return self.grpc_collections.Delete(
                 grpc.DeleteCollection(collection_name=collection_name, timeout=effective_timeout),
                 timeout=effective_timeout,
@@ -2050,6 +2057,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> bool:
         if self._prefer_grpc:
+            effective_timeout = self._effective_timeout(timeout)
             if isinstance(vectors_config, (models.VectorParams, dict)):
                 vectors_config = RestToGrpc.convert_vectors_config(vectors_config)
 
@@ -2089,7 +2097,7 @@ class QdrantRemote(QdrantBase):
                 optimizers_config=optimizers_config,
                 shard_number=shard_number,
                 on_disk_payload=on_disk_payload,
-                timeout=timeout,
+                timeout=effective_timeout,
                 vectors_config=vectors_config,
                 replication_factor=replication_factor,
                 write_consistency_factor=write_consistency_factor,
@@ -2099,7 +2107,7 @@ class QdrantRemote(QdrantBase):
                 strict_mode_config=strict_mode_config,
                 metadata=metadata,
             )
-            return self.grpc_collections.Create(create_collection, timeout=self._timeout).result
+            return self.grpc_collections.Create(create_collection, timeout=effective_timeout).result
 
         if isinstance(hnsw_config, grpc.HnswConfigDiff):
             hnsw_config = GrpcToRest.convert_hnsw_config_diff(hnsw_config)
@@ -2328,6 +2336,7 @@ class QdrantRemote(QdrantBase):
             field_schema = field_type
 
         if self._prefer_grpc:
+            effective_timeout = self._effective_timeout(timeout)
             field_index_params = None
             if isinstance(field_schema, models.PayloadSchemaType):
                 field_schema = RestToGrpc.convert_payload_schema_type(field_schema)
@@ -2382,10 +2391,10 @@ class QdrantRemote(QdrantBase):
                 field_index_params=field_index_params,
                 wait=wait,
                 ordering=ordering,
-                timeout=timeout,
+                timeout=effective_timeout,
             )
             return GrpcToRest.convert_update_result(
-                self.grpc_points.CreateFieldIndex(request, timeout=self._timeout).result
+                self.grpc_points.CreateFieldIndex(request, timeout=effective_timeout).result
             )
 
         if isinstance(field_schema, int):  # type(grpc.PayloadSchemaType) == int
@@ -2416,15 +2425,16 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
+            effective_timeout = self._effective_timeout(timeout)
             request = grpc.DeleteFieldIndexCollection(
                 collection_name=collection_name,
                 field_name=field_name,
                 wait=wait,
                 ordering=ordering,
-                timeout=timeout,
+                timeout=effective_timeout,
             )
             return GrpcToRest.convert_update_result(
-                self.grpc_points.DeleteFieldIndex(request, timeout=self._timeout).result
+                self.grpc_points.DeleteFieldIndex(request, timeout=effective_timeout).result
             )
 
         result: types.UpdateResult | None = self.openapi_client.indexes_api.delete_field_index(
@@ -2448,6 +2458,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
+            effective_timeout = self._effective_timeout(timeout)
             dense_config = None
             sparse_config = None
             if isinstance(vector_name_config, models.DenseVectorNameConfig):
@@ -2491,11 +2502,11 @@ class QdrantRemote(QdrantBase):
                 vector_name=vector_name,
                 dense_config=dense_config,
                 sparse_config=sparse_config,
-                timeout=timeout,
+                timeout=effective_timeout,
                 ordering=grpc_ordering,
             )
             return GrpcToRest.convert_update_result(
-                self.grpc_points.CreateVectorName(request, timeout=self._timeout).result
+                self.grpc_points.CreateVectorName(request, timeout=effective_timeout).result
             )
 
         result: types.UpdateResult | None = self.http.collections_api.create_vector_name(
@@ -2519,6 +2530,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
+            effective_timeout = self._effective_timeout(timeout)
             grpc_ordering = (
                 RestToGrpc.convert_write_ordering(ordering)
                 if isinstance(ordering, models.WriteOrdering)
@@ -2528,11 +2540,11 @@ class QdrantRemote(QdrantBase):
                 collection_name=collection_name,
                 wait=wait,
                 vector_name=vector_name,
-                timeout=timeout,
+                timeout=effective_timeout,
                 ordering=grpc_ordering,
             )
             return GrpcToRest.convert_update_result(
-                self.grpc_points.DeleteVectorName(request, timeout=self._timeout).result
+                self.grpc_points.DeleteVectorName(request, timeout=effective_timeout).result
             )
 
         result: types.UpdateResult | None = self.openapi_client.collections_api.delete_vector_name(
@@ -2577,7 +2589,7 @@ class QdrantRemote(QdrantBase):
         self, collection_name: str, snapshot_name: str, wait: bool = True, **kwargs: Any
     ) -> bool | None:
         if self._prefer_grpc:
-            effective_timeout = self._timeout
+            effective_timeout = self._effective_timeout(None)
             self.grpc_snapshots.Delete(
                 grpc.DeleteSnapshotRequest(
                     collection_name=collection_name, snapshot_name=snapshot_name
@@ -2594,7 +2606,7 @@ class QdrantRemote(QdrantBase):
 
     def list_full_snapshots(self, **kwargs: Any) -> list[types.SnapshotDescription]:
         if self._prefer_grpc:
-            effective_timeout = self._timeout
+            effective_timeout = self._effective_timeout(None)
             snapshots = self.grpc_snapshots.ListFull(
                 grpc.ListFullSnapshotsRequest(),
                 timeout=effective_timeout,
@@ -2618,7 +2630,7 @@ class QdrantRemote(QdrantBase):
         self, snapshot_name: str, wait: bool = True, **kwargs: Any
     ) -> bool | None:
         if self._prefer_grpc:
-            effective_timeout = self._timeout
+            effective_timeout = self._effective_timeout(None)
             self.grpc_snapshots.DeleteFull(
                 grpc.DeleteFullSnapshotRequest(snapshot_name=snapshot_name),
                 timeout=effective_timeout,
@@ -2719,7 +2731,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> bool:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if isinstance(shard_key, get_args_subscribed(models.ShardKey)):
                 shard_key = RestToGrpc.convert_shard_key(shard_key)
 
@@ -2763,7 +2775,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> bool:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             if isinstance(shard_key, get_args_subscribed(models.ShardKey)):
                 shard_key = RestToGrpc.convert_shard_key(shard_key)
 
@@ -2806,7 +2818,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> bool:
         if self._prefer_grpc:
-            effective_timeout = timeout if timeout is not None else self._timeout
+            effective_timeout = self._effective_timeout(timeout)
             cluster_operation = RestToGrpc.convert_cluster_operations(cluster_operation)
             grpc_operation = {}
 
@@ -2871,7 +2883,7 @@ class QdrantRemote(QdrantBase):
 
     def collection_cluster_info(self, collection_name: str) -> types.CollectionClusterInfo:
         if self._prefer_grpc:
-            effective_timeout = self._timeout
+            effective_timeout = self._effective_timeout(None)
             collection_info = self.grpc_collections.CollectionClusterInfo(
                 grpc.CollectionClusterInfoRequest(collection_name=collection_name),
                 timeout=effective_timeout,
@@ -2903,7 +2915,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.ShardKeysResponse:
         if self._prefer_grpc:
-            effective_timeout = self._timeout
+            effective_timeout = self._effective_timeout(None)
             response = self.grpc_collections.ListShardKeys(
                 grpc.ListShardKeysRequest(collection_name=collection_name),
                 timeout=effective_timeout,

--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -497,6 +497,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.QueryResponse:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if query is not None:
                 query = RestToGrpc.convert_query(query)
 
@@ -544,11 +545,11 @@ class QdrantRemote(QdrantBase):
                     score_threshold=score_threshold,
                     using=using,
                     lookup_from=lookup_from,
-                    timeout=timeout,
+                    timeout=effective_timeout,
                     shard_key_selector=shard_key_selector,
                     read_consistency=consistency,
                 ),
-                timeout=timeout if timeout is not None else self._timeout,
+                timeout=effective_timeout,
             )
 
             scored_points = [GrpcToRest.convert_scored_point(hit) for hit in res.result]
@@ -602,6 +603,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> list[types.QueryResponse]:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             requests = [
                 (
                     RestToGrpc.convert_query_request(r, collection_name)
@@ -619,9 +621,9 @@ class QdrantRemote(QdrantBase):
                     collection_name=collection_name,
                     query_points=requests,
                     read_consistency=consistency,
-                    timeout=timeout,
+                    timeout=effective_timeout,
                 ),
-                timeout=timeout if timeout is not None else self._timeout,
+                timeout=effective_timeout,
             )
 
             return [
@@ -671,6 +673,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.GroupsResult:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if query is not None:
                 query = RestToGrpc.convert_query(query)
 
@@ -726,11 +729,11 @@ class QdrantRemote(QdrantBase):
                     group_size=group_size,
                     with_lookup=with_lookup,
                     lookup_from=lookup_from,
-                    timeout=timeout,
+                    timeout=effective_timeout,
                     shard_key_selector=shard_key_selector,
                     read_consistency=consistency,
                 ),
-                timeout=timeout if timeout is not None else self._timeout,
+                timeout=effective_timeout,
             ).result
             return GrpcToRest.convert_groups_result(result)
         else:
@@ -785,6 +788,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.SearchMatrixPairsResponse:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if isinstance(query_filter, models.Filter):
                 query_filter = RestToGrpc.convert_filter(model=query_filter)
 
@@ -801,11 +805,11 @@ class QdrantRemote(QdrantBase):
                     sample=sample,
                     limit=limit,
                     using=using,
-                    timeout=timeout,
+                    timeout=effective_timeout,
                     read_consistency=consistency,
                     shard_key_selector=shard_key_selector,
                 ),
-                timeout=timeout if timeout is not None else self._timeout,
+                timeout=effective_timeout,
             )
             return GrpcToRest.convert_search_matrix_pairs(response.result)
 
@@ -841,6 +845,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.SearchMatrixOffsetsResponse:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if isinstance(query_filter, models.Filter):
                 query_filter = RestToGrpc.convert_filter(model=query_filter)
 
@@ -857,11 +862,11 @@ class QdrantRemote(QdrantBase):
                     sample=sample,
                     limit=limit,
                     using=using,
-                    timeout=timeout,
+                    timeout=effective_timeout,
                     read_consistency=consistency,
                     shard_key_selector=shard_key_selector,
                 ),
-                timeout=timeout if timeout is not None else self._timeout,
+                timeout=effective_timeout,
             )
             return GrpcToRest.convert_search_matrix_offsets(response.result)
 
@@ -899,6 +904,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> tuple[list[types.Record], types.PointId | None]:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if isinstance(offset, get_args_subscribed(models.ExtendedPointId)):
                 offset = RestToGrpc.convert_extended_point_id(offset)
 
@@ -931,9 +937,9 @@ class QdrantRemote(QdrantBase):
                     limit=limit,
                     read_consistency=consistency,
                     shard_key_selector=shard_key_selector,
-                    timeout=timeout,
+                    timeout=effective_timeout,
                 ),
-                timeout=timeout if timeout is not None else self._timeout,
+                timeout=effective_timeout,
             )
 
             return [GrpcToRest.convert_retrieved_point(point) for point in res.result], (
@@ -985,6 +991,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.CountResult:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if isinstance(count_filter, models.Filter):
                 count_filter = RestToGrpc.convert_filter(model=count_filter)
 
@@ -1000,10 +1007,10 @@ class QdrantRemote(QdrantBase):
                     filter=count_filter,
                     exact=exact,
                     shard_key_selector=shard_key_selector,
-                    timeout=timeout,
+                    timeout=effective_timeout,
                     read_consistency=consistency,
                 ),
-                timeout=timeout if timeout is not None else self._timeout,
+                timeout=effective_timeout,
             ).result
             return GrpcToRest.convert_count_result(response)
 
@@ -1036,6 +1043,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.FacetResponse:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if isinstance(facet_filter, models.Filter):
                 facet_filter = RestToGrpc.convert_filter(model=facet_filter)
 
@@ -1052,11 +1060,11 @@ class QdrantRemote(QdrantBase):
                     filter=facet_filter,
                     limit=limit,
                     exact=exact,
-                    timeout=timeout,
+                    timeout=effective_timeout,
                     read_consistency=consistency,
                     shard_key_selector=shard_key_selector,
                 ),
-                timeout=timeout if timeout is not None else self._timeout,
+                timeout=effective_timeout,
             )
 
             return types.FacetResponse(
@@ -1095,6 +1103,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if isinstance(points, models.Batch):
                 vectors_batch: list[grpc.Vectors] = RestToGrpc.convert_batch_vector_struct(
                     points.vectors, len(points.ids)
@@ -1141,10 +1150,10 @@ class QdrantRemote(QdrantBase):
                     ordering=ordering,
                     shard_key_selector=shard_key_selector,
                     update_filter=update_filter,
-                    timeout=timeout,
+                    timeout=effective_timeout,
                     update_mode=update_mode,
                 ),
-                timeout=self._timeout,
+                timeout=effective_timeout,
             ).result
 
             assert grpc_result is not None, "Upsert returned None result"
@@ -1200,6 +1209,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             points = [RestToGrpc.convert_point_vectors(point) for point in points]
 
             if isinstance(ordering, models.WriteOrdering):
@@ -1219,9 +1229,9 @@ class QdrantRemote(QdrantBase):
                     ordering=ordering,
                     shard_key_selector=shard_key_selector,
                     update_filter=update_filter,
-                    timeout=timeout,
+                    timeout=effective_timeout,
                 ),
-                timeout=self._timeout,
+                timeout=effective_timeout,
             ).result
             assert grpc_result is not None, "Upsert returned None result"
             return GrpcToRest.convert_update_result(grpc_result)
@@ -1253,6 +1263,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             points_selector, opt_shard_key_selector = self._try_argument_to_grpc_selector(points)
             shard_key_selector = shard_key_selector or opt_shard_key_selector
 
@@ -1272,9 +1283,9 @@ class QdrantRemote(QdrantBase):
                     points_selector=points_selector,
                     ordering=ordering,
                     shard_key_selector=shard_key_selector,
-                    timeout=timeout,
+                    timeout=effective_timeout,
                 ),
-                timeout=self._timeout,
+                timeout=effective_timeout,
             ).result
 
             assert grpc_result is not None, "Delete vectors returned None result"
@@ -1308,6 +1319,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> list[types.Record]:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if isinstance(with_payload, get_args_subscribed(models.WithPayloadInterface)):
                 with_payload = RestToGrpc.convert_with_payload_interface(with_payload)
 
@@ -1336,9 +1348,9 @@ class QdrantRemote(QdrantBase):
                     with_vectors=with_vectors,
                     read_consistency=consistency,
                     shard_key_selector=shard_key_selector,
-                    timeout=timeout,
+                    timeout=effective_timeout,
                 ),
-                timeout=timeout if timeout is not None else self._timeout,
+                timeout=effective_timeout,
             ).result
 
             assert result is not None, "Retrieve returned None result"
@@ -1493,6 +1505,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             points_selector, opt_shard_key_selector = self._try_argument_to_grpc_selector(
                 points_selector
             )
@@ -1512,9 +1525,9 @@ class QdrantRemote(QdrantBase):
                         points=points_selector,
                         ordering=ordering,
                         shard_key_selector=shard_key_selector,
-                        timeout=timeout,
+                        timeout=effective_timeout,
                     ),
-                    timeout=self._timeout,
+                    timeout=effective_timeout,
                 ).result
             )
         else:
@@ -1544,6 +1557,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             points_selector, opt_shard_key_selector = self._try_argument_to_grpc_selector(points)
             shard_key_selector = shard_key_selector or opt_shard_key_selector
 
@@ -1563,9 +1577,9 @@ class QdrantRemote(QdrantBase):
                         ordering=ordering,
                         shard_key_selector=shard_key_selector,
                         key=key,
-                        timeout=timeout,
+                        timeout=effective_timeout,
                     ),
-                    timeout=self._timeout,
+                    timeout=effective_timeout,
                 ).result
             )
         else:
@@ -1598,6 +1612,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             points_selector, opt_shard_key_selector = self._try_argument_to_grpc_selector(points)
             shard_key_selector = shard_key_selector or opt_shard_key_selector
 
@@ -1616,9 +1631,9 @@ class QdrantRemote(QdrantBase):
                         points_selector=points_selector,
                         ordering=ordering,
                         shard_key_selector=shard_key_selector,
-                        timeout=timeout,
+                        timeout=effective_timeout,
                     ),
-                    timeout=self._timeout,
+                    timeout=effective_timeout,
                 ).result
             )
         else:
@@ -1650,6 +1665,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             points_selector, opt_shard_key_selector = self._try_argument_to_grpc_selector(points)
             shard_key_selector = shard_key_selector or opt_shard_key_selector
             if isinstance(ordering, models.WriteOrdering):
@@ -1667,9 +1683,9 @@ class QdrantRemote(QdrantBase):
                         points_selector=points_selector,
                         ordering=ordering,
                         shard_key_selector=shard_key_selector,
-                        timeout=timeout,
+                        timeout=effective_timeout,
                     ),
-                    timeout=self._timeout,
+                    timeout=effective_timeout,
                 ).result
             )
         else:
@@ -1700,6 +1716,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.UpdateResult:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             points_selector, opt_shard_key_selector = self._try_argument_to_grpc_selector(
                 points_selector
             )
@@ -1719,9 +1736,9 @@ class QdrantRemote(QdrantBase):
                         points=points_selector,
                         ordering=ordering,
                         shard_key_selector=shard_key_selector,
-                        timeout=timeout,
+                        timeout=effective_timeout,
                     ),
-                    timeout=self._timeout,
+                    timeout=effective_timeout,
                 ).result
             )
         else:
@@ -1748,6 +1765,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> list[types.UpdateResult]:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             update_operations = [
                 RestToGrpc.convert_update_operation(operation) for operation in update_operations
             ]
@@ -1763,9 +1781,9 @@ class QdrantRemote(QdrantBase):
                         wait=wait,
                         operations=update_operations,
                         ordering=ordering,
-                        timeout=timeout,
+                        timeout=effective_timeout,
                     ),
-                    timeout=self._timeout,
+                    timeout=effective_timeout,
                 ).result
             ]
         else:
@@ -1786,6 +1804,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> bool:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             change_aliases_operation = [
                 (
                     RestToGrpc.convert_alias_operations(operation)
@@ -1796,10 +1815,10 @@ class QdrantRemote(QdrantBase):
             ]
             return self.grpc_collections.UpdateAliases(
                 grpc.ChangeAliases(
-                    timeout=timeout,
+                    timeout=effective_timeout,
                     actions=change_aliases_operation,
                 ),
-                timeout=timeout if timeout is not None else self._timeout,
+                timeout=effective_timeout,
             ).result
 
         change_aliases_operation = [
@@ -1823,9 +1842,10 @@ class QdrantRemote(QdrantBase):
         self, collection_name: str, **kwargs: Any
     ) -> types.CollectionsAliasesResponse:
         if self._prefer_grpc:
+            effective_timeout = self._timeout
             response = self.grpc_collections.ListCollectionAliases(
                 grpc.ListCollectionAliasesRequest(collection_name=collection_name),
-                timeout=self._timeout,
+                timeout=effective_timeout,
             ).aliases
             return types.CollectionsAliasesResponse(
                 aliases=[
@@ -1875,10 +1895,11 @@ class QdrantRemote(QdrantBase):
 
     def get_collection(self, collection_name: str, **kwargs: Any) -> types.CollectionInfo:
         if self._prefer_grpc:
+            effective_timeout = self._timeout
             return GrpcToRest.convert_collection_info(
                 self.grpc_collections.Get(
                     grpc.GetCollectionInfoRequest(collection_name=collection_name),
-                    timeout=self._timeout,
+                    timeout=effective_timeout,
                 ).result
             )
         result: types.CollectionInfo | None = self.http.collections_api.get_collection(
@@ -1889,9 +1910,10 @@ class QdrantRemote(QdrantBase):
 
     def collection_exists(self, collection_name: str, **kwargs: Any) -> bool:
         if self._prefer_grpc:
+            effective_timeout = self._timeout
             return self.grpc_collections.CollectionExists(
                 grpc.CollectionExistsRequest(collection_name=collection_name),
-                timeout=self._timeout,
+                timeout=effective_timeout,
             ).result.exists
 
         result: models.CollectionExistence | None = self.http.collections_api.collection_exists(
@@ -1915,6 +1937,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> bool:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if isinstance(optimizers_config, models.OptimizersConfigDiff):
                 optimizers_config = RestToGrpc.convert_optimizers_config_diff(optimizers_config)
 
@@ -1953,10 +1976,10 @@ class QdrantRemote(QdrantBase):
                     quantization_config=quantization_config,
                     sparse_vectors_config=sparse_vectors_config,
                     strict_mode_config=strict_mode_config,
-                    timeout=timeout,
+                    timeout=effective_timeout,
                     metadata=metadata,
                 ),
-                timeout=timeout if timeout is not None else self._timeout,
+                timeout=effective_timeout,
             ).result
 
         if isinstance(optimizers_config, grpc.OptimizersConfigDiff):
@@ -1995,9 +2018,10 @@ class QdrantRemote(QdrantBase):
         self, collection_name: str, timeout: int | None = None, **kwargs: Any
     ) -> bool:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             return self.grpc_collections.Delete(
-                grpc.DeleteCollection(collection_name=collection_name, timeout=timeout),
-                timeout=timeout if timeout is not None else self._timeout,
+                grpc.DeleteCollection(collection_name=collection_name, timeout=effective_timeout),
+                timeout=effective_timeout,
             ).result
 
         result: bool | None = self.http.collections_api.delete_collection(
@@ -2553,11 +2577,12 @@ class QdrantRemote(QdrantBase):
         self, collection_name: str, snapshot_name: str, wait: bool = True, **kwargs: Any
     ) -> bool | None:
         if self._prefer_grpc:
+            effective_timeout = self._timeout
             self.grpc_snapshots.Delete(
                 grpc.DeleteSnapshotRequest(
                     collection_name=collection_name, snapshot_name=snapshot_name
                 ),
-                timeout=self._timeout,
+                timeout=effective_timeout,
             )
             return True
 
@@ -2569,9 +2594,10 @@ class QdrantRemote(QdrantBase):
 
     def list_full_snapshots(self, **kwargs: Any) -> list[types.SnapshotDescription]:
         if self._prefer_grpc:
+            effective_timeout = self._timeout
             snapshots = self.grpc_snapshots.ListFull(
                 grpc.ListFullSnapshotsRequest(),
-                timeout=self._timeout,
+                timeout=effective_timeout,
             ).snapshot_descriptions
             return [GrpcToRest.convert_snapshot_description(snapshot) for snapshot in snapshots]
 
@@ -2592,9 +2618,10 @@ class QdrantRemote(QdrantBase):
         self, snapshot_name: str, wait: bool = True, **kwargs: Any
     ) -> bool | None:
         if self._prefer_grpc:
+            effective_timeout = self._timeout
             self.grpc_snapshots.DeleteFull(
                 grpc.DeleteFullSnapshotRequest(snapshot_name=snapshot_name),
-                timeout=self._timeout,
+                timeout=effective_timeout,
             )
             return True
 
@@ -2692,6 +2719,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> bool:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if isinstance(shard_key, get_args_subscribed(models.ShardKey)):
                 shard_key = RestToGrpc.convert_shard_key(shard_key)
 
@@ -2701,7 +2729,7 @@ class QdrantRemote(QdrantBase):
             return self.grpc_collections.CreateShardKey(
                 grpc.CreateShardKeyRequest(
                     collection_name=collection_name,
-                    timeout=timeout,
+                    timeout=effective_timeout,
                     request=grpc.CreateShardKey(
                         shard_key=shard_key,
                         shards_number=shards_number,
@@ -2710,7 +2738,7 @@ class QdrantRemote(QdrantBase):
                         initial_state=initial_state,
                     ),
                 ),
-                timeout=timeout if timeout is not None else self._timeout,
+                timeout=effective_timeout,
             ).result
         else:
             result = self.openapi_client.distributed_api.create_shard_key(
@@ -2735,18 +2763,19 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> bool:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             if isinstance(shard_key, get_args_subscribed(models.ShardKey)):
                 shard_key = RestToGrpc.convert_shard_key(shard_key)
 
             return self.grpc_collections.DeleteShardKey(
                 grpc.DeleteShardKeyRequest(
                     collection_name=collection_name,
-                    timeout=timeout,
+                    timeout=effective_timeout,
                     request=grpc.DeleteShardKey(
                         shard_key=shard_key,
                     ),
                 ),
-                timeout=timeout if timeout is not None else self._timeout,
+                timeout=effective_timeout,
             ).result
         else:
             result = self.openapi_client.distributed_api.delete_shard_key(
@@ -2777,6 +2806,7 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> bool:
         if self._prefer_grpc:
+            effective_timeout = timeout if timeout is not None else self._timeout
             cluster_operation = RestToGrpc.convert_cluster_operations(cluster_operation)
             grpc_operation = {}
 
@@ -2801,9 +2831,9 @@ class QdrantRemote(QdrantBase):
 
             return self.grpc_collections.UpdateCollectionClusterSetup(
                 grpc.UpdateCollectionClusterSetupRequest(
-                    collection_name=collection_name, timeout=timeout, **grpc_operation
+                    collection_name=collection_name, timeout=effective_timeout, **grpc_operation
                 ),
-                timeout=timeout if timeout is not None else self._timeout,
+                timeout=effective_timeout,
             ).result
         update_result = self.rest.distributed_api.update_collection_cluster(
             collection_name=collection_name, cluster_operations=cluster_operation, timeout=timeout
@@ -2841,9 +2871,10 @@ class QdrantRemote(QdrantBase):
 
     def collection_cluster_info(self, collection_name: str) -> types.CollectionClusterInfo:
         if self._prefer_grpc:
+            effective_timeout = self._timeout
             collection_info = self.grpc_collections.CollectionClusterInfo(
                 grpc.CollectionClusterInfoRequest(collection_name=collection_name),
-                timeout=self._timeout,
+                timeout=effective_timeout,
             )
             return GrpcToRest.convert_collection_cluster_info(collection_info)
         collection_info = self.rest.distributed_api.collection_cluster_info(
@@ -2872,9 +2903,10 @@ class QdrantRemote(QdrantBase):
         **kwargs: Any,
     ) -> types.ShardKeysResponse:
         if self._prefer_grpc:
+            effective_timeout = self._timeout
             response = self.grpc_collections.ListShardKeys(
                 grpc.ListShardKeysRequest(collection_name=collection_name),
-                timeout=self._timeout,
+                timeout=effective_timeout,
             )
             return models.ShardKeysResponse(
                 shard_keys=[

--- a/tests/test_grpc_timeout_fallback.py
+++ b/tests/test_grpc_timeout_fallback.py
@@ -1,0 +1,302 @@
+"""Tests for the gRPC timeout-fallback fix (issue #948).
+
+The bug: when a method on QdrantRemote / AsyncQdrantRemote is called without
+a per-call `timeout`, the protobuf `timeout` field on the gRPC request was
+left as `None`. The gRPC transport deadline (a separate argument) was set
+from `self._timeout` correctly, but the Qdrant server uses the protobuf
+field for its own internal operation budget, so a user-set global timeout
+was effectively ignored.
+
+The fix: every gRPC call site in qdrant_remote.py / async_qdrant_remote.py
+now uses the same `effective_timeout = timeout if timeout is not None
+else self._timeout` for both the protobuf field and the gRPC deadline.
+Methods that don't take a per-call `timeout` use `self._timeout` directly.
+
+These tests exercise the protobuf field and the gRPC deadline without
+making a real network call, by monkey-patching the gRPC stub. They call
+the gRPC method on the remote directly, then assert on the captured
+request and deadline (any post-call processing errors are irrelevant
+to the fix being tested).
+"""
+
+import inspect
+from unittest.mock import MagicMock
+
+import pytest
+
+from qdrant_client import AsyncQdrantClient, QdrantClient
+
+
+def _patch_stub_pool(remote, async_mode: bool) -> list:
+    """Replace every gRPC stub method on every stub in the pool. The remote
+    property round-robins across the pool, so we must patch all of them.
+    Returns a list that will be populated with (method_name, request, deadline)
+    tuples as calls happen."""
+    # Force lazy initialization.
+    _ = remote.grpc_points
+    _ = remote.grpc_collections
+
+    captured: list = []
+
+    def make_recorder(name: str):
+        if async_mode:
+            async def recorder(request, timeout=None, **_):
+                captured.append((name, request, timeout))
+                resp = MagicMock()
+                resp.result = []
+                # Scroll response shape: next_page_offset and result.
+                resp.next_page_offset = None
+                resp.points = []
+                return resp
+        else:
+            def recorder(request, timeout=None, **_):
+                captured.append((name, request, timeout))
+                resp = MagicMock()
+                resp.result = []
+                resp.next_page_offset = None
+                resp.points = []
+                return resp
+        return recorder
+
+    pools = [remote._grpc_points_client_pool, remote._grpc_collections_client_pool]
+    for pool in pools:
+        if pool is None:
+            continue
+        for stub in pool:
+            for method_name in dir(stub):
+                if method_name.startswith("_"):
+                    continue
+                attr = getattr(stub, method_name)
+                if not callable(attr):
+                    continue
+                # Both sync and async stubs expose plain callables; the
+                # async variant returns a coroutine on call. We replace
+                # every callable with a recorder; in async mode the
+                # recorder itself is an async coroutine function.
+                if async_mode and inspect.iscoroutinefunction(attr):
+                    continue  # never the case for grpc.aio stubs
+                setattr(stub, method_name, make_recorder(method_name))
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# sync
+# ---------------------------------------------------------------------------
+
+
+class TestSyncGrpcTimeoutFallback:
+    def test_query_points_propagates_global_timeout(self):
+        client = QdrantClient(prefer_grpc=True, check_compatibility=False, timeout=42)
+        remote = client._client
+        captured = _patch_stub_pool(remote, async_mode=False)
+
+        # Suppress post-call conversion; the test cares about the request.
+        try:
+            client.query_points(collection_name="test", query=[0.1, 0.2, 0.3])
+        except Exception:
+            pass
+
+        method_name, request, deadline = captured[0]
+        assert method_name == "Query"
+        assert request.timeout == 42
+        assert deadline == 42
+
+    def test_query_points_per_call_timeout_overrides_global(self):
+        client = QdrantClient(prefer_grpc=True, check_compatibility=False, timeout=42)
+        remote = client._client
+        captured = _patch_stub_pool(remote, async_mode=False)
+
+        try:
+            client.query_points(
+                collection_name="test", query=[0.1, 0.2, 0.3], timeout=7
+            )
+        except Exception:
+            pass
+
+        method_name, request, deadline = captured[0]
+        assert method_name == "Query"
+        assert request.timeout == 7
+        assert deadline == 7
+
+    def test_query_points_default_timeout_used_when_neither_set(self):
+        # When neither a per-call timeout nor a global QdrantClient timeout is
+        # set, the QdrantRemote default (DEFAULT_GRPC_TIMEOUT = 5) is used
+        # for both the protobuf field and the gRPC deadline.
+        client = QdrantClient(prefer_grpc=True, check_compatibility=False)
+        remote = client._client
+        captured = _patch_stub_pool(remote, async_mode=False)
+
+        try:
+            client.query_points(collection_name="test", query=[0.1, 0.2, 0.3])
+        except Exception:
+            pass
+
+        method_name, request, deadline = captured[0]
+        assert method_name == "Query"
+        assert request.timeout == 5
+        assert deadline == 5
+
+    def test_scroll_propagates_global_timeout(self):
+        client = QdrantClient(prefer_grpc=True, check_compatibility=False, timeout=99)
+        remote = client._client
+        captured = _patch_stub_pool(remote, async_mode=False)
+
+        try:
+            client.scroll(collection_name="test")
+        except Exception:
+            pass
+
+        # Find the Scroll call (round-robin may pick a different pool entry).
+        scroll_calls = [c for c in captured if c[0] == "Scroll"]
+        assert scroll_calls, f"expected Scroll call, got {[c[0] for c in captured]}"
+        _method, request, deadline = scroll_calls[0]
+        assert request.timeout == 99
+        assert deadline == 99
+
+    def test_count_propagates_global_timeout(self):
+        client = QdrantClient(prefer_grpc=True, check_compatibility=False, timeout=11)
+        remote = client._client
+        captured = _patch_stub_pool(remote, async_mode=False)
+
+        try:
+            client.count(collection_name="test")
+        except Exception:
+            pass
+
+        count_calls = [c for c in captured if c[0] == "Count"]
+        assert count_calls, f"expected Count call, got {[c[0] for c in captured]}"
+        _method, request, deadline = count_calls[0]
+        assert request.timeout == 11
+        assert deadline == 11
+
+    def test_upsert_propagates_global_timeout(self):
+        # Write methods originally used `timeout=self._timeout` for the gRPC
+        # deadline, ignoring the per-call timeout. The fix applies the
+        # fallback to both the protobuf field and the deadline.
+        from qdrant_client import models
+
+        client = QdrantClient(prefer_grpc=True, check_compatibility=False, timeout=33)
+        remote = client._client
+        captured = _patch_stub_pool(remote, async_mode=False)
+
+        try:
+            client.upsert(
+                collection_name="test",
+                points=[models.PointStruct(id=1, vector=[0.1, 0.2])],
+            )
+        except Exception:
+            pass
+
+        upsert_calls = [c for c in captured if c[0] == "Upsert"]
+        assert upsert_calls, f"expected Upsert call, got {[c[0] for c in captured]}"
+        _method, request, deadline = upsert_calls[0]
+        assert request.timeout == 33
+        assert deadline == 33
+
+    def test_collection_method_uses_self_timeout_only(self):
+        # collection_exists takes no per-call timeout. The local is
+        # `effective_timeout = self._timeout` (not the with-fallback form).
+        # CollectionExistsRequest has no protobuf `timeout` field, so we
+        # verify the gRPC deadline equals the global timeout instead.
+        client = QdrantClient(prefer_grpc=True, check_compatibility=False, timeout=55)
+        remote = client._client
+        captured = _patch_stub_pool(remote, async_mode=False)
+
+        try:
+            client.collection_exists(collection_name="test")
+        except Exception:
+            pass
+
+        assert captured, "expected a gRPC call"
+        deadlines = [d for _m, _r, d in captured]
+        assert any(d == 55 for d in deadlines), (
+            f"expected at least one gRPC deadline == 55, got {deadlines}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# async
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncGrpcTimeoutFallback:
+    @pytest.mark.asyncio
+    async def test_query_points_propagates_global_timeout(self):
+        client = AsyncQdrantClient(
+            prefer_grpc=True, check_compatibility=False, timeout=42
+        )
+        remote = client._client
+        captured = _patch_stub_pool(remote, async_mode=True)
+
+        try:
+            await client.query_points(collection_name="test", query=[0.1, 0.2, 0.3])
+        except Exception:
+            pass
+
+        method_name, request, deadline = captured[0]
+        assert method_name == "Query"
+        assert request.timeout == 42
+        assert deadline == 42
+
+    @pytest.mark.asyncio
+    async def test_query_points_per_call_timeout_overrides_global(self):
+        client = AsyncQdrantClient(
+            prefer_grpc=True, check_compatibility=False, timeout=42
+        )
+        remote = client._client
+        captured = _patch_stub_pool(remote, async_mode=True)
+
+        try:
+            await client.query_points(
+                collection_name="test", query=[0.1, 0.2, 0.3], timeout=7
+            )
+        except Exception:
+            pass
+
+        method_name, request, deadline = captured[0]
+        assert method_name == "Query"
+        assert request.timeout == 7
+        assert deadline == 7
+
+    @pytest.mark.asyncio
+    async def test_scroll_propagates_global_timeout(self):
+        client = AsyncQdrantClient(
+            prefer_grpc=True, check_compatibility=False, timeout=99
+        )
+        remote = client._client
+        captured = _patch_stub_pool(remote, async_mode=True)
+
+        try:
+            await client.scroll(collection_name="test")
+        except Exception:
+            pass
+
+        scroll_calls = [c for c in captured if c[0] == "Scroll"]
+        assert scroll_calls, f"expected Scroll call, got {[c[0] for c in captured]}"
+        _method, request, deadline = scroll_calls[0]
+        assert request.timeout == 99
+        assert deadline == 99
+
+    @pytest.mark.asyncio
+    async def test_upsert_propagates_global_timeout(self):
+        from qdrant_client import models
+
+        client = AsyncQdrantClient(
+            prefer_grpc=True, check_compatibility=False, timeout=33
+        )
+        remote = client._client
+        captured = _patch_stub_pool(remote, async_mode=True)
+
+        try:
+            await client.upsert(
+                collection_name="test",
+                points=[models.PointStruct(id=1, vector=[0.1, 0.2])],
+            )
+        except Exception:
+            pass
+
+        upsert_calls = [c for c in captured if c[0] == "Upsert"]
+        assert upsert_calls, f"expected Upsert call, got {[c[0] for c in captured]}"
+        _method, request, deadline = upsert_calls[0]
+        assert request.timeout == 33
+        assert deadline == 33

--- a/tests/test_grpc_timeout_fallback.py
+++ b/tests/test_grpc_timeout_fallback.py
@@ -213,6 +213,76 @@ class TestSyncGrpcTimeoutFallback:
             f"expected at least one gRPC deadline == 55, got {deadlines}"
         )
 
+    def test_create_collection_propagates_global_timeout(self):
+        # create_collection was missed in the first round of the fix
+        # (CodeRabbit review). The per-call timeout was being ignored:
+        # the protobuf field got the raw (possibly None) `timeout` while
+        # the gRPC deadline always used `self._timeout`. Verify the
+        # effective timeout now flows through to both.
+        from qdrant_client import models
+
+        client = QdrantClient(prefer_grpc=True, check_compatibility=False, timeout=77)
+        remote = client._client
+        captured = _patch_stub_pool(remote, async_mode=False)
+
+        try:
+            client.create_collection(
+                collection_name="test",
+                vectors_config=models.VectorParams(
+                    size=4, distance=models.Distance.COSINE
+                ),
+            )
+        except Exception:
+            pass
+
+        create_calls = [c for c in captured if c[0] == "Create"]
+        assert create_calls, f"expected Create call, got {[c[0] for c in captured]}"
+        _method, request, deadline = create_calls[0]
+        assert request.timeout == 77
+        assert deadline == 77
+
+    def test_create_payload_index_propagates_global_timeout(self):
+        client = QdrantClient(prefer_grpc=True, check_compatibility=False, timeout=88)
+        remote = client._client
+        captured = _patch_stub_pool(remote, async_mode=False)
+
+        try:
+            client.create_payload_index(
+                collection_name="test",
+                field_name="my_field",
+                field_schema="keyword",
+            )
+        except Exception:
+            pass
+
+        create_calls = [c for c in captured if c[0] == "CreateFieldIndex"]
+        assert create_calls, f"expected CreateFieldIndex call, got {[c[0] for c in captured]}"
+        _method, request, deadline = create_calls[0]
+        assert request.timeout == 88
+        assert deadline == 88
+
+    def test_create_vector_name_propagates_global_timeout(self):
+        from qdrant_client import models
+
+        client = QdrantClient(prefer_grpc=True, check_compatibility=False, timeout=66)
+        remote = client._client
+        captured = _patch_stub_pool(remote, async_mode=False)
+
+        try:
+            client.create_vector_name(
+                collection_name="test",
+                vector_name="my_vec",
+                vector_name_config=models.VectorParams(size=4, distance=models.Distance.COSINE),
+            )
+        except Exception:
+            pass
+
+        create_calls = [c for c in captured if c[0] == "CreateVectorName"]
+        assert create_calls, f"expected CreateVectorName call, got {[c[0] for c in captured]}"
+        _method, request, deadline = create_calls[0]
+        assert request.timeout == 66
+        assert deadline == 66
+
 
 # ---------------------------------------------------------------------------
 # async
@@ -300,3 +370,52 @@ class TestAsyncGrpcTimeoutFallback:
         _method, request, deadline = upsert_calls[0]
         assert request.timeout == 33
         assert deadline == 33
+
+    @pytest.mark.asyncio
+    async def test_create_collection_propagates_global_timeout(self):
+        from qdrant_client import models
+
+        client = AsyncQdrantClient(
+            prefer_grpc=True, check_compatibility=False, timeout=77
+        )
+        remote = client._client
+        captured = _patch_stub_pool(remote, async_mode=True)
+
+        try:
+            await client.create_collection(
+                collection_name="test",
+                vectors_config=models.VectorParams(
+                    size=4, distance=models.Distance.COSINE
+                ),
+            )
+        except Exception:
+            pass
+
+        create_calls = [c for c in captured if c[0] == "Create"]
+        assert create_calls, f"expected Create call, got {[c[0] for c in captured]}"
+        _method, request, deadline = create_calls[0]
+        assert request.timeout == 77
+        assert deadline == 77
+
+    @pytest.mark.asyncio
+    async def test_create_payload_index_propagates_global_timeout(self):
+        client = AsyncQdrantClient(
+            prefer_grpc=True, check_compatibility=False, timeout=88
+        )
+        remote = client._client
+        captured = _patch_stub_pool(remote, async_mode=True)
+
+        try:
+            await client.create_payload_index(
+                collection_name="test",
+                field_name="my_field",
+                field_schema="keyword",
+            )
+        except Exception:
+            pass
+
+        create_calls = [c for c in captured if c[0] == "CreateFieldIndex"]
+        assert create_calls, f"expected CreateFieldIndex call, got {[c[0] for c in captured]}"
+        _method, request, deadline = create_calls[0]
+        assert request.timeout == 88
+        assert deadline == 88


### PR DESCRIPTION
## Summary

Fix the gRPC timeout-fallback bug: when a method is called without a per-call `timeout`, the gRPC transport deadline was set from `self._timeout` (the global constructor value), but the protobuf `timeout` field on the gRPC request stayed as `None`. The Qdrant server uses the protobuf field for its own internal operation budget, so a user-set global timeout was effectively ignored server-side.

Repro from the issue:

```
AsyncQdrantClient(timeout=120)  # 120s gRPC deadline
                              # but server still enforces its own ~60s default
```

## Root cause

Per `@yudelevi` on #948, every gRPC call site in `qdrant_remote.py` / `async_qdrant_remote.py` had the pattern:

```python
self.grpc_points.X(
    grpc.Y(..., timeout=timeout, ...),  # protobuf field, may be None
    timeout=timeout if timeout is not None else self._timeout,  # gRPC deadline, correct
)
```

The first `timeout=` is the protobuf field, which the server uses for its internal operation budget. When the per-call `timeout` was `None`, the field stayed unset and the server fell back to its default (~60s).

## Fix

Across every gRPC call site (read methods, write methods, batches, single-line gRPC calls, the `UpdateCollectionClusterSetupRequest` single-line path, etc.), introduce a local:

```python
effective_timeout = timeout if timeout is not None else self._timeout
```

and use it for both the protobuf field and the gRPC deadline. Methods that take no per-call `timeout` parameter (e.g. `collection_exists`, `get_collection`, `list_shard_keys`) use `effective_timeout = self._timeout` directly.

Total: 174 insertions / 111 deletions across `qdrant_remote.py` and `async_qdrant_remote.py`. The diff is mechanical and reviewable site by site.

## What's NOT in this PR

The HTTP path has the same `timeout=timeout` pattern in calls like `self.http.search_api.query_points(...)`. But `httpx` treats `None` as "no timeout", which is a different bug worth its own discussion. Left out of scope.

## Test plan

`tests/test_grpc_timeout_fallback.py` exercises the protobuf field and the gRPC deadline without a real network call by monkey-patching the gRPC stub pool (the property round-robins across the pool, so all pool entries are patched). Covers:

- global `timeout=42` -> both proto field and gRPC deadline = 42
- per-call `timeout=7` overrides global `timeout=42` -> both = 7
- neither set -> both = `QdrantRemote.DEFAULT_GRPC_TIMEOUT` (5)
- a write method (`upsert`) that originally ignored the per-call timeout
- a no-timeout-param method (`collection_exists`) that uses `self._timeout` directly
- all of the above for both `QdrantClient` and `AsyncQdrantClient`

```
$ .ossvenv/bin/pytest tests/test_grpc_timeout_fallback.py -v
============================== 11 passed in 0.43s ==============================
```

Existing `tests/test_tracing.py`, `tests/test_common.py`, `tests/test_in_memory.py` still pass (41/41).

`mypy qdrant_client/qdrant_remote.py qdrant_client/async_qdrant_remote.py` is clean. `ruff check tests/test_grpc_timeout_fallback.py` is clean. The 3 pre-existing F541 warnings in `qdrant_remote.py` / `async_qdrant_remote.py` are not introduced by this PR.

## Backward compatibility

This is a behavior change, but only in the direction of "user-set timeout is now respected". The default behavior (no global, no per-call) still uses `DEFAULT_GRPC_TIMEOUT = 5` for both the proto field and the gRPC deadline — same as before, just made consistent. Callers that were relying on the per-call `timeout` to be silently ignored by write methods (e.g. `upsert`) will see the per-call value now flow through to the protobuf field; the gRPC deadline was already using `self._timeout` for those.

Fixes #948
