### PR TITLE
fix(conversion): raise on an unmapped StartFrom instead of returning None

### DIFF
--- a/qdrant_client/conversions/conversion.py
+++ b/qdrant_client/conversions/conversion.py
@@ -2409,6 +2409,7 @@ class GrpcToRest:
             return dt
         if model.HasField("datetime"):
             return model.datetime
+        raise ValueError(f"invalid StartFrom model: {model}")  # pragma: no cover
 
     @classmethod
     def convert_order_by(cls, model: grpc.OrderBy) -> rest.OrderBy:


### PR DESCRIPTION
### Problem

`GrpcToRest.convert_start_from` dispatches over the four variants of the `StartFrom` protobuf oneof and then simply ends:

```python
@classmethod
def convert_start_from(cls, model: grpc.StartFrom) -> rest.StartFrom:
    if model.HasField("integer"):
        return model.integer
    if model.HasField("float"):
        return model.float
    if model.HasField("timestamp"):
        dt = cls.convert_timestamp(model.timestamp)
        return dt
    if model.HasField("datetime"):
        return model.datetime
    # falls through -> None
```

If none of the four branches match, it returns `None` even though it is annotated `-> rest.StartFrom`.

This is reachable: `StartFrom` is a message wrapping a oneof, so a *present but empty* `StartFrom` makes `OrderBy.HasField("start_from")` true while the inner oneof is unset. `convert_order_by` then builds a `rest.OrderBy` whose `start_from` is silently `None` — the ordering anchor is dropped rather than reported.

```python
>>> from qdrant_client import grpc
>>> from qdrant_client.conversions.conversion import GrpcToRest
>>> ob = grpc.OrderBy(key="ts", start_from=grpc.StartFrom())
>>> ob.HasField("start_from")
True
>>> GrpcToRest.convert_order_by(ob)
OrderBy(key='ts', direction=None, start_from=None)   # start_from silently lost
```

The same hole applies to forward compatibility: if a future server adds a fifth `StartFrom` variant, an older client silently drops it instead of failing loudly.

### Why this looks like an oversight rather than a decision

`conversion.py` guards this exact situation everywhere else — there are 136 `raise ValueError(f"invalid ... model: {model}")` clauses in the file. An AST pass over every converter in the module that dispatches on `HasField`/`WhichOneof` finds `GrpcToRest.convert_start_from` to be **the only one** that neither raises nor otherwise terminates on the unmatched path.

Its own mirror already does the right thing (`RestToGrpc.convert_start_from`, same file):

```python
raise ValueError(f"invalid StartFrom model: {model}")  # pragma: no cover
```

### Fix

One line, copying the sibling's idiom verbatim so the two directions agree:

```python
raise ValueError(f"invalid StartFrom model: {model}")  # pragma: no cover
```

### Verification

Ran against `qdrant-client==1.19.0`, whose `conversions/conversion.py` is byte-identical to `dev` HEAD, comparing the unpatched module with the patched one:

```
-- empty oneof --
  OLD convert_order_by -> key='ts' direction=None start_from=None
  NEW raises ValueError: 'invalid StartFrom model: '

-- regression: all 4 valid variants --
  integer   old=42                        new=42                        SAME
  float     old=2.5                       new=2.5                       SAME
  timestamp old=2024-06-01 12:00:00+00:00 new=2024-06-01 12:00:00+00:00 SAME
  datetime  old=2024-06-01T12:00:00Z      new=2024-06-01T12:00:00Z      SAME

all default paths unchanged: True
```

Every path that previously produced a value produces the identical value; only the path that previously produced a silent `None` changes.

No test is added, matching how the other 136 guards in this file are treated (`# pragma: no cover`).

### Note on the base branch

Targeting `dev` per the contribution guide. The branch is cut from this fork's `dev` tip rather than upstream `dev` HEAD because syncing the fork trips the `workflow` scope restriction on my token; the diff against `dev` is still exactly the one line above, and the touched region is byte-identical on both refs, so it three-way merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
