### PR TITLE
feat(client): add __repr__ to QdrantClient, AsyncQdrantClient, QdrantRemote, AsyncQdrantRemote, QdrantLocal, AsyncQdrantLocal

### DIFF
--- a/qdrant_client/async_qdrant_client.py
+++ b/qdrant_client/async_qdrant_client.py
@@ -164,6 +164,15 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
         if hasattr(self, "_client"):
             await self._client.close(grpc_grace=grpc_grace, **kwargs)
 
+    def __repr__(self) -> str:
+        if isinstance(self._client, AsyncQdrantRemote):
+            return (
+                f"<AsyncQdrantClient mode=remote scheme={self._client._scheme} "
+                f"host={self._client._host!r} port={self._client._port} "
+                f"prefer_grpc={self._client._prefer_grpc}>"
+            )
+        return f"<AsyncQdrantClient mode=local location={self._client.location!r}>"
+
     @property
     def grpc_collections(self) -> grpc.CollectionsStub:
         """gRPC client for collections methods

--- a/qdrant_client/async_qdrant_remote.py
+++ b/qdrant_client/async_qdrant_remote.py
@@ -261,6 +261,12 @@ class AsyncQdrantRemote(AsyncQdrantBase):
             )
         self._closed = True
 
+    def __repr__(self) -> str:
+        return (
+            f"<AsyncQdrantRemote scheme={self._scheme} host={self._host!r} "
+            f"port={self._port} prefer_grpc={self._prefer_grpc}>"
+        )
+
     @staticmethod
     def _parse_url(url: str) -> tuple[str | None, str, int | None, str | None]:
         parse_result: Url = parse_url(url)

--- a/qdrant_client/local/async_qdrant_local.py
+++ b/qdrant_client/local/async_qdrant_local.py
@@ -89,6 +89,9 @@ class AsyncQdrantLocal(AsyncQdrantBase):
         except TypeError:
             pass
 
+    def __repr__(self) -> str:
+        return f"<AsyncQdrantLocal location={self.location!r}>"
+
     def _load(self) -> None:
         deprecated_config_fields = ("init_from",)
         if not self.persistent:

--- a/qdrant_client/local/qdrant_local.py
+++ b/qdrant_client/local/qdrant_local.py
@@ -91,6 +91,9 @@ class QdrantLocal(QdrantBase):
             # QdrantLocal instance
             pass
 
+    def __repr__(self) -> str:
+        return f"<QdrantLocal location={self.location!r}>"
+
     def _load(self) -> None:
         deprecated_config_fields = ("init_from",)
 

--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -177,6 +177,15 @@ class QdrantClient(QdrantFastembedMixin):
         if hasattr(self, "_client"):
             self._client.close(grpc_grace=grpc_grace, **kwargs)
 
+    def __repr__(self) -> str:
+        if isinstance(self._client, QdrantRemote):
+            return (
+                f"<QdrantClient mode=remote scheme={self._client._scheme} "
+                f"host={self._client._host!r} port={self._client._port} "
+                f"prefer_grpc={self._client._prefer_grpc}>"
+            )
+        return f"<QdrantClient mode=local location={self._client.location!r}>"
+
     @property
     def grpc_collections(self) -> grpc.CollectionsStub:
         """gRPC client for collections methods

--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -321,6 +321,12 @@ class QdrantRemote(QdrantBase):
 
         self._closed = True
 
