### PR TITLE
feat(client): expose `closed` property on QdrantClient and AsyncQdrantClient facades

### DIFF
--- a/qdrant_client/async_qdrant_client.py
+++ b/qdrant_client/async_qdrant_client.py
@@ -165,6 +165,15 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
             await self._client.close(grpc_grace=grpc_grace, **kwargs)
 
     @property
+    def closed(self) -> bool:
+        """Whether the client has been closed.
+
+        Returns:
+            ``False`` before :meth:`close` is called, ``True`` afterwards.
+        """
+        return self._client.closed
+
+    @property
     def grpc_collections(self) -> grpc.CollectionsStub:
         """gRPC client for collections methods
 

--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -178,6 +178,15 @@ class QdrantClient(QdrantFastembedMixin):
             self._client.close(grpc_grace=grpc_grace, **kwargs)
 
     @property
+    def closed(self) -> bool:
+        """Whether the client has been closed.
+
+        Returns:
+            ``False`` before :meth:`close` is called, ``True`` afterwards.
+        """
+        return self._client.closed
+
+    @property
     def grpc_collections(self) -> grpc.CollectionsStub:
         """gRPC client for collections methods
 

--- a/tests/test_closed.py
+++ b/tests/test_closed.py
@@ -1,0 +1,126 @@
+"""Regression tests for the `closed` property on the client facades.
+
+Issue #1299. Verifies that QdrantClient and AsyncQdrantClient expose a
+`closed` property that returns False before close() is called and True
+afterwards, delegating to the inner client. Works for :memory: local
+mode, path= local mode, and remote mode.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from qdrant_client import QdrantClient
+from qdrant_client.async_qdrant_client import AsyncQdrantClient
+
+
+class TestSyncFacadeClosed:
+    """QdrantClient.closed returns False before close(), True after."""
+
+    def test_local_in_memory_starts_false(self):
+        client = QdrantClient(":memory:")
+        assert client.closed is False
+
+    def test_local_in_memory_true_after_close(self):
+        client = QdrantClient(":memory:")
+        client.close()
+        assert client.closed is True
+
+    def test_local_path_starts_false(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            client = QdrantClient(path=str(Path(tmp) / "qdrant_test"))
+            assert client.closed is False
+
+    def test_local_path_true_after_close(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            client = QdrantClient(path=str(Path(tmp) / "qdrant_test"))
+            client.close()
+            assert client.closed is True
+
+    def test_remote_starts_false(self):
+        client = QdrantClient("http://localhost:6333", prefer_grpc=False)
+        assert client.closed is False
+
+    def test_remote_true_after_close(self):
+        client = QdrantClient("http://localhost:6333", prefer_grpc=False)
+        client.close()
+        assert client.closed is True
+
+    def test_delegates_to_inner_client(self):
+        # closed should be the same value the inner client exposes,
+        # not a copy or a stale snapshot.
+        client = QdrantClient(":memory:")
+        assert client.closed == client._client.closed
+        client.close()
+        assert client.closed == client._client.closed
+
+    def test_double_close_keeps_closed_true(self):
+        client = QdrantClient(":memory:")
+        client.close()
+        assert client.closed is True
+        client.close()
+        assert client.closed is True
+
+
+class TestAsyncFacadeClosed:
+    """AsyncQdrantClient.closed is a sync property, returnable without await."""
+
+    @pytest.mark.asyncio
+    async def test_local_in_memory_starts_false(self):
+        client = AsyncQdrantClient(":memory:")
+        assert client.closed is False
+
+    @pytest.mark.asyncio
+    async def test_local_in_memory_true_after_close(self):
+        client = AsyncQdrantClient(":memory:")
+        await client.close()
+        assert client.closed is True
+
+    @pytest.mark.asyncio
+    async def test_local_path_starts_false(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            client = AsyncQdrantClient(path=str(Path(tmp) / "qdrant_test_async"))
+            assert client.closed is False
+
+    @pytest.mark.asyncio
+    async def test_local_path_true_after_close(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            client = AsyncQdrantClient(path=str(Path(tmp) / "qdrant_test_async"))
+            await client.close()
+            assert client.closed is True
+
+    @pytest.mark.asyncio
+    async def test_remote_starts_false(self):
+        client = AsyncQdrantClient("http://localhost:6333", prefer_grpc=False)
+        assert client.closed is False
+
+    @pytest.mark.asyncio
+    async def test_remote_true_after_close(self):
+        client = AsyncQdrantClient("http://localhost:6333", prefer_grpc=False)
+        await client.close()
+        assert client.closed is True
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_inner_client(self):
+        client = AsyncQdrantClient(":memory:")
+        assert client.closed == client._client.closed
+        await client.close()
+        assert client.closed == client._client.closed
+
+    @pytest.mark.asyncio
+    async def test_double_close_keeps_closed_true(self):
+        client = AsyncQdrantClient(":memory:")
+        await client.close()
+        assert client.closed is True
+        await client.close()
+        assert client.closed is True
+
+    @pytest.mark.asyncio
+    async def test_property_is_not_coroutine(self):
+        # closed is a synchronous @property — it must not return a coroutine.
+        # If a maintainer accidentally makes it async, this test catches it.
+        client = AsyncQdrantClient(":memory:")
+        result = client.closed
+        assert not hasattr(result, "__await__")
+        assert isinstance(result, bool)

--- a/tests/test_closed.py
+++ b/tests/test_closed.py
@@ -20,7 +20,10 @@ class TestSyncFacadeClosed:
 
     def test_local_in_memory_starts_false(self):
         client = QdrantClient(":memory:")
-        assert client.closed is False
+        try:
+            assert client.closed is False
+        finally:
+            client.close()
 
     def test_local_in_memory_true_after_close(self):
         client = QdrantClient(":memory:")
@@ -30,7 +33,10 @@ class TestSyncFacadeClosed:
     def test_local_path_starts_false(self):
         with tempfile.TemporaryDirectory() as tmp:
             client = QdrantClient(path=str(Path(tmp) / "qdrant_test"))
-            assert client.closed is False
+            try:
+                assert client.closed is False
+            finally:
+                client.close()
 
     def test_local_path_true_after_close(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -40,7 +46,10 @@ class TestSyncFacadeClosed:
 
     def test_remote_starts_false(self):
         client = QdrantClient("http://localhost:6333", prefer_grpc=False)
-        assert client.closed is False
+        try:
+            assert client.closed is False
+        finally:
+            client.close()
 
     def test_remote_true_after_close(self):
         client = QdrantClient("http://localhost:6333", prefer_grpc=False)
@@ -51,9 +60,12 @@ class TestSyncFacadeClosed:
         # closed should be the same value the inner client exposes,
         # not a copy or a stale snapshot.
         client = QdrantClient(":memory:")
-        assert client.closed == client._client.closed
-        client.close()
-        assert client.closed == client._client.closed
+        try:
+            assert client.closed == client._client.closed
+            client.close()
+            assert client.closed == client._client.closed
+        finally:
+            client.close()
 
     def test_double_close_keeps_closed_true(self):
         client = QdrantClient(":memory:")
@@ -69,7 +81,10 @@ class TestAsyncFacadeClosed:
     @pytest.mark.asyncio
     async def test_local_in_memory_starts_false(self):
         client = AsyncQdrantClient(":memory:")
-        assert client.closed is False
+        try:
+            assert client.closed is False
+        finally:
+            await client.close()
 
     @pytest.mark.asyncio
     async def test_local_in_memory_true_after_close(self):
@@ -81,7 +96,10 @@ class TestAsyncFacadeClosed:
     async def test_local_path_starts_false(self):
         with tempfile.TemporaryDirectory() as tmp:
             client = AsyncQdrantClient(path=str(Path(tmp) / "qdrant_test_async"))
-            assert client.closed is False
+            try:
+                assert client.closed is False
+            finally:
+                await client.close()
 
     @pytest.mark.asyncio
     async def test_local_path_true_after_close(self):
@@ -93,7 +111,10 @@ class TestAsyncFacadeClosed:
     @pytest.mark.asyncio
     async def test_remote_starts_false(self):
         client = AsyncQdrantClient("http://localhost:6333", prefer_grpc=False)
-        assert client.closed is False
+        try:
+            assert client.closed is False
+        finally:
+            await client.close()
 
     @pytest.mark.asyncio
     async def test_remote_true_after_close(self):
@@ -104,9 +125,12 @@ class TestAsyncFacadeClosed:
     @pytest.mark.asyncio
     async def test_delegates_to_inner_client(self):
         client = AsyncQdrantClient(":memory:")
-        assert client.closed == client._client.closed
-        await client.close()
-        assert client.closed == client._client.closed
+        try:
+            assert client.closed == client._client.closed
+            await client.close()
+            assert client.closed == client._client.closed
+        finally:
+            await client.close()
 
     @pytest.mark.asyncio
     async def test_double_close_keeps_closed_true(self):
@@ -121,6 +145,9 @@ class TestAsyncFacadeClosed:
         # closed is a synchronous @property — it must not return a coroutine.
         # If a maintainer accidentally makes it async, this test catches it.
         client = AsyncQdrantClient(":memory:")
-        result = client.closed
-        assert not hasattr(result, "__await__")
-        assert isinstance(result, bool)
+        try:
+            result = client.closed
+            assert not hasattr(result, "__await__")
+            assert isinstance(result, bool)
+        finally:
+            await client.close()


### PR DESCRIPTION
## Summary

Add a public `closed` property to the `QdrantClient` and `AsyncQdrantClient` facade classes, delegating to the inner client. The four inner classes (`QdrantRemote`, `AsyncQdrantRemote`, `QdrantLocal`, `AsyncQdrantLocal`) already expose this property; the user-facing facades did not. Users had to reach into `client._client.closed` (private attribute) to check state.

Fixes #1299

## Changes

- `qdrant_client/qdrant_client.py`: add `@property def closed(self) -> bool: return self._client.closed`
- `qdrant_client/async_qdrant_client.py`: same property, kept synchronous (the inner `closed` is also a synchronous bool, not a coroutine)
- `tests/test_closed.py`: 17 new tests covering sync + async × in-memory / path / remote × before-close / after-close, plus double-close, inner-delegation, and not-coroutine sanity checks

## Behavior

```python
client = QdrantClient(":memory:")
assert client.closed is False
client.close()
assert client.closed is True
```

Async equivalent (no `await` needed on the property):

```python
client = AsyncQdrantClient(":memory:")
assert client.closed is False
await client.close()
assert client.closed is True
```

Works for `:memory:` local mode, `path=` local mode, and remote mode — the facade forwards to the inner client in all three cases.

## Verification

- `.ossvenv/bin/python -m pytest tests/test_closed.py -v` — 17 passed
- `.ossvenv/bin/python -m ruff check` — clean
- `.ossvenv/bin/python -m ruff format --check` — clean
- `.ossvenv/bin/python -m mypy` — clean
- `bash tools/generate_async_client.sh` — the `closed` property is preserved in the regen output (no AST sed step needed; properties are kept sync by the function-def transformer because `closed` is not in the async-method set derived from `AsyncQdrantBase`)

## Notes

- Base branch: `dev` (per the PR template and maintainer joein's 2026-07-21 guidance on PRs pointing the wrong base)
- The async file is autogenerated but this property survives regen without an AST-based sed step. No generator config change required.
- No new dependencies, no new abstractions, no public API change beyond the new property names.
