### PR TITLE
fix: values_count bounds must be satisfied by a single value in local…

### DIFF
--- a/qdrant_client/local/payload_filters.py
+++ b/qdrant_client/local/payload_filters.py
@@ -33,15 +33,16 @@ def check_values_count(condition: models.ValuesCount, values: list[Any] | None) 
 
     counts = get_value_counts(values)
 
-    if condition.lt is not None and all(count >= condition.lt for count in counts):
-        return False
-    if condition.lte is not None and all(count > condition.lte for count in counts):
-        return False
-    if condition.gt is not None and all(count <= condition.gt for count in counts):
-        return False
-    if condition.gte is not None and all(count < condition.gte for count in counts):
-        return False
-    return True
+    # A single value's count must satisfy every bound at once, and the condition
+    # matches if any one value does. Checking each bound independently across all
+    # counts would let separate values satisfy separate bounds.
+    return any(
+        (condition.lt is None or count < condition.lt)
+        and (condition.lte is None or count <= condition.lte)
+        and (condition.gt is None or count > condition.gt)
+        and (condition.gte is None or count >= condition.gte)
+        for count in counts
+    )
 
 
 def check_geo_radius(condition: models.GeoRadius, values: Any) -> bool:

--- a/tests/congruence_tests/test_values_count.py
+++ b/tests/congruence_tests/test_values_count.py
@@ -79,3 +79,67 @@ def test_values_count():
                 with_payload=False,
             ),
         )
+
+
+def test_values_count_multiple_values():
+    # A wildcard path yields one count per matched value. Each bound must be
+    # satisfied by the same value, not by different ones.
+    vectors_config = models.VectorParams(size=2, distance=models.Distance.COSINE)
+    points = [
+        # counts == [1, 10]: neither is inside (1, 5), so bounded filters must not match
+        models.PointStruct(
+            id=1,
+            vector=[0.1, 0.2],
+            payload={"nested": [{"field": [1]}, {"field": list(range(10))}]},
+        ),
+        # counts == [3]: inside (1, 5)
+        models.PointStruct(
+            id=2, vector=[0.2, 0.3], payload={"nested": [{"field": [1, 2, 3]}]}
+        ),
+        # counts == [1, 2]: 2 is inside (1, 5)
+        models.PointStruct(
+            id=3, vector=[0.3, 0.4], payload={"nested": [{"field": [1]}, {"field": [1, 2]}]}
+        ),
+    ]
+
+    local_client = init_local()
+    init_client(local_client, points, vectors_config=vectors_config)
+
+    remote_client = init_remote()
+    init_client(remote_client, points, vectors_config=vectors_config)
+
+    filters = [
+        models.Filter(
+            must=[
+                models.FieldCondition(
+                    key="nested[].field", values_count=models.ValuesCount(gt=1, lt=5)
+                )
+            ]
+        ),
+        models.Filter(
+            must=[
+                models.FieldCondition(
+                    key="nested[].field", values_count=models.ValuesCount(gte=2, lte=4)
+                )
+            ]
+        ),
+        models.Filter(
+            must=[
+                models.FieldCondition(
+                    key="nested[].field", values_count=models.ValuesCount(gt=2, lt=9)
+                )
+            ]
+        ),
+    ]
+
+    for flt in filters:
+        compare_client_results(
+            local_client,
+            remote_client,
+            lambda c, f=flt: c.scroll(
+                COLLECTION_NAME,
+                scroll_filter=f,
+                limit=100,
+                with_payload=False,
+            ),
+        )


### PR DESCRIPTION
Fixes #1292

`check_values_count` checked each bound independently across all of a point's
value counts, so separate values could satisfy separate bounds. This matches
the server's `ValuesCount::check_count`, which requires one count to satisfy
all four bounds, and matches the condition if any single value does.

**Tests**

Added `test_values_count_multiple_values` to the existing congruence test,
covering a wildcard path that yields multiple counts. It fails on `dev` and
passes with this change:

| filter | before | after (and server) |
|---|---|---|
| `gt=1, lt=5`  | 1, 2, 3 | 2, 3 |
| `gte=2, lte=4`| 1, 2, 3 | 2, 3 |
| `gt=2, lt=9`  | 1, 2    | 2    |

Point 1 has counts `[1, 10]`; no count falls inside any of those ranges, so it
should never match.

Existing single-key cases are unaffected — I swept all 10 existing filters
against all 7 existing payloads with no behavior change.

I don't have Docker locally, so the congruence test hasn't been run against a
live server on my machine; the expected values above are derived from the
server's `check_count` implementation.
