### PR TITLE
fix: reject negative score indices in formula variables

### DIFF
--- a/qdrant_client/hybrid/formula.py
+++ b/qdrant_client/hybrid/formula.py
@@ -318,11 +318,14 @@ def parse_variable(var: str) -> str | int:
     if bracket_end == -1:
         raise ValueError(f"Invalid score pattern: {var}")
 
-    # try parsing the content in between brackets as integer
-    try:
-        idx = int(remaining[:bracket_end])
-    except ValueError:
+    # parse the content in between brackets as an unsigned integer. qdrant core represents
+    # the score index as a usize, while `int()` would also accept a sign, underscore
+    # separators and surrounding whitespace
+    raw_idx = remaining[:bracket_end]
+    if not (raw_idx.isascii() and raw_idx.isdigit()):
         raise ValueError(f"Invalid score pattern: {var}")
+
+    idx = int(raw_idx)
 
     # make sure the string ends after the closing bracket
     if len(remaining) > bracket_end + 1:

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -1,0 +1,31 @@
+import pytest
+
+from qdrant_client.hybrid.formula import evaluate_variable, parse_variable
+
+
+def test_parse_variable_score_index() -> None:
+    assert parse_variable("$score") == 0
+    assert parse_variable("$score[0]") == 0
+    assert parse_variable("$score[2]") == 2
+    assert parse_variable("$score[10]") == 10
+
+    # qdrant core represents the score index as a usize, so anything that is not a plain
+    # run of ascii digits is not a valid score pattern
+    for var in ("$score[-1]", "$score[+1]", "$score[1_0]", "$score[ 1 ]", "$score[²]"):
+        with pytest.raises(ValueError):
+            parse_variable(var)
+
+
+def test_evaluate_variable_rejects_negative_score_index() -> None:
+    scores = [{1: 10.0}, {1: 20.0}, {1: 30.0}]
+
+    assert evaluate_variable("$score[0]", 1, scores, {}, {}) == 10.0
+    assert evaluate_variable("$score[2]", 1, scores, {}, {}) == 30.0
+    # an index past the end falls back to the default score
+    assert evaluate_variable("$score[3]", 1, scores, {}, {}) == 0.0
+
+    # a negative index must not wrap around to the last prefetch, nor leak an IndexError
+    with pytest.raises(ValueError):
+        evaluate_variable("$score[-1]", 1, scores, {}, {})
+    with pytest.raises(ValueError):
+        evaluate_variable("$score[-9]", 1, scores, {}, {})


### PR DESCRIPTION
### What & why

`$score[-1]` is accepted in a formula and silently resolves to the **last** prefetch's score, and a negative index past the start leaks a raw `IndexError`.

qdrant core represents the score index as a `usize` (`VariableId::Score(usize)`), so a negative index isn't a valid pattern there. `parse_variable` uses `int()`, which additionally accepts a sign, underscore separators and surrounding whitespace:

```python
>>> from qdrant_client.hybrid.formula import parse_variable
>>> parse_variable("$score[-1]")
-1
>>> parse_variable("$score[+1]"), parse_variable("$score[1_0]"), parse_variable("$score[ 1 ]")
(1, 10, 1)
```

`evaluate_variable` then bounds-checks with `if var < len(scores)`, which assumes a non-negative index, so the negative one passes straight through to Python's wrap-around indexing:

```python
>>> scores = [{1: 10.0}, {1: 20.0}, {1: 30.0}]   # three prefetches
>>> evaluate_variable("$score[3]",  1, scores, {}, {})
0.0     # out of range -> DEFAULT_SCORE, correct
>>> evaluate_variable("$score[-1]", 1, scores, {}, {})
30.0    # silently the last prefetch
>>> evaluate_variable("$score[-9]", 1, scores, {}, {})
IndexError: list index out of range
```

The contrast between `$score[3]` and `$score[-1]` is the part I'd highlight: an out-of-range index already has well-defined behaviour (fall back to the default score), so a negative one returning a real score from the other end is inconsistent as well as wrong.

### Fix

Validate the bracket contents against the same grammar as core in `parse_variable`. With the index guaranteed non-negative, the existing `var < len(scores)` check in `evaluate_variable` becomes sound again, so no call site needed changing.

`isascii()` is part of the check because `str.isdigit()` is also true for characters like `²`.

### Tests

Added `tests/test_formula.py` (new file, following `tests/test_order_by.py`) covering both the parser and the evaluator. Both tests fail on `dev` and pass with the change.

```
$ python -m pytest qdrant_client/local/tests/ tests/test_formula.py -q
74 passed in 3.11s
```

`ruff-format --line-length=99` and `mypy` are clean on both files.

### Note

This is the same class of bug as #1340 (negative array index in the payload json path), in the formula parser rather than the payload one — I went looking here precisely because of that. They're independent files and either can land without the other.
