### PR TITLE
fix(local): pass the migration error as a logging format arg

### DIFF
--- a/qdrant_client/local/persistence.py
+++ b/qdrant_client/local/persistence.py
@@ -50,7 +50,7 @@ def try_migrate_to_sqlite(location: str) -> None:
         dbm_storage.close()
         dbm_path.unlink()
     except Exception as e:
-        logging.error("Failed to migrate dbm to sqlite:", e)
+        logging.error("Failed to migrate dbm to sqlite: %s", e)
         logging.error(
             "Please try to use previous version of qdrant-client or re-create collection"
         )


### PR DESCRIPTION
## Problem

`qdrant_client/local/persistence.py`, in the dbm → sqlite migration path:

```python
except Exception as e:
    logging.error("Failed to migrate dbm to sqlite:", e)
```

The message has no `%` placeholder, so `logging` treats `e` as a stray %-format argument and `record.getMessage()` raises. `logging` catches that internally and prints a `--- Logging error ---` traceback instead of the message — so the one line naming what actually failed is replaced by noise, exactly when a user's local storage is failing to migrate.

Reproduced on Python 3.12 with a `ValueError("disk image is malformed")`:

```
# before
--- Logging error ---
Traceback (most recent call last):
  ...
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Message: 'Failed to migrate dbm to sqlite:'
Arguments: (ValueError('disk image is malformed'),)

# after
ERROR Failed to migrate dbm to sqlite: disk image is malformed
```

## Fix

Add the `%s` placeholder so the exception is interpolated instead of being passed as an unused argument. One character of behaviour change; the following `logging.error(...)` and the `raise e` are untouched, so control flow is identical.

I scanned the rest of `qdrant_client` for the same shape (`logger.<level>` with a constant message whose placeholder count doesn't match the number of positional args) — this is the only occurrence.

## Note, not addressed here

While reading this function: if the migration raises after `sqlite3.connect(str(sql_path))` has created the file, a partially-populated `storage.sqlite` is left on disk. The next call then hits `if sql_path.exists(): return` at the top and skips migration silently, so the remaining points in `storage.dbm` are never carried over. Whether to unlink the partial file, migrate to a temp path and rename, or leave it as-is is a maintainer call, so I left it out of this PR — happy to open a separate issue if it's worth tracking.

Branched from `dev` per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
