### PR TITLE
fix: support FieldCondition.is_empty/is_null in local mode

### DIFF
--- a/qdrant_client/local/payload_filters.py
+++ b/qdrant_client/local/payload_filters.py
@@ -45,6 +45,22 @@ def check_values_count(condition: models.ValuesCount, values: list[Any] | None) 
     return True
 
 
+def check_is_empty_value(is_empty: bool, value: Any) -> bool:
+    if value is None:
+        return is_empty
+    if isinstance(value, list):
+        return (len(value) == 0) == is_empty
+    return not is_empty
+
+
+def check_is_null_value(is_null: bool, value: Any) -> bool:
+    if value is None:
+        return is_null
+    if isinstance(value, list):
+        return any(v is None for v in value) == is_null
+    return not is_null
+
+
 def check_geo_radius(condition: models.GeoRadius, values: Any) -> bool:
     if isinstance(values, dict) and "lat" in values and "lon" in values:
         lat = values["lat"]
@@ -227,6 +243,19 @@ def check_condition(
         if condition.has_vector in has_vector and has_vector[condition.has_vector]:
             return True
     elif isinstance(condition, models.FieldCondition):
+        if condition.values_count is None and (
+            condition.is_empty is not None or condition.is_null is not None
+        ):
+            # values_count keeps its own branch below, this must not shadow it
+            raw_values = value_by_key(payload, condition.key, flat=False)
+            if not raw_values:
+                # nothing stored under the key: the server counts that as empty, not null
+                if condition.is_empty is not None:
+                    return condition.is_empty
+                return not condition.is_null
+            if condition.is_empty is not None:
+                return any(check_is_empty_value(condition.is_empty, v) for v in raw_values)
+            return any(check_is_null_value(condition.is_null, v) for v in raw_values)
         values = value_by_key(payload, condition.key)
         if condition.match is not None:
             if values is None:

--- a/qdrant_client/local/tests/test_payload_filters.py
+++ b/qdrant_client/local/tests/test_payload_filters.py
@@ -187,3 +187,152 @@ def test_geo_polygon_filter_query():
 
     res = check_filter(query, payload, 0, has_vector={})
     assert res is False
+
+
+def test_field_condition_is_empty():
+    # `FieldCondition.is_empty` is the shorthand syntax for `IsEmptyCondition`.
+    # A value is empty if it is null, an empty array, or the key is absent.
+    payloads = {
+        1: {"reports": [1, 2]},
+        2: {"reports": []},
+        3: {"reports": None},
+        4: {},
+        5: {"reports": [None, 1]},
+    }
+
+    def matches(is_empty: bool) -> list[int]:
+        query = models.Filter(must=[models.FieldCondition(key="reports", is_empty=is_empty)])
+        return [
+            idx
+            for idx, payload in payloads.items()
+            if check_filter(query, payload, idx, has_vector={})
+        ]
+
+    assert matches(True) == [2, 3, 4]
+    assert matches(False) == [1, 5]
+
+    # `must_not` must be the exact complement, not "everything"
+    negated = models.Filter(must_not=[models.FieldCondition(key="reports", is_empty=True)])
+    assert [
+        idx
+        for idx, payload in payloads.items()
+        if check_filter(negated, payload, idx, has_vector={})
+    ] == [1, 5]
+
+    # for a key holding a single value, the shorthand agrees with the verbose condition
+    # it abbreviates
+    verbose = models.Filter(
+        must=[models.IsEmptyCondition(is_empty=models.PayloadField(key="reports"))]
+    )
+    assert [
+        idx
+        for idx, payload in payloads.items()
+        if check_filter(verbose, payload, idx, has_vector={})
+    ] == matches(True)
+
+
+def test_field_condition_is_null():
+    # `FieldCondition.is_null` matches a null value, or an array containing one.
+    # An absent key is not null.
+    payloads = {
+        1: {"reports": [1, 2]},
+        2: {"reports": []},
+        3: {"reports": None},
+        4: {},
+        5: {"reports": [None, 1]},
+    }
+
+    def matches(is_null: bool) -> list[int]:
+        query = models.Filter(must=[models.FieldCondition(key="reports", is_null=is_null)])
+        return [
+            idx
+            for idx, payload in payloads.items()
+            if check_filter(query, payload, idx, has_vector={})
+        ]
+
+    assert matches(True) == [3, 5]
+    assert matches(False) == [1, 2, 4]
+
+    negated = models.Filter(must_not=[models.FieldCondition(key="reports", is_null=True)])
+    assert [
+        idx
+        for idx, payload in payloads.items()
+        if check_filter(negated, payload, idx, has_vector={})
+    ] == [1, 2, 4]
+
+    # Deliberately no equivalence assertion against `IsNullCondition` here. On a field
+    # without a payload index the server does not treat the two as interchangeable: the
+    # verbose condition tests the values the key resolves to, so an array holding a null
+    # is not itself null, while the shorthand looks inside it. Point 5 matches the
+    # shorthand only. Local mode does not model payload indexes, so it mirrors that.
+    verbose = models.Filter(
+        must=[models.IsNullCondition(is_null=models.PayloadField(key="reports"))]
+    )
+    assert [
+        idx
+        for idx, payload in payloads.items()
+        if check_filter(verbose, payload, idx, has_vector={})
+    ] == [3]
+
+
+def test_field_condition_is_empty_is_null_with_values_count():
+    # a condition carrying values_count as well keeps going to the values_count branch,
+    # so adding is_empty / is_null to it changes nothing
+    payloads = {
+        1: {"reports": [1, 2]},
+        2: {"reports": []},
+        3: {"reports": None},
+        4: {},
+    }
+
+    def matches(query: models.Filter) -> list[int]:
+        return [
+            idx
+            for idx, payload in payloads.items()
+            if check_filter(query, payload, idx, has_vector={})
+        ]
+
+    assert matches(
+        models.Filter(
+            must=[
+                models.FieldCondition(
+                    key="reports", is_empty=True, values_count=models.ValuesCount(gte=1)
+                )
+            ]
+        )
+    ) == [1]
+    assert matches(
+        models.Filter(
+            must=[
+                models.FieldCondition(
+                    key="reports", is_null=True, values_count=models.ValuesCount(lt=1)
+                )
+            ]
+        )
+    ) == [2, 3, 4]
+
+
+def test_field_condition_is_empty_is_null_json_path():
+    # a key resolving to several values matches when any one of them satisfies the
+    # condition
+    payloads = {
+        1: {"a": [{"b": 1}, {"b": None}]},
+        2: {"a": [{"b": 1}, {"b": 2}]},
+        3: {"a": []},
+        4: {"a": [{"b": []}, {"b": 1}]},
+    }
+
+    def matches(kind: str, flag: bool) -> list[int]:
+        query = models.Filter(must=[models.FieldCondition(key="a[].b", **{kind: flag})])
+        return [
+            idx
+            for idx, payload in payloads.items()
+            if check_filter(query, payload, idx, has_vector={})
+        ]
+
+    assert matches("is_null", True) == [1]
+    # point 1 also holds a non-null value, so it satisfies both directions
+    assert matches("is_null", False) == [1, 2, 3, 4]
+    assert matches("is_empty", True) == [1, 3, 4]
+    # likewise points 1 and 4 hold a non-empty value as well
+    assert matches("is_empty", False) == [1, 2, 4]

--- a/tests/congruence_tests/test_is_empty_is_null.py
+++ b/tests/congruence_tests/test_is_empty_is_null.py
@@ -83,3 +83,8 @@ def test_field_condition_is_empty_is_null():
                 with_payload=False,
             ),
         )
