### PR TITLE
fix(local): require one value count to satisfy all values_count bounds (#1292)

### DIFF
--- a/qdrant_client/local/payload_filters.py
+++ b/qdrant_client/local/payload_filters.py
@@ -33,15 +33,18 @@ def check_values_count(condition: models.ValuesCount, values: list[Any] | None) 
 
     counts = get_value_counts(values)
 
-    if condition.lt is not None and all(count >= condition.lt for count in counts):
-        return False
-    if condition.lte is not None and all(count > condition.lte for count in counts):
-        return False
-    if condition.gt is not None and all(count <= condition.gt for count in counts):
-        return False
-    if condition.gte is not None and all(count < condition.gte for count in counts):
-        return False
-    return True
+    def check_count(count: int) -> bool:
+        if condition.lt is not None and count >= condition.lt:
+            return False
+        if condition.lte is not None and count > condition.lte:
+            return False
+        if condition.gt is not None and count <= condition.gt:
+            return False
+        if condition.gte is not None and count < condition.gte:
+            return False
+        return True
+
+    return any(check_count(count) for count in counts)
 
 
 def check_geo_radius(condition: models.GeoRadius, values: Any) -> bool:

--- a/tests/congruence_tests/test_values_count.py
+++ b/tests/congruence_tests/test_values_count.py
@@ -79,3 +79,76 @@ def test_values_count():
                 with_payload=False,
             ),
         )
+
+
+def test_values_count_multivalue():
+    """A multi-value path must satisfy every bound with the *same* count."""
+    vectors_config = models.VectorParams(size=2, distance=models.Distance.COSINE)
+    points = [
+        # counts == [1, 10]: neither count is inside (2, 9)
+        models.PointStruct(
+            id=1,
+            vector=[0.1, 0.2],
+            payload={"nested": [{"field": [1]}, {"field": list(range(10))}]},
+        ),
+        # counts == [3]
+        models.PointStruct(id=2, vector=[0.2, 0.3], payload={"nested": [{"field": [1, 2, 3]}]}),
+        # counts == [1, 5]: 5 is inside (2, 9)
+        models.PointStruct(
+            id=3,
+            vector=[0.3, 0.4],
+            payload={"nested": [{"field": [1]}, {"field": [1, 2, 3, 4, 5]}]},
+        ),
+    ]
+
+    local_client = init_local()
+    init_client(local_client, points, vectors_config=vectors_config)
+
+    remote_client = init_remote()
+    init_client(remote_client, points, vectors_config=vectors_config)
+
+    filters = [
+        models.Filter(
+            must=[
+                models.FieldCondition(
+                    key="nested[].field", values_count=models.ValuesCount(gt=2, lt=9)
+                )
+            ]
+        ),
+        models.Filter(
+            must=[
+                models.FieldCondition(
+                    key="nested[].field", values_count=models.ValuesCount(gte=3, lte=8)
+                )
+            ]
+        ),
+        models.Filter(
+            must=[
+                models.FieldCondition(
+                    key="nested[].field", values_count=models.ValuesCount(gte=2, lte=4)
+                )
+            ]
+        ),
+        models.Filter(
+            must=[
+                models.FieldCondition(key="nested[].field", values_count=models.ValuesCount(gt=2))
+            ]
+        ),
+        models.Filter(
+            must=[
+                models.FieldCondition(key="nested[].field", values_count=models.ValuesCount(lt=9))
+            ]
+        ),
+    ]
+
+    for flt in filters:
+        compare_client_results(
+            local_client,
+            remote_client,
+            lambda c, f=flt: c.scroll(
+                COLLECTION_NAME,
+                scroll_filter=f,
+                limit=100,
+                with_payload=False,
+            ),
+        )


### PR DESCRIPTION
Fixes #1292

## Problem

`check_values_count` in `qdrant_client/local/payload_filters.py` evaluated each bound (`lt`, `lte`, `gt`, `gte`) independently against *all* of a point's value counts:

```python
if condition.lt is not None and all(count >= condition.lt for count in counts):
    return False
...
```

For a multi-value path this ORs the bounds across *different* values: a point matches when one value satisfies the lower bound and a **different** value satisfies the upper one, even though no single value satisfies the whole range.

The server ANDs all four bounds against a single count — `ValuesCount::check_count` in `lib/segment/src/types.rs`:

```rust
lt.is_none_or(|x| count < x)
    && gt.is_none_or(|x| count > x)
    && lte.is_none_or(|x| count <= x)
    && gte.is_none_or(|x| count >= x)
```

and combines multiple extracted values with `any` (`ValueChecker::_check` in `lib/segment/src/payload_storage/condition_checker.rs`). So local mode and the server disagree.

## Fix

Check every bound against one count at a time, and match if **any** count satisfies all of them.

Single-count paths are unaffected: with exactly one count, the old per-bound `all(...)` is arithmetically equivalent to the new per-count check — which is why every existing case in `tests/congruence_tests/test_values_count.py` (all top-level keys, one count each) passed and kept the bug invisible.

## Verification

Old vs. new against the installed client (`qdrant_client/local/payload_filters.py` byte-identical to `master`), points on the multi-value path `nested[].field`:

| id | payload | counts |
|----|---------|--------|
| 1 | `{"nested": [{"field": [1]}, {"field": [0..9]}]}` | `[1, 10]` |
| 2 | `{"nested": [{"field": [1,2,3]}]}` | `[3]` |
| 3 | `{"nested": [{"field": [1]}, {"field": [1..5]}]}` | `[1, 5]` |

| filter | before | after | server |
|--------|--------|-------|--------|
| `ValuesCount(gt=2, lt=9)` | `[1, 2, 3]` | `[2, 3]` | `[2, 3]` |
| `ValuesCount(gte=3, lte=8)` | `[1, 2, 3]` | `[2, 3]` | `[2, 3]` |
| `ValuesCount(gte=2, lte=4)` | `[1, 2, 3]` | `[2]` | `[2]` |
| `ValuesCount(gt=2)` | `[1, 2, 3]` | `[1, 2, 3]` | `[1, 2, 3]` |
| `ValuesCount(lt=9)` | `[1, 2, 3]` | `[1, 2, 3]` | `[1, 2, 3]` |

Point 1 has no single value with a count inside `(2, 9)` — `1` is below and `10` is above — so it must not match the two-sided filters.

Replaying the existing `test_values_count` point set and all ten of its filters through the local client produces **identical** results before and after, confirming no behavior change on single-count paths.

`ruff format --line-length=99` (v0.4.3, matching `.pre-commit-config.yaml`) reports both files clean.

## Tests

Adds `test_values_count_multivalue` to `tests/congruence_tests/test_values_count.py`, covering the multi-value path with two-sided and one-sided bounds. It asserts local/remote congruence rather than a hardcoded answer, so it fails on `master` and passes with this change.

I do not have a qdrant server available in this environment, so the new congruence test itself was not executed locally — the local-mode side was verified as shown above, and the expected server side is derived from `ValuesCount::check_count`. CI will exercise both.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
