### PR TITLE
fix: return synchronous API responses directly

### DIFF
--- a/qdrant_client/http/api_client.py
+++ b/qdrant_client/http/api_client.py
@@ -109,7 +109,7 @@ class ApiClient:
         """
         This method is not used by the generated apis, but is included for convenience
         """
-        return get_event_loop().run_until_complete(self.request(type_=type_, **kwargs))
+        return self.request(type_=type_, **kwargs)
 
     def send(self, request: Request, type_: Type[T]) -> T:
         response = self.middleware(request, self.send_inner)

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,28 @@
+from unittest.mock import patch
+from typing import Any
+
+import pytest
+
+from qdrant_client.http.api_client import ApiClient
+
+
+@pytest.mark.parametrize(
+    ("type_", "response"),
+    [
+        (dict, {"status": "ok"}),
+        (None, None),
+    ],
+)
+def test_api_client_request_sync_returns_synchronous_response(
+    type_: Any, response: Any
+) -> None:
+    client = ApiClient("http://localhost:6333")
+
+    try:
+        with patch.object(client, "request", return_value=response) as request:
+            result = client.request_sync(type_=type_, method="GET", url="/collections")
+
+        assert result == response
+        request.assert_called_once_with(type_=type_, method="GET", url="/collections")
+    finally:
+        client.close()


### PR DESCRIPTION
### All Submissions:

* [x] Contributions target the `dev` branch.
* [x] I followed the repository contribution guidance.
* [x] I checked for other open pull requests for the same change.

### Changes to Core Features:

* [x] The change and motivation are explained below.
* [x] Regression tests cover the core change.
* [x] Relevant tests pass locally.

## Summary

Fixes #1336.

`ApiClient.request_sync()` previously passed the result of the synchronous `ApiClient.request()` to `asyncio.run_until_complete()`. Successful dictionary responses and `None` responses were therefore rejected with `TypeError` because they are not awaitable.

The synchronous wrapper now directly returns `self.request(...)`. `AsyncApiClient.request_sync()` is intentionally unchanged because its `request()` method is a coroutine and still needs the event-loop bridge.

## Validation

- red-to-green regression for typed dictionary and `type_=None` responses: 2 passed
- Ruff check and format check on changed Python files
- focused mypy check for the new test
- `git diff --check`
- duplicate search across open and closed issues/PRs

AI assistance was used to reproduce the sync/async drift, review edge cases, and draft tests; every changed line and test result was manually verified.