+        compare_client_results(
+            local_client,
+            remote_client,
+            lambda c, f=flt: c.count(COLLECTION_NAME, count_filter=f).count,
+        )

--- a/tests/congruence_tests/test_is_empty_is_null.py
+++ b/tests/congruence_tests/test_is_empty_is_null.py
@@ -1,0 +1,85 @@
+from qdrant_client import models
+from tests.congruence_tests.test_common import (
+    COLLECTION_NAME,
+    compare_client_results,
+    init_client,
+    init_local,
+    init_remote,
+)
+
+
+def test_field_condition_is_empty_is_null():
+    """`FieldCondition.is_empty` / `is_null` are the shorthand syntax for
+    `IsEmptyCondition` / `IsNullCondition`."""
+    vectors_config = models.VectorParams(size=2, distance=models.Distance.COSINE)
+    points = [
+        # non-empty list: neither empty nor null
+        models.PointStruct(id=1, vector=[0.1, 0.2], payload={"field": [1, 2]}),
+        # empty list: empty, not null
+        models.PointStruct(id=2, vector=[0.2, 0.3], payload={"field": []}),
+        # null: both empty and null
+        models.PointStruct(id=3, vector=[0.3, 0.4], payload={"field": None}),
+        # missing key: empty, but not null
+        models.PointStruct(id=4, vector=[0.4, 0.5], payload={}),
+        # list containing a null: not empty, but null
+        models.PointStruct(id=5, vector=[0.5, 0.6], payload={"field": [None, 1]}),
+        # scalars and objects are neither empty nor null
+        models.PointStruct(id=6, vector=[0.6, 0.7], payload={"field": 0}),
+        models.PointStruct(id=7, vector=[0.7, 0.8], payload={"field": ""}),
+        models.PointStruct(id=8, vector=[0.8, 0.9], payload={"field": {"a": 1}}),
+        # the same shapes under a nested key, and under a key resolving to several values
+        models.PointStruct(id=9, vector=[0.9, 1.0], payload={"nested": {"field": None}}),
+        models.PointStruct(id=10, vector=[1.0, 1.1], payload={"nested": {"field": []}}),
+        models.PointStruct(id=11, vector=[1.1, 1.2], payload={"nested": {}}),
+        models.PointStruct(id=12, vector=[1.2, 1.3], payload={"nested": {"field": [1, 2]}}),
+        models.PointStruct(
+            id=13, vector=[1.3, 1.4], payload={"array": [{"field": 1}, {"field": None}]}
+        ),
+        models.PointStruct(
+            id=14, vector=[1.4, 1.5], payload={"array": [{"field": 1}, {"field": 2}]}
+        ),
+        models.PointStruct(id=15, vector=[1.5, 1.6], payload={"array": []}),
+        models.PointStruct(
+            id=16, vector=[1.6, 1.7], payload={"array": [{"field": []}, {"field": 1}]}
+        ),
+    ]
+
+    local_client = init_local()
+    init_client(local_client, points, vectors_config=vectors_config)
+
+    remote_client = init_remote()
+    init_client(remote_client, points, vectors_config=vectors_config)
+
+    filters = [
+        models.Filter(must=[models.FieldCondition(key="field", is_empty=True)]),
+        models.Filter(must=[models.FieldCondition(key="field", is_empty=False)]),
+        models.Filter(must=[models.FieldCondition(key="field", is_null=True)]),
+        models.Filter(must=[models.FieldCondition(key="field", is_null=False)]),
+        models.Filter(must_not=[models.FieldCondition(key="field", is_empty=True)]),
+        models.Filter(must_not=[models.FieldCondition(key="field", is_null=True)]),
+        # the verbose conditions the shorthand abbreviates
+        models.Filter(must=[models.IsEmptyCondition(is_empty=models.PayloadField(key="field"))]),
+        models.Filter(must=[models.IsNullCondition(is_null=models.PayloadField(key="field"))]),
+        # nested keys, and keys resolving to several values
+        models.Filter(must=[models.FieldCondition(key="nested.field", is_empty=True)]),
+        models.Filter(must=[models.FieldCondition(key="nested.field", is_empty=False)]),
+        models.Filter(must=[models.FieldCondition(key="nested.field", is_null=True)]),
+        models.Filter(must=[models.FieldCondition(key="nested.field", is_null=False)]),
+        models.Filter(must=[models.FieldCondition(key="array[].field", is_empty=True)]),
+        models.Filter(must=[models.FieldCondition(key="array[].field", is_empty=False)]),
+        models.Filter(must=[models.FieldCondition(key="array[].field", is_null=True)]),
+        models.Filter(must=[models.FieldCondition(key="array[].field", is_null=False)]),
+        models.Filter(must_not=[models.FieldCondition(key="array[].field", is_empty=True)]),
+    ]
+
+    for flt in filters:
+        compare_client_results(
+            local_client,
+            remote_client,
+            lambda c, f=flt: c.scroll(
+                COLLECTION_NAME,
+                scroll_filter=f,
+                limit=100,
+                with_payload=False,
+            ),
+        )


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

---

## The problem

`FieldCondition` carries `is_empty` and `is_null` — the shorthand syntax for
`IsEmptyCondition` / `IsNullCondition`, described in the generated models as
"alternative syntax for `is_empty: 'field_name'`". In local mode they are ignored
**silently**, and the failure is total rather than partial:

```python
client = QdrantClient(":memory:")
# ... 5 points, only some of which have a "reports" value

flt = models.Filter(must=[models.FieldCondition(key="reports", is_empty=True)])
client.scroll("c", scroll_filter=flt)      # -> []  (server: the 3 empty ones)

flt = models.Filter(must_not=[models.FieldCondition(key="reports", is_empty=True)])
client.scroll("c", scroll_filter=flt)      # -> every point in the collection
```

So `must` matches nothing and `must_not` matches everything — with no warning and
no `NotImplementedError`. It reaches `scroll`, `count`, `query_points`, `facet`
and `delete(filter=...)`, which means a `delete` guarded by `must_not=[...]` can
clear a whole local collection while doing almost nothing against a server.

## Root cause

`check_condition()`'s `FieldCondition` branch only ever inspected `match`,
`range`, `geo_bounding_box`, `geo_radius`, `values_count` and `geo_polygon`. A
condition carrying `is_empty=`/`is_null=` matches none of those `if`s, falls out
of the `elif` body and hits the trailing `return False` at the end of the
function — evaluating to `False` for every point.

