### PR TITLE
fix: escape url path params in the rest api client

### DIFF
--- a/qdrant_client/http/api_client.py
+++ b/qdrant_client/http/api_client.py
@@ -1,7 +1,7 @@
 from asyncio import get_event_loop
 from functools import lru_cache
 from typing import Any, Awaitable, Callable, Dict, Generic, Type, TypeVar, overload
-from urllib.parse import urljoin
+from urllib.parse import quote, urljoin
 
 from httpx import AsyncClient, Client, Request, Response
 from pydantic import ValidationError
@@ -64,6 +64,12 @@ MiddlewareT = Callable[[Request, Send], Response]
 AsyncMiddlewareT = Callable[[Request, SendAsync], Awaitable[Response]]
 
 
+def quote_path_params(path_params: Dict[str, Any]) -> Dict[str, str]:
+    # each path param is a single URL segment, so reserved characters have to be escaped,
+    # otherwise a name like `example/collection1` would change the path of the request
+    return {name: quote(str(value), safe="") for name, value in path_params.items()}
+
+
 class ApiClient:
     def __init__(self, host: str, **kwargs: Any) -> None:
         self.host = host
@@ -88,7 +94,7 @@ class ApiClient:
         url = url[1:] if url.startswith("/") else url
         # in order to do a correct join, url join requires base_url to end with /, and url to not start with /,
         # since url is treated as an absolute path and might truncate prefix in base_url
-        url = urljoin(host, url.format(**path_params))
+        url = urljoin(host, url.format(**quote_path_params(path_params)))
         if "params" in kwargs and "timeout" in kwargs["params"]:
             kwargs["timeout"] = int(kwargs["params"]["timeout"])
         request = self._client.build_request(method, url, **kwargs)
@@ -179,7 +185,7 @@ class AsyncApiClient:
         url = url[1:] if url.startswith("/") else url
         # in order to do a correct join, url join requires base_url to end with /, and url to not start with /,
         # since url is treated as an absolute path and might truncate prefix in base_url
-        url = urljoin(host, url.format(**path_params))
+        url = urljoin(host, url.format(**quote_path_params(path_params)))
         request = self._async_client.build_request(method, url, **kwargs)
         return await self.send(request, type_)
 

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,75 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from qdrant_client.http.api_client import ApiClient, AsyncApiClient
+
+COLLECTION_EXISTS_URL = "/collections/{collection_name}/exists"
+
+
+def build_sync_url(collection_name: str) -> str:
+    client = ApiClient("http://localhost:6333")
+    client.send = MagicMock(return_value=None)
+    client.request(
+        type_=None,
+        method="GET",
+        url=COLLECTION_EXISTS_URL,
+        path_params={"collection_name": collection_name},
+    )
+    return str(client.send.call_args[0][0].url)
+
+
+async def build_async_url(collection_name: str) -> str:
+    client = AsyncApiClient("http://localhost:6333")
+    client.send = AsyncMock(return_value=None)
+    await client.request(
+        type_=None,
+        method="GET",
+        url=COLLECTION_EXISTS_URL,
+        path_params={"collection_name": collection_name},
+    )
+    return str(client.send.call_args[0][0].url)
+
+
+class TestPathParamsEncoding:
+    def test_plain_collection_name_is_not_escaped(self):
+        assert build_sync_url("my_collection-1") == (
+            "http://localhost:6333/collections/my_collection-1/exists"
+        )
+
+    def test_slash_in_collection_name_stays_a_single_path_segment(self):
+        # without escaping, the name would add a path segment and the request would be
+        # sent to a route which does not exist
+        assert build_sync_url("example/collection1") == (
+            "http://localhost:6333/collections/example%2Fcollection1/exists"
+        )
+
+    def test_space_in_collection_name_is_escaped(self):
+        assert build_sync_url("my collection") == (
+            "http://localhost:6333/collections/my%20collection/exists"
+        )
+
+    def test_non_string_path_params_are_supported(self):
+        client = ApiClient("http://localhost:6333")
+        client.send = MagicMock(return_value=None)
+        client.request(
+            type_=None,
+            method="GET",
+            url="/collections/{collection_name}/shards/{shard_id}",
+            path_params={"collection_name": "test_collection", "shard_id": 1},
+        )
+        assert str(client.send.call_args[0][0].url) == (
+            "http://localhost:6333/collections/test_collection/shards/1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_client_escapes_path_params(self):
+        assert await build_async_url("example/collection1") == (
+            "http://localhost:6333/collections/example%2Fcollection1/exists"
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_plain_collection_name_is_not_escaped(self):
+        assert await build_async_url("my_collection-1") == (
+            "http://localhost:6333/collections/my_collection-1/exists"
+        )


### PR DESCRIPTION
Closes #807

### Problem

Path params are interpolated into the request path as-is in `ApiClient.request`, so a value containing a reserved character silently changes the path of the request instead of being sent as a single segment:

```python
client = QdrantClient(url="http://localhost:6333")
client.collection_exists(collection_name="example/collection1")
```

builds `GET /collections/example/collection1/exists`, which is not an existing route, so the call fails with `UnexpectedResponse` instead of reporting on the collection.

### Change

`quote_path_params()` percent-encodes every path param before the url is formatted, in both `ApiClient` and `AsyncApiClient`. All path params in the generated api (`collection_name`, `shard_id`, `snapshot_name`, `vector_name`, `peer_id`, `id`, `field_name`) are single segments, so escaping them is safe. Names made of unreserved characters are unchanged, so this does not affect existing requests.

### Tests

Added `tests/test_api_client.py`, which asserts the built request url without needing a running Qdrant:

* a plain name is not escaped (both clients)
* a name with `/` stays one path segment (both clients)
* a name with a space is escaped
* non-string path params such as `shard_id=1` still work

I checked that the two escaping cases fail without the change and pass with it.

### How I verified

```
$ pytest tests/test_api_client.py -q
6 passed

$ pytest tests/test_in_memory.py tests/test_tracing.py tests/conversions -q
40 passed
```

I did not run the integration test suite locally, since it needs a running Qdrant instance — relying on CI for that.

### One thing worth your call

`qdrant_client/http/` is generated, and `generate_rest_client.sh` replaces the whole directory, so this would be overwritten on the next regeneration. I put the change here because `api_client.py` has been patched directly in this repo before (#890, #996, #914). If you would rather have it in the `pydantic_openapi_v3` template, I am happy to open a PR there instead and drop this one.

I also assumed encoding is preferable to raising a client-side `ValueError` on such names, since it does not add new error semantics — but the issue mentioned validation as an option too, so let me know if you prefer that.
