### PR TITLE
fix: propagate per-call timeout to httpx in AsyncApiClient

### DIFF
--- a/qdrant_client/http/api_client.py
+++ b/qdrant_client/http/api_client.py
@@ -183,6 +183,8 @@ class AsyncApiClient:
         # in order to do a correct join, url join requires base_url to end with /, and url to not start with /,
         # since url is treated as an absolute path and might truncate prefix in base_url
         url = urljoin(host, url.format(**path_params))
+        if "params" in kwargs and "timeout" in kwargs["params"]:
+            kwargs["timeout"] = int(kwargs["params"]["timeout"])
         request = self._async_client.build_request(method, url, **kwargs)
         return await self.send(request, type_)
 

--- a/tests/test_async_qdrant_client.py
+++ b/tests/test_async_qdrant_client.py
@@ -270,27 +270,49 @@ async def test_async_qdrant_client(prefer_grpc):
 @pytest.mark.asyncio
 async def test_async_timeout_propagation():
     client = AsyncQdrantClient()
-    vectors_config = models.VectorParams(size=2, distance=models.Distance.COSINE)
-    with pytest.raises(qdrant_client.http.exceptions.ResponseHandlingException) as exc_info:
-        # timeout is Optional[int]
-        # if we set it to 0 - recreate_collection raises operation is in progress instead of timed out
-        client.http.client._async_client._timeout = Timeout(0.01)
+    try:
+        vectors_config = models.VectorParams(size=2, distance=models.Distance.COSINE)
         if await client.collection_exists(COLLECTION_NAME):
             await client.delete_collection(collection_name=COLLECTION_NAME)
-        await client.create_collection(
-            collection_name=COLLECTION_NAME, vectors_config=vectors_config
-        )
-    # httpx's async transport raises TimeoutException with an empty message (unlike the sync
-    # transport's "timed out"), so assert on the exception type instead of the message text
-    assert isinstance(exc_info.value.source, httpx.TimeoutException)
-    await asyncio.sleep(0.5)
-    if await client.collection_exists(COLLECTION_NAME):
-        await client.delete_collection(collection_name=COLLECTION_NAME, timeout=10)
-    await client.create_collection(
-        collection_name=COLLECTION_NAME, vectors_config=vectors_config, timeout=10
-    )
-    await client.delete_collection(collection_name=COLLECTION_NAME)
-    await client.close()
+
+        # collection_exists() takes no per-call timeout, so only mutate the client-wide
+        # default around the call that's actually under test, and restore it right after
+        original_timeout = client.http.client._async_client._timeout
+        client.http.client._async_client._timeout = Timeout(0.01)
+        try:
+            with pytest.raises(
+                qdrant_client.http.exceptions.ResponseHandlingException
+            ) as exc_info:
+                # timeout is Optional[int]
+                # if we set it to 0 - recreate_collection raises operation is in progress
+                # instead of timed out
+                await client.create_collection(
+                    collection_name=COLLECTION_NAME, vectors_config=vectors_config
+                )
+            # httpx's async transport raises TimeoutException with an empty message (unlike
+            # the sync transport's "timed out"), so assert on the exception type, not the message
+            assert isinstance(exc_info.value.source, httpx.TimeoutException)
+        finally:
+            client.http.client._async_client._timeout = original_timeout
+
+        await asyncio.sleep(0.5)
+        if await client.collection_exists(COLLECTION_NAME):
+            await client.delete_collection(collection_name=COLLECTION_NAME, timeout=10)
+
+        # force the ambient default back down so this call can only succeed if
+        # create_collection's own timeout=10 argument reaches httpx -- that per-call
+        # override is exactly the regression this test guards against
+        client.http.client._async_client._timeout = Timeout(0.01)
+        try:
+            await client.create_collection(
+                collection_name=COLLECTION_NAME, vectors_config=vectors_config, timeout=10
+            )
+        finally:
+            client.http.client._async_client._timeout = original_timeout
+
+        await client.delete_collection(collection_name=COLLECTION_NAME)
+    finally:
+        await client.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_async_qdrant_client.py
+++ b/tests/test_async_qdrant_client.py
@@ -3,8 +3,10 @@ import random
 import time
 
 import grpc.aio._call
+import httpx
 import numpy as np
 import pytest
+from httpx import Timeout
 
 import qdrant_client.http.exceptions
 from qdrant_client import models
@@ -263,6 +265,32 @@ async def test_async_qdrant_client(prefer_grpc):
     assert all(collection.name != COLLECTION_NAME for collection in collections.collections)
     await client.close()
     # endregion
