### PR TITLE
fix: require values_count bounds to hold for the same count

### DIFF
--- a/qdrant_client/local/payload_filters.py
+++ b/qdrant_client/local/payload_filters.py
@@ -31,17 +31,16 @@ def check_values_count(condition: models.ValuesCount, values: list[Any] | None) 
     if values is None:
         return False
 
-    counts = get_value_counts(values)
-
-    if condition.lt is not None and all(count >= condition.lt for count in counts):
-        return False
-    if condition.lte is not None and all(count > condition.lte for count in counts):
-        return False
-    if condition.gt is not None and all(count <= condition.gt for count in counts):
-        return False
-    if condition.gte is not None and all(count < condition.gte for count in counts):
-        return False
-    return True
+    # All bounds have to hold for the *same* count, matching the server's
+    # ValuesCount::check_count. Evaluating each bound separately would let two
+    # different values combine to satisfy a range that neither one is inside.
+    return any(
+        (condition.lt is None or count < condition.lt)
+        and (condition.lte is None or count <= condition.lte)
+        and (condition.gt is None or count > condition.gt)
+        and (condition.gte is None or count >= condition.gte)
+        for count in get_value_counts(values)
+    )
 
 
 def check_geo_radius(condition: models.GeoRadius, values: Any) -> bool:

--- a/tests/test_local_payload_filters.py
+++ b/tests/test_local_payload_filters.py
@@ -1,0 +1,98 @@
+"""Unit tests for local-mode payload filter helpers.
+
+These run without a server, so they can cover the multi-value paths that the
+congruence tests in ``tests/congruence_tests`` don't reach.
+"""
+
+import pytest
+
+from qdrant_client import models
+from qdrant_client.local.payload_filters import check_values_count, get_value_counts
+
+
+class TestGetValueCounts:
+    @pytest.mark.parametrize(
+        ("values", "expected"),
+        [
+            ([], [0]),
+            ([None], [0]),
+            ([None, None], [0]),
+            (["a"], [1]),
+            ([[1, 2, 3]], [3]),
+            ([[1], [1, 2, 3]], [1, 3]),
+            ([None, [1, 2]], [0, 2]),
+        ],
+    )
+    def test_counts(self, values, expected):
+        assert get_value_counts(values) == expected
+
+
+class TestCheckValuesCount:
+    def test_none_values_never_match(self):
+        assert check_values_count(models.ValuesCount(gt=0), None) is False
+
+    @pytest.mark.parametrize(
+        ("condition", "expected"),
+        [
+            (models.ValuesCount(lt=4), True),
+            (models.ValuesCount(lt=3), False),
+            (models.ValuesCount(lte=3), True),
+            (models.ValuesCount(lte=2), False),
+            (models.ValuesCount(gt=2), True),
+            (models.ValuesCount(gt=3), False),
+            (models.ValuesCount(gte=3), True),
+            (models.ValuesCount(gte=4), False),
+            (models.ValuesCount(gt=2, lt=4), True),
+            (models.ValuesCount(gte=3, lte=3), True),
+        ],
+    )
+    def test_single_count(self, condition, expected):
+        """One value, one count — the case the congruence tests already cover."""
+        assert check_values_count(condition, [[1, 2, 3]]) is expected
+
+    def test_bounds_must_be_satisfied_by_the_same_count(self):
+        """Regression for #1292.
+
+        Counts are ``[1, 10]``. ``1`` satisfies ``lt=9`` and ``10`` satisfies
+        ``gt=2``, but neither count is inside ``(2, 9)``, so the point must not
+        match. The bounds used to be evaluated independently, which let two
+        different values combine to satisfy the range.
+        """
+        values = [[1], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]]
+        assert get_value_counts(values) == [1, 10]
+
+        assert check_values_count(models.ValuesCount(gt=2, lt=9), values) is False
+
+    def test_multi_value_matches_when_one_count_satisfies_all_bounds(self):
+        """The same shape, but with a count that genuinely falls in range."""
+        values = [[1], [1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]]
+        assert get_value_counts(values) == [1, 5, 10]
+
+        assert check_values_count(models.ValuesCount(gt=2, lt=9), values) is True
+
+    @pytest.mark.parametrize(
+        ("condition", "expected"),
+        [
+            # 1 satisfies lte=1, 10 satisfies gte=10 — but no single count does both.
+            (models.ValuesCount(gte=10, lte=1), False),
+            # Both bounds satisfied by the count 10.
+            (models.ValuesCount(gte=10, lte=10), True),
+            # Both bounds satisfied by the count 1.
+            (models.ValuesCount(gte=1, lte=1), True),
+        ],
+    )
+    def test_inverted_bounds_across_values(self, condition, expected):
+        values = [[1], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]]
+        assert check_values_count(condition, values) is expected
+
+    def test_all_four_bounds_against_one_count(self):
+        values = [[1, 2, 3]]
+        assert (
+            check_values_count(models.ValuesCount(gt=2, gte=3, lt=4, lte=3), values) is True
+        )
+        assert (
+            check_values_count(models.ValuesCount(gt=2, gte=3, lt=4, lte=2), values) is False
+        )
+
+    def test_no_bounds_matches_any_count(self):
+        assert check_values_count(models.ValuesCount(), [[1, 2, 3]]) is True


### PR DESCRIPTION
Fixes #1292

## Problem

`check_values_count` evaluated each bound (`lt`, `lte`, `gt`, `gte`) independently across all of a point's value counts. A point therefore matched when *one* value satisfied one bound and a *different* value satisfied another, even though no single count was in range.

The server ANDs all four bounds against a single count (`ValuesCount::check_count` in `lib/segment/src/types.rs`), so local mode diverged.

## Reproduction

```python
payload = {"nested": [{"field": [1]}, {"field": list(range(10))}]}   # counts: [1, 10]
flt = models.Filter(must=[models.FieldCondition(
    key="nested[].field", values_count=models.ValuesCount(gt=2, lt=9))])
```

Local mode returned the point, because `10 > 2` and `1 < 9`. Neither `1` nor `10` is inside `(2, 9)`, and the server rejects it.

## Fix

A point matches when at least one count satisfies *every* bound:

```python
return any(
    (condition.lt is None or count < condition.lt)
    and (condition.lte is None or count <= condition.lte)
    and (condition.gt is None or count > condition.gt)
    and (condition.gte is None or count >= condition.gte)
    for count in get_value_counts(values)
)
```

`get_value_counts` never returns an empty list (`[]` yields `[0]`), so `any()` doesn't introduce an empty-sequence edge case.

## Why this wasn't caught

It only reproduces on multi-value paths. With a single count the old logic is accidentally equivalent to the correct one, and every case in `tests/congruence_tests/test_values_count.py` uses a top-level key, which yields exactly one count.

## Tests

Adds `tests/test_local_payload_filters.py` — unit coverage for `get_value_counts` and `check_values_count`, including multi-value cases and the `gte=10, lte=1` shape where two different counts each satisfy one bound. These need no server, so they cover paths the congruence tests can't reach.

Both regression tests fail on `master` and pass with this change; the other 23 cases pass either way. `tests/test_in_memory.py` and `tests/test_local_persistence.py` still pass (34 total).

Also verified end to end through `QdrantClient(":memory:")` with the payload above: the out-of-range point is no longer returned, and a point whose count is genuinely inside the range still matches.