### PR TITLE
fix(local): reject negative array indices in json path

### DIFF
--- a/qdrant_client/local/json_path_parser.py
+++ b/qdrant_client/local/json_path_parser.py
@@ -140,11 +140,14 @@ def _match_brackets(path: str) -> tuple[JsonPathItem | None, str]:
             path[right_bracket_pos + 1 :],
         )
 
-    try:
-        index = int(path[left_bracket_pos + 1 : right_bracket_pos])
-        return (
-            JsonPathItem(item_type=JsonPathItemType.INDEX, index=index),
-            path[right_bracket_pos + 1 :],
-        )
-    except ValueError as e:
-        raise ValueError("Invalid path") from e
+    raw_index = path[left_bracket_pos + 1 : right_bracket_pos]
+
+    # qdrant core only accepts unsigned integers as array indices, while `int()` would also
+    # accept a sign, underscore separators and surrounding whitespace
+    if not (raw_index.isascii() and raw_index.isdigit()):
+        raise ValueError("Invalid path")
+
+    return (
+        JsonPathItem(item_type=JsonPathItemType.INDEX, index=int(raw_index)),
+        path[right_bracket_pos + 1 :],
+    )

--- a/qdrant_client/local/tests/test_payload_utils.py
+++ b/qdrant_client/local/tests/test_payload_utils.py
@@ -143,6 +143,11 @@ def test_parse_json_path() -> None:
         jp_key = ".a"
         parse_json_path(jp_key)
 
+    # qdrant core only accepts unsigned integers as array indices
+    for jp_key in ("a[-1]", "a[+1]", "a[1_0]", "a[ 1 ]", "a[²]", "a[٣]"):
+        with pytest.raises(ValueError):
+            parse_json_path(jp_key)
+
     with pytest.raises(ValueError):
         jp_key = "a[x]"
         parse_json_path(jp_key)
@@ -209,6 +214,12 @@ def test_value_by_key() -> None:
     assert value_by_key(payload, "location[1].name") == ["work"]
     assert value_by_key(payload, "location[2].name") is None
     assert value_by_key(payload, "location[].name[0]") is None
+    # a negative index is an invalid path, it must neither wrap around to the end of the
+    # list nor leak an IndexError
+    with pytest.raises(ValueError):
+        value_by_key(payload, "location[-1].name")
+    with pytest.raises(ValueError):
+        value_by_key(payload, "location[-3].name")
     assert value_by_key(payload, "location[0]") == [{"name": "home", "counts": [1, 2, 3]}]
     assert value_by_key(payload, "not_exits") is None
     assert value_by_key(payload, "address") == [{"city": "New York"}]
@@ -460,41 +471,31 @@ def test_set_value_by_key() -> None:
 
     # region exceptions
 
-    try:
+    # `except Exception` also catches the `AssertionError` of the `assert False` below it, so
+    # these have to use `pytest.raises` in order to assert anything at all
+    with pytest.raises(ValueError):
         payload = {"a": []}
         new_value = {"c": 3}
         key = "a.'b.c'"
         set_value_by_key(payload, parse_json_path(key), new_value)
-        assert False, f"Should've raised an exception due to the key with incorrect quotes: {key}"
-    except Exception:
-        assert True
 
-    try:
+    with pytest.raises(ValueError):
         payload = {"a": [{"b": 1}, {"b": 2}]}
         new_value = {"c": 3}
         key = "a[-1]"
         set_value_by_key(payload, parse_json_path(key), new_value)
-        assert False, "Negative indexation is not supported"
-    except Exception:
-        assert True
 
-    try:
+    with pytest.raises(ValueError):
         payload = {"a": [{"b": 1}, {"b": 2}]}
         new_value = {"c": 3}
         key = "a["
         set_value_by_key(payload, parse_json_path(key), new_value)
-        assert False, f"Should've raised an exception due to the incorrect key: {key}"
-    except Exception:
-        assert True
 
-    try:
+    with pytest.raises(ValueError):
         payload = {"a": [{"b": 1}, {"b": 2}]}
         new_value = {"c": 3}
         key = "a]"
         set_value_by_key(payload, parse_json_path(key), new_value)
-        assert False, f"Should've raise an exception due to the incorrect key: {key}"
-    except Exception:
-        assert True
 
     # endregion
 


### PR DESCRIPTION
### What & why

In local mode a json path like `a[-1]` is accepted and silently resolves to the **last** element of the array, and a negative index past the start leaks a raw `IndexError` out of the filter.

Qdrant core parses a bracket index with `digit1` mapped to `usize`, so a negative index is a parse error there:

```rust
delimited(char('['), number, char(']')).map(JsonPathItem::Index),

fn number(input: &str) -> IResult<&str, usize> {
    map_res(recognize(digit1), str::parse).parse(input)
}
```

Local mode used `int()`, which additionally accepts a sign, underscore separators and surrounding whitespace. The downstream bounds checks are written as `current_key.index < len(data)`, which assume a non-negative index, so a negative one passes straight through to Python's own wrap-around indexing.

Reproduction on `dev`:

```python
from qdrant_client.local.json_path_parser import parse_json_path
from qdrant_client.local.payload_value_extractor import value_by_key
from qdrant_client.local.payload_value_setter import set_value_by_key

payload = {"a": [10, 20, 30]}
value_by_key(payload, "a[-1]")   # [30]   -- expected: invalid path
value_by_key(payload, "a[-4]")   # IndexError: list index out of range

payload = {"a": [{"x": 1}, {"x": 2}]}
set_value_by_key(payload, parse_json_path("a[-1]"), {"x": 99})
# {'a': [{'x': 1}, {'x': {'x': 99}}]}  -- writes to the last element

parse_json_path("a[+1]")    # index=1
parse_json_path("a[1_0]")   # index=10
parse_json_path("a[ 1 ]")   # index=1
```

So both the read path (`value_by_key`, and therefore filters and `count`) and the write path (`set_value_by_key`, and therefore `set_payload`) are affected.

### The fix

Validate the bracket contents against the same grammar as core in `_match_brackets`, rather than deferring to `int()`. That is a single-point fix: with the index guaranteed non-negative, the existing `index < len(data)` checks become sound again, so no call site needed changing.

`isascii()` is part of the check because `str.isdigit()` is also true for characters like `²` and `٣`, which `digit1` does not accept.

### A note on the existing test

`test_set_value_by_key` already asserted this behaviour:

```python
    try:
        ...
        key = "a[-1]"
        set_value_by_key(payload, parse_json_path(key), new_value)
        assert False, "Negative indexation is not supported"
    except Exception:
        assert True
```

It could never fail: `assert False` raises `AssertionError`, which its own `except Exception` then swallowed. Meanwhile the payload was being mutated. I switched that whole `# region exceptions` block to `pytest.raises(ValueError)` so the intent is actually enforced — happy to split that into its own PR if you would rather keep this one to the parser change.

### Tests

Added regression coverage to `test_parse_json_path`, `test_value_by_key` and `test_set_value_by_key`. All three fail on `dev` without the parser change and pass with it.

```
$ python -m pytest qdrant_client/local/tests/ -q
72 passed in 7.53s
```

`ruff-format --line-length=99` and `mypy` are clean on the changed files. `tests/test_local_persistence.py` has 4 failures on my machine both with and without this change (Windows `PermissionError` on tempfile cleanup), so they are unrelated.

---

### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