+
+
+@pytest.mark.asyncio
+async def test_async_timeout_propagation():
+    client = AsyncQdrantClient()
+    vectors_config = models.VectorParams(size=2, distance=models.Distance.COSINE)
+    with pytest.raises(qdrant_client.http.exceptions.ResponseHandlingException) as exc_info:
+        # timeout is Optional[int]
+        # if we set it to 0 - recreate_collection raises operation is in progress instead of timed out
+        client.http.client._async_client._timeout = Timeout(0.01)
+        if await client.collection_exists(COLLECTION_NAME):
+            await client.delete_collection(collection_name=COLLECTION_NAME)
+        await client.create_collection(
+            collection_name=COLLECTION_NAME, vectors_config=vectors_config
+        )
+    # httpx's async transport raises TimeoutException with an empty message (unlike the sync
+    # transport's "timed out"), so assert on the exception type instead of the message text
+    assert isinstance(exc_info.value.source, httpx.TimeoutException)
+    await asyncio.sleep(0.5)
+    if await client.collection_exists(COLLECTION_NAME):
+        await client.delete_collection(collection_name=COLLECTION_NAME, timeout=10)
+    await client.create_collection(
+        collection_name=COLLECTION_NAME, vectors_config=vectors_config, timeout=10
+    )
+    await client.delete_collection(collection_name=COLLECTION_NAME)
+    await client.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

## Summary

`AsyncQdrantClient`'s REST transport silently ignores a per-call `timeout=` at the httpx level — e.g. `await client.create_collection(..., timeout=30)` is still bound by httpx's default 5s connect/read/write/pool timeout. `QdrantClient` (sync) does not have this problem.

Fixes #1325

## Problem

`ApiClient.request` (sync) and `AsyncApiClient.request` (async), both in `qdrant_client/http/api_client.py`, build the request the same way, but only the sync one promotes a `timeout` found in the query params up to httpx's own `timeout=` kwarg:

```python
# ApiClient.request (sync) — present
if "params" in kwargs and "timeout" in kwargs["params"]:
    kwargs["timeout"] = int(kwargs["params"]["timeout"])
```

Reproduction (no server needed, monkeypatches `build_request` to capture kwargs — full script in #1325):
```
sync build_request kwargs:  {'params': {'timeout': '50'}, 'timeout': 50}
async build_request kwargs: {'params': {'timeout': '50'}}
```

## Root cause

Sync/async twin drift: `qdrant_client/http/api_client.py` — PR #534 ("propagate timeout from methods to httpx", 2024) added the override block only to `ApiClient.request`; `AsyncApiClient.request`, in the same file, never got the equivalent change and has drifted since. There's a regression test for the sync path (`tests/test_qdrant_client.py::test_timeout_propagation`) but no async equivalent.

## Fix

Add the identical override block to `AsyncApiClient.request`, in the same position as the sync version (right before `build_request`). Minimal, mechanical port of an already-reviewed pattern — no new abstraction, no shared helper introduced, since the two classes in this file are otherwise kept fully parallel and independent.

This is related to but distinct from #948, which is about the **gRPC** transport (the protobuf `timeout` field). A comment on that issue explicitly scopes the HTTP path out ("that one needs a separate discussion") — this PR is that separate discussion, for REST specifically.

## Tests

- New `tests/test_async_qdrant_client.py::test_async_timeout_propagation`, mirroring `test_timeout_propagation`'s structure. Fails before this fix (the `timeout=10` call still times out because the override never reaches httpx), passes after.
- One deliberate adaptation rather than a literal copy: asserts on `isinstance(exc_info.value.source, httpx.TimeoutException)` instead of matching the string `"timed out"`, because httpx's async transport raises `ReadTimeout('')` with an empty message here, while the sync transport's says `"timed out"` — confirmed by running both directly.
- `pytest tests/test_qdrant_client.py -q` → 67 passed, 6 skipped (pre-existing).
- `pytest tests/test_async_qdrant_client.py -q` → 5 passed, 2 skipped (pre-existing).
- `ruff format --check --line-length=99` and `mypy --disallow-incomplete-defs --disallow-untyped-defs` on the changed file: identical to baseline (verified via `git stash` that the pre-existing reformat-needed state and 8 mypy errors in `api_client.py` predate this change; none are on the added lines).

## Compatibility / risk

Internal-only, no public API/signature change. Behavior changes only for async REST callers who pass a per-call `timeout=`; previously they silently got httpx's 5s default regardless, which had no legitimate use case to preserve.

## Out of scope

- #948's gRPC protobuf-timeout-field bug — different transport, already being worked on by another contributor.
- httpx's `timeout=None` semantics mentioned in passing on #948 — separate, not-yet-scoped question.