## The fix

Two small helpers plus a branch in `check_condition`:

- a value is **empty** when it is `null` or an empty array; a key holding no
  value counts as empty but **not** null
- a value is **null** when it is `null` or an array containing a `null`
- for a key resolving to several values (`a[].b`), any one of them satisfying the
  condition is a match — so one point can satisfy both `is_empty=True` and
  `is_empty=False`

A condition that also carries `values_count` is left to the existing
`values_count` branch, so nothing about its behaviour changes.

Values are read with `flat=False`, like the two neighbouring `IsEmptyCondition`
and `IsNullCondition` branches. That is load-bearing rather than stylistic:
`{"field": []}` flattens to `None`, which would otherwise collapse the
empty-array case into the no-value case.

## How this was tested

The semantics above were **established by running the queries against a real
`qdrant/qdrant:dev` (1.18.3-dev) container, not by reading core** — an earlier
revision of this PR was written from the Rust source and got the `values_count`
interaction wrong in a way only the live server revealed.

- `tests/congruence_tests/test_is_empty_is_null.py` (new) — 16 points and 19
  filters diffed between local mode and a live server, covering a flat key, a
  nested key and an array-traversing key, both directions of each condition,
  `must_not`, and both verbose conditions. This follows the same pattern as
  #1190 / #1191 / #1224 / #1259.
- `qdrant_client/local/tests/test_payload_filters.py` — 4 new unit tests
  (72 → 76 collected in that directory).
- Full congruence suite against `qdrant/qdrant:dev`: **284 passed**, matching a
  clean `dev` baseline.
- `ruff-format --line-length=99` clean; `mypy` clean on `qdrant_client/local`.

## Risk and compatibility

No public API, signature, default or return-shape change — this is local-mode
internals, and the async local client picks it up unchanged. The only behaviour
that changes is for conditions that are currently broken. In principle someone
could be relying on `must_not=[FieldCondition(is_empty=True)]` matching
everything, but that is the bug rather than a contract.

## Two things worth your judgement

**1. Payload indexes.** Local mode does not model them (it warns as much), so
where the server's answer depends on whether a field is indexed, local mode can
only mirror one path. This PR mirrors the unindexed payload-scan path, which is
what the surrounding local-mode branches already do and what the congruence
fixtures exercise.

That matters in one visible place: on an **unindexed** field the server does not
treat `is_null` and `IsNullCondition` as interchangeable — the verbose condition
tests the values a key resolves to, so an array holding a null is not itself
null, while the shorthand looks inside it:

```
payload {"field": [None, 1]}
  FieldCondition(key="field", is_null=True)   -> matches
  IsNullCondition(key="field")                -> does not match
```

With a keyword index on the field, both match. `is_empty` and
`IsEmptyCondition` agree either way. Since the models call the two forms
alternative syntax, this looks like it may be a core inconsistency rather than
intended — happy to flip the client whenever core settles it, and the congruence
test means you would hear about it either way.

**2. Deliberately out of scope.** `check_condition` evaluates `match` / `range` /
geo *before* `values_count`, whereas the server prefers `values_count`. That
predates this PR and is unchanged by it, so I have not touched it. Glad to send a
separate PR if you want it fixed.

---

Found by comparing local mode against server behaviour rather than from a
reported issue, so there is no linked issue. AI-assisted: an agent wrote the
patch and tests, and every behavioural claim here was verified against a running
Qdrant container.