+    def __repr__(self) -> str:
+        return (
+            f"<QdrantRemote scheme={self._scheme} host={self._host!r} "
+            f"port={self._port} prefer_grpc={self._prefer_grpc}>"
+        )
+
     @staticmethod
     def _parse_url(url: str) -> tuple[str | None, str, int | None, str | None]:
         parse_result: Url = parse_url(url)

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -1,0 +1,174 @@
+"""Regression tests for __repr__ on the client classes.
+
+Issue #1287. Verifies that QdrantClient, AsyncQdrantClient, QdrantRemote,
+AsyncQdrantRemote, QdrantLocal, and AsyncQdrantLocal all produce meaningful
+repr() output that includes the connection info and never leaks the api_key.
+"""
+
+import pytest
+
+from qdrant_client import QdrantClient
+from qdrant_client.async_qdrant_client import AsyncQdrantClient
+
+
+class TestQdrantClientRepr:
+    """QdrantClient (the sync facade)."""
+
+    def test_local_in_memory(self):
+        client = QdrantClient(":memory:")
+        r = repr(client)
+        assert r.startswith("<QdrantClient mode=local location=':memory:'>")
+
+    def test_local_path(self):
+        client = QdrantClient(path="/tmp/qdrant")
+        r = repr(client)
+        assert r.startswith("<QdrantClient mode=local location='/tmp/qdrant'>")
+
+    def test_remote_default(self):
+        client = QdrantClient("localhost", port=6333, prefer_grpc=True)
+        r = repr(client)
+        assert r.startswith("<QdrantClient mode=remote ")
+        assert "scheme=http" in r
+        assert "host='localhost'" in r
+        assert "port=6333" in r
+        assert "prefer_grpc=True" in r
+
+    def test_remote_https(self):
+        client = QdrantClient("https://api.qdrant.io", api_key="sk-secret-12345")
+        r = repr(client)
+        assert "scheme=https" in r
+        assert "host='api.qdrant.io'" in r
+        # api_key must NEVER appear in the repr
+        assert "sk-secret-12345" not in r
+        assert "api_key" not in r
+
+    def test_remote_url_with_port(self):
+        client = QdrantClient(url="https://example.com:1234")
+        r = repr(client)
+        assert "scheme=https" in r
+        assert "host='example.com'" in r
+        assert "port=1234" in r
+
+
+class TestQdrantRemoteRepr:
+    """QdrantRemote (the inner sync class, directly instantiated)."""
+
+    def test_default(self):
+        from qdrant_client.qdrant_remote import QdrantRemote
+
+        client = QdrantRemote(url="https://api.qdrant.io", api_key="sk-secret-12345")
+        r = repr(client)
+        assert r.startswith("<QdrantRemote ")
+        assert "scheme=https" in r
+        assert "host='api.qdrant.io'" in r
+        assert "sk-secret-12345" not in r
+
+    def test_prefer_grpc(self):
+        from qdrant_client.qdrant_remote import QdrantRemote
+
+        client = QdrantRemote(host="localhost", port=6333, prefer_grpc=True)
+        r = repr(client)
+        assert "prefer_grpc=True" in r
+        assert "scheme=http" in r
+
+
+class TestQdrantLocalRepr:
+    """QdrantLocal (the inner sync class, directly instantiated)."""
+
+    def test_in_memory(self):
+        from qdrant_client.local.qdrant_local import QdrantLocal
+
+        local = QdrantLocal(":memory:")
+        r = repr(local)
+        assert r == "<QdrantLocal location=':memory:'>"
+
+    def test_path(self):
+        from qdrant_client.local.qdrant_local import QdrantLocal
+
+        local = QdrantLocal("/tmp/qdrant_storage")
+        r = repr(local)
+        assert r == "<QdrantLocal location='/tmp/qdrant_storage'>"
+
+
+class TestAsyncQdrantClientRepr:
+    """AsyncQdrantClient (the async facade)."""
+
+    def test_local_in_memory(self):
+        client = AsyncQdrantClient(":memory:")
+        r = repr(client)
+        assert r.startswith("<AsyncQdrantClient mode=local location=':memory:'>")
+
+    def test_local_path(self):
+        client = AsyncQdrantClient(path="/tmp/qdrant")
+        r = repr(client)
+        assert r.startswith("<AsyncQdrantClient mode=local location='/tmp/qdrant'>")
+
+    def test_remote(self):
+        client = AsyncQdrantClient("localhost", port=6333, prefer_grpc=True)
+        r = repr(client)
+        assert r.startswith("<AsyncQdrantClient mode=remote ")
+        assert "scheme=http" in r
+        assert "host='localhost'" in r
+        assert "port=6333" in r
+        assert "prefer_grpc=True" in r
+
+    def test_remote_https_no_api_key_leak(self):
+        client = AsyncQdrantClient("https://api.qdrant.io", api_key="sk-secret-12345")
+        r = repr(client)
+        assert "scheme=https" in r
+        assert "host='api.qdrant.io'" in r
+        assert "sk-secret-12345" not in r
+        assert "api_key" not in r
+
+
+class TestAsyncQdrantRemoteRepr:
+    """AsyncQdrantRemote (the inner async class, directly instantiated)."""
+
+    def test_default(self):
+        from qdrant_client.async_qdrant_remote import AsyncQdrantRemote
+
+        client = AsyncQdrantRemote(
+            url="https://api.qdrant.io", api_key="sk-secret-12345"
+        )
+        r = repr(client)
+        assert r.startswith("<AsyncQdrantRemote ")
+        assert "scheme=https" in r
+        assert "host='api.qdrant.io'" in r
+        assert "sk-secret-12345" not in r
+
+
+class TestAsyncQdrantLocalRepr:
+    """AsyncQdrantLocal (the inner async class, directly instantiated)."""
+
+    def test_in_memory(self):
+        from qdrant_client.local.async_qdrant_local import AsyncQdrantLocal
+
+        local = AsyncQdrantLocal(":memory:")
+        r = repr(local)
+        assert r == "<AsyncQdrantLocal location=':memory:'>"
+
+    def test_path(self):
+        from qdrant_client.local.async_qdrant_local import AsyncQdrantLocal
+
+        local = AsyncQdrantLocal("/tmp/qdrant_storage")
+        r = repr(local)
+        assert r == "<AsyncQdrantLocal location='/tmp/qdrant_storage'>"
+
+
+class TestReprIsStr:
+    """repr() must return a str (never a coroutine). It is called synchronously
+    by Python's built-in formatter, so the async client's __repr__ must be a
+    regular def, not an async def (which would return a coroutine)."""
+
+    def test_repr_returns_str_not_coroutine_sync(self):
+        client = QdrantClient(":memory:")
+        r = repr(client)
+        assert isinstance(r, str)
+        assert "QdrantClient" in r
+
+    @pytest.mark.asyncio
+    async def test_repr_returns_str_not_coroutine_async(self):
+        client = AsyncQdrantClient(":memory:")
+        r = repr(client)
+        assert isinstance(r, str)
+        assert "AsyncQdrantClient" in r

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -19,10 +19,10 @@ class TestQdrantClientRepr:
         r = repr(client)
         assert r.startswith("<QdrantClient mode=local location=':memory:'>")
 
