### PR TITLE
feat(client): add get_collection_names() shortcut (#1302)

### DIFF
--- a/qdrant_client/async_client_base.py
+++ b/qdrant_client/async_client_base.py
@@ -224,6 +224,9 @@ class AsyncQdrantBase:
     async def get_collections(self, **kwargs: Any) -> types.CollectionsResponse:
         raise NotImplementedError()
 
+    async def get_collection_names(self, **kwargs: Any) -> list[str]:
+        raise NotImplementedError()
+
     async def get_collection(self, collection_name: str, **kwargs: Any) -> types.CollectionInfo:
         raise NotImplementedError()
 

--- a/qdrant_client/async_qdrant_client.py
+++ b/qdrant_client/async_qdrant_client.py
@@ -1517,6 +1517,15 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
         assert len(kwargs) == 0, f"Unknown arguments: {list(kwargs.keys())}"
         return await self._client.get_collections(**kwargs)
 
+    async def get_collection_names(self, **kwargs: Any) -> list[str]:
+        """Get names of all existing collections
+
+        Returns:
+            List of the collection names
+        """
+        assert len(kwargs) == 0, f"Unknown arguments: {list(kwargs.keys())}"
+        return await self._client.get_collection_names(**kwargs)
+
     async def get_collection(self, collection_name: str, **kwargs: Any) -> types.CollectionInfo:
         """Get detailed information about specified existing collection
 

--- a/qdrant_client/async_qdrant_remote.py
+++ b/qdrant_client/async_qdrant_remote.py
@@ -1712,6 +1712,11 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         assert result is not None, "Get collections returned None"
         return result
 
+    async def get_collection_names(self, **kwargs: Any) -> list[str]:
+        return [
+            collection.name for collection in (await self.get_collections(**kwargs)).collections
+        ]
+
     async def get_collection(self, collection_name: str, **kwargs: Any) -> types.CollectionInfo:
         if self._prefer_grpc:
             return GrpcToRest.convert_collection_info(

--- a/qdrant_client/client_base.py
+++ b/qdrant_client/client_base.py
@@ -231,6 +231,9 @@ class QdrantBase:
     def get_collections(self, **kwargs: Any) -> types.CollectionsResponse:
         raise NotImplementedError()
 
+    def get_collection_names(self, **kwargs: Any) -> list[str]:
+        raise NotImplementedError()
+
     def get_collection(self, collection_name: str, **kwargs: Any) -> types.CollectionInfo:
         raise NotImplementedError()
 

--- a/qdrant_client/local/async_qdrant_local.py
+++ b/qdrant_client/local/async_qdrant_local.py
@@ -662,6 +662,11 @@ class AsyncQdrantLocal(AsyncQdrantBase):
             ]
         )
 
+    async def get_collection_names(self, **kwargs: Any) -> list[str]:
+        return [
+            collection.name for collection in (await self.get_collections(**kwargs)).collections
+        ]
+
     async def get_collection(self, collection_name: str, **kwargs: Any) -> types.CollectionInfo:
         collection = self._get_collection(collection_name)
         return collection.info()

--- a/qdrant_client/local/qdrant_local.py
+++ b/qdrant_client/local/qdrant_local.py
@@ -719,6 +719,9 @@ class QdrantLocal(QdrantBase):
             ]
         )
 
+    def get_collection_names(self, **kwargs: Any) -> list[str]:
+        return [collection.name for collection in self.get_collections(**kwargs).collections]
+
     def get_collection(self, collection_name: str, **kwargs: Any) -> types.CollectionInfo:
         collection = self._get_collection(collection_name)
         return collection.info()

--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -1576,6 +1576,16 @@ class QdrantClient(QdrantFastembedMixin):
 
         return self._client.get_collections(**kwargs)
 
+    def get_collection_names(self, **kwargs: Any) -> list[str]:
+        """Get names of all existing collections
+
+        Returns:
+            List of the collection names
+        """
+        assert len(kwargs) == 0, f"Unknown arguments: {list(kwargs.keys())}"
+
+        return self._client.get_collection_names(**kwargs)
+
     def get_collection(self, collection_name: str, **kwargs: Any) -> types.CollectionInfo:
         """Get detailed information about specified existing collection
 

--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -1873,6 +1873,9 @@ class QdrantRemote(QdrantBase):
         assert result is not None, "Get collections returned None"
         return result
 
+    def get_collection_names(self, **kwargs: Any) -> list[str]:
+        return [collection.name for collection in self.get_collections(**kwargs).collections]
+
     def get_collection(self, collection_name: str, **kwargs: Any) -> types.CollectionInfo:
         if self._prefer_grpc:
             return GrpcToRest.convert_collection_info(

--- a/tests/congruence_tests/test_collections.py
+++ b/tests/congruence_tests/test_collections.py
@@ -51,6 +51,33 @@ def test_get_collection():
     )
 
 
+def test_get_collection_names():
+    fixture_points = generate_fixtures()
+
+    remote_client = init_remote()
+
+    for collection in remote_client.get_collections().collections:
+        remote_client.delete_collection(collection.name)
+
+    local_client = init_local()
+    init_client(local_client, fixture_points)
+
+    init_client(remote_client, fixture_points)
+
+    local_names = local_client.get_collection_names()
+    remote_names = remote_client.get_collection_names()
+
+    # the shortcut returns exactly the names carried by get_collections()
+    assert local_names == [
+        collection.name for collection in local_client.get_collections().collections
+    ]
+    assert remote_names == [
+        collection.name for collection in remote_client.get_collections().collections
+    ]
+
+    assert sorted(local_names) == sorted(remote_names)
+
+
 def test_recreate_collection():
     # this method has been marked as deprecated and should be removed in qdrant-client v1.12
     local_client = init_local()


### PR DESCRIPTION
## Problem

Closes #1302.

`get_collections()` returns a `types.CollectionsResponse` whose `.collections` is a list of `CollectionDescription` objects. The common case — "I just want the names" — requires a list comprehension every time:

```python
names = [c.name for c in client.get_collections().collections]
```

This is verbose for what should be a one-liner (cleanup scripts, "which collections exist" checks, health dashboards), and `CollectionDescription` is more than a "list of names" query needs.

## Change

Add `get_collection_names()` as a thin convenience wrapper that returns `list[str]`, following the exact convention of the existing `collection_exists()` helper:

- abstract `QdrantBase` (`client_base.py`)
- concrete `QdrantRemote` and `QdrantLocal` — each derives the names from its own `get_collections()`, so gRPC/REST/local behave identically for free
- the `QdrantClient` facade delegates to `self._client.get_collection_names(...)`

The async variants (`AsyncQdrantBase`, `AsyncQdrantRemote`, `AsyncQdrantLocal`, `AsyncQdrantClient`) are **regenerated** via `tools/generate_async_client.sh` — not hand-edited — so `tests/async-client-consistency-check.sh` stays green.

## Test

`tests/congruence_tests/test_collections.py::test_get_collection_names` asserts local and remote return the same names, and that each equals the `.collections` name comprehension. Verified locally in `:memory:` mode for both the sync and async clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