-    def test_local_path(self):
-        client = QdrantClient(path="/tmp/qdrant")
+    def test_local_path(self, tmp_path):
+        client = QdrantClient(path=str(tmp_path / "qdrant"))
         r = repr(client)
-        assert r.startswith("<QdrantClient mode=local location='/tmp/qdrant'>")
+        assert r.startswith(f"<QdrantClient mode=local location='{tmp_path / 'qdrant'}'>")
 
     def test_remote_default(self):
         client = QdrantClient("localhost", port=6333, prefer_grpc=True)
@@ -82,12 +82,12 @@ class TestQdrantLocalRepr:
         r = repr(local)
         assert r == "<QdrantLocal location=':memory:'>"
 
-    def test_path(self):
+    def test_path(self, tmp_path):
         from qdrant_client.local.qdrant_local import QdrantLocal
 
-        local = QdrantLocal("/tmp/qdrant_storage")
+        local = QdrantLocal(str(tmp_path / "qdrant_storage"))
         r = repr(local)
-        assert r == "<QdrantLocal location='/tmp/qdrant_storage'>"
+        assert r == f"<QdrantLocal location='{tmp_path / 'qdrant_storage'}'>"
 
 
 class TestAsyncQdrantClientRepr:
@@ -98,10 +98,10 @@ class TestAsyncQdrantClientRepr:
         r = repr(client)
         assert r.startswith("<AsyncQdrantClient mode=local location=':memory:'>")
 
-    def test_local_path(self):
-        client = AsyncQdrantClient(path="/tmp/qdrant")
+    def test_local_path(self, tmp_path):
+        client = AsyncQdrantClient(path=str(tmp_path / "qdrant"))
         r = repr(client)
-        assert r.startswith("<AsyncQdrantClient mode=local location='/tmp/qdrant'>")
+        assert r.startswith(f"<AsyncQdrantClient mode=local location='{tmp_path / 'qdrant'}'>")
 
     def test_remote(self):
         client = AsyncQdrantClient("localhost", port=6333, prefer_grpc=True)
@@ -147,12 +147,12 @@ class TestAsyncQdrantLocalRepr:
         r = repr(local)
         assert r == "<AsyncQdrantLocal location=':memory:'>"
 
-    def test_path(self):
+    def test_path(self, tmp_path):
         from qdrant_client.local.async_qdrant_local import AsyncQdrantLocal
 
-        local = AsyncQdrantLocal("/tmp/qdrant_storage")
+        local = AsyncQdrantLocal(str(tmp_path / "qdrant_storage"))
         r = repr(local)
-        assert r == "<AsyncQdrantLocal location='/tmp/qdrant_storage'>"
+        assert r == f"<AsyncQdrantLocal location='{tmp_path / 'qdrant_storage'}'>"
 
 
 class TestReprIsStr:


### PR DESCRIPTION
## Summary

Add `__repr__` to all 6 client classes so debugging, logging, and Jupyter inspection produce useful output instead of `<qdrant_client.qdrant_client.QdrantClient object at 0x...>`.

Fixes #1287.

## Problem

None of the 6 client classes (QdrantClient, AsyncQdrantClient, QdrantRemote, AsyncQdrantRemote, QdrantLocal, AsyncQdrantLocal) implemented `__repr__`. Three concrete pain points:

1. **Debugging.** Exception logs show `<... object at 0x...>` instead of the host/mode.
2. **Jupyter.** `client` in a cell prints the memory address.
3. **Structured logging.** `structlog`/`loguru` call `repr()` on objects by default.

`httpx.Client`, `redis.Redis`, `boto3.client`, and `motor.AsyncIOMotorClient` all ship with a meaningful `__repr__`. This is the standard Python convention.

## Implementation

One `__repr__` method per class. Each is 3-6 lines, all return a string. No new abstractions, no new state, no public API change beyond the special-method names.

- `QdrantRemote` and `AsyncQdrantRemote` show `scheme=http host='localhost' port=6333 prefer_grpc=False`.
- `QdrantLocal` and `AsyncQdrantLocal` show `location=':memory:'` or `location='/tmp/qdrant'`.
- `QdrantClient` and `AsyncQdrantClient` (the facades) prefix the inner repr with `mode=remote` or `mode=local`.

`api_key` is never included in the repr — secrets don't belong in reprs (they end up in logs, exception tracebacks, debuggers).

## Regen

The async files are generated by the AST transformer pipeline. The transformer converts `def X` to `async def X` only when `X` is in `async_methods` (built from `iscoroutinefunction` of the async base class). `__repr__` is not in any async base and is not a coroutine function, so the transformer leaves it as `def __repr__` in the async mirror. Verified the transformer end-to-end with a small test that round-trips a `QdrantClient` snippet through `ClientFunctionDefTransformer`.

No `exclude_methods` change, no regen-script sed step, no maintainer documentation burden.

## Tests

`tests/test_repr.py` (18 tests) covers:

- `QdrantClient` facade: local `:memory:`, local path, remote with default args, remote HTTPS with api_key (asserts no leak), remote URL with port.
- `QdrantRemote` directly: default, prefer_grpc, api_key masking.
- `QdrantLocal` directly: in-memory, path.
- `AsyncQdrantClient` facade: same matrix.
- `AsyncQdrantRemote` directly: default with api_key masking.
- `AsyncQdrantLocal` directly: in-memory, path.
- Sync and async `repr()` return `str`, never a coroutine.

All 18 new tests pass; 46 existing tests in `test_tracing.py`, `test_common.py`, `test_in_memory.py`, and `test_local_persistence.py` still pass.

## Verification

- mypy clean on all 6 modified files.
- ruff check + format clean on the new test file.
- AST transformer verified to leave `__repr__` sync in the async mirror.

## Base branch

PR targets `upstream/dev` per maintainer joein's 2026-07-21 close comment on #1269: "All the PRs should point `dev` branch, not master." Matches the PR template at `.github/PULL_REQUEST_TEMPLATE.md:4`.

## Out of scope

- `__str__` (Python convention is to make `__str__` and `__repr__` the same unless they serve different audiences; here they don't).
- `closed` property on the facade classes (orthogonal; the `with` block from #1286 already covers the common case).
- A `client_options` property returning connection state (orthogonal; users can already inspect `init_options`).
