### PR TITLE
feat(client): add `__repr__` to the six client classes

### DIFF
--- a/qdrant_client/async_qdrant_client.py
+++ b/qdrant_client/async_qdrant_client.py
@@ -160,7 +160,9 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
             return f"<{type(self).__name__} uninitialized>"
         if isinstance(self._client, AsyncQdrantLocal):
             return f"<{type(self).__name__} mode=local location={self._client.location!r}>"
-        return f"<{type(self).__name__} mode=remote host={self._client._address!r} prefer_grpc={self._client._prefer_grpc}>"
+        if isinstance(self._client, AsyncQdrantRemote):
+            return f"<{type(self).__name__} mode=remote host={self._client._address!r} prefer_grpc={self._client._prefer_grpc}>"
+        return f"<{type(self).__name__} client={type(self._client).__name__}>"
 
     async def close(self, grpc_grace: float | None = None, **kwargs: Any) -> None:
         """Closes the connection to Qdrant

--- a/qdrant_client/async_qdrant_client.py
+++ b/qdrant_client/async_qdrant_client.py
@@ -155,6 +155,13 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
             is_local_mode=isinstance(self._client, AsyncQdrantLocal),
         )
 
+    def __repr__(self) -> str:
+        if not hasattr(self, "_client"):
+            return f"<{type(self).__name__} uninitialized>"
+        if isinstance(self._client, AsyncQdrantLocal):
+            return f"<{type(self).__name__} mode=local location={self._client.location!r}>"
+        return f"<{type(self).__name__} mode=remote host={self._client._address!r} prefer_grpc={self._client._prefer_grpc}>"
+
     async def close(self, grpc_grace: float | None = None, **kwargs: Any) -> None:
         """Closes the connection to Qdrant
 

--- a/qdrant_client/async_qdrant_remote.py
+++ b/qdrant_client/async_qdrant_remote.py
@@ -165,8 +165,7 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                 "grpc.Compression.Deflate is not supported. Try grpc.Compression.Gzip or grpc.Compression.NoCompression"
             )
         self._grpc_compression = grpc_compression
-        address = f"{self._host}:{self._port}" if self._port is not None else self._host
-        base_url = f"{self._scheme}://{address}"
+        base_url = f"{self._scheme}://{self._address}"
         self.rest_uri = urljoin(base_url, self._prefix)
         self._rest_args = {"headers": self._rest_headers, "http2": http2, **kwargs}
         if limits is not None:
@@ -233,6 +232,13 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                 category=UserWarning,
                 stacklevel=2,
             )
+
+    def __repr__(self) -> str:
+        return f"<{type(self).__name__} scheme={self._scheme} host={self._address!r} prefer_grpc={self._prefer_grpc}>"
+
+    @property
+    def _address(self) -> str:
+        return f"{self._host}:{self._port}" if self._port is not None else self._host
 
     @property
     def closed(self) -> bool:

--- a/qdrant_client/local/async_qdrant_local.py
+++ b/qdrant_client/local/async_qdrant_local.py
@@ -88,6 +88,9 @@ class AsyncQdrantLocal(AsyncQdrantBase):
         self._load()
         self._closed: bool = False
 
+    def __repr__(self) -> str:
+        return f"<{type(self).__name__} location={self.location!r}>"
+
     @property
     def closed(self) -> bool:
         return self._closed

--- a/qdrant_client/local/qdrant_local.py
+++ b/qdrant_client/local/qdrant_local.py
@@ -86,6 +86,9 @@ class QdrantLocal(QdrantBase):
         self._load()
         self._closed: bool = False
 
+    def __repr__(self) -> str:
+        return f"<{type(self).__name__} location={self.location!r}>"
+
     @property
     def closed(self) -> bool:
         return self._closed

--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -176,10 +176,13 @@ class QdrantClient(QdrantFastembedMixin):
         if isinstance(self._client, QdrantLocal):
             return f"<{type(self).__name__} mode=local location={self._client.location!r}>"
 
-        return (
-            f"<{type(self).__name__} mode=remote host={self._client._address!r} "
-            f"prefer_grpc={self._client._prefer_grpc}>"
-        )
+        if isinstance(self._client, QdrantRemote):
+            return (
+                f"<{type(self).__name__} mode=remote host={self._client._address!r} "
+                f"prefer_grpc={self._client._prefer_grpc}>"
+            )
+
+        return f"<{type(self).__name__} client={type(self._client).__name__}>"
 
     def close(self, grpc_grace: float | None = None, **kwargs: Any) -> None:
         """Closes the connection to Qdrant

--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -168,6 +168,19 @@ class QdrantClient(QdrantFastembedMixin):
     def __del__(self) -> None:
         self.close()
 
+    def __repr__(self) -> str:
+        if not hasattr(self, "_client"):
+            # __init__ raised before the inner client was built.
+            return f"<{type(self).__name__} uninitialized>"
+
+        if isinstance(self._client, QdrantLocal):
+            return f"<{type(self).__name__} mode=local location={self._client.location!r}>"
+
+        return (
+            f"<{type(self).__name__} mode=remote host={self._client._address!r} "
+            f"prefer_grpc={self._client._prefer_grpc}>"
+        )
+
     def close(self, grpc_grace: float | None = None, **kwargs: Any) -> None:
         """Closes the connection to Qdrant
 

--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -204,8 +204,7 @@ class QdrantRemote(QdrantBase):
             )
         self._grpc_compression = grpc_compression
 
-        address = f"{self._host}:{self._port}" if self._port is not None else self._host
-        base_url = f"{self._scheme}://{address}"
+        base_url = f"{self._scheme}://{self._address}"
         self.rest_uri = urljoin(base_url, self._prefix)
 
         self._rest_args = {"headers": self._rest_headers, "http2": http2, **kwargs}
@@ -293,6 +292,17 @@ class QdrantRemote(QdrantBase):
                 category=UserWarning,
                 stacklevel=2,
             )
+
+    def __repr__(self) -> str:
+        # api_key is deliberately absent: reprs end up in logs and tracebacks.
+        return (
+            f"<{type(self).__name__} scheme={self._scheme} host={self._address!r} "
+            f"prefer_grpc={self._prefer_grpc}>"
+        )
+
+    @property
+    def _address(self) -> str:
+        return f"{self._host}:{self._port}" if self._port is not None else self._host
 
     @property
     def closed(self) -> bool:

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -1,0 +1,68 @@
+import pytest
+
+from qdrant_client import AsyncQdrantClient, QdrantClient
+from qdrant_client.async_qdrant_remote import AsyncQdrantRemote
+from qdrant_client.local.async_qdrant_local import AsyncQdrantLocal
+from qdrant_client.local.qdrant_local import QdrantLocal
+from qdrant_client.qdrant_remote import QdrantRemote
+
+
+def test_local_client_repr_shows_location():
+    assert repr(QdrantClient(":memory:")) == "<QdrantClient mode=local location=':memory:'>"
+
+
+def test_async_local_client_repr_shows_location():
+    assert (
+        repr(AsyncQdrantClient(":memory:")) == "<AsyncQdrantClient mode=local location=':memory:'>"
+    )
+
+
+def test_persistent_local_client_repr_shows_path(tmp_path):
+    path = str(tmp_path / "storage")
+    assert repr(QdrantClient(path=path)) == f"<QdrantClient mode=local location={path!r}>"
+
+
+def test_remote_client_repr_shows_host_and_grpc_preference():
+    client = QdrantClient("localhost", port=6333, prefer_grpc=True)
+    assert repr(client) == "<QdrantClient mode=remote host='localhost:6333' prefer_grpc=True>"
+
+
+def test_async_remote_client_repr_shows_host_and_grpc_preference():
+    client = AsyncQdrantClient("localhost", port=6333, prefer_grpc=True)
+    assert repr(client) == "<AsyncQdrantClient mode=remote host='localhost:6333' prefer_grpc=True>"
+
+
+def test_remote_repr_shows_scheme():
+    remote = QdrantRemote(url="https://api.qdrant.example:443")
+    assert (
+        repr(remote)
+        == "<QdrantRemote scheme=https host='api.qdrant.example:443' prefer_grpc=False>"
+    )
+
+
+def test_async_remote_repr_shows_scheme():
+    remote = AsyncQdrantRemote(url="https://api.qdrant.example:443")
+    assert (
+        repr(remote)
+        == "<AsyncQdrantRemote scheme=https host='api.qdrant.example:443' prefer_grpc=False>"
+    )
+
+
+def test_local_repr():
+    assert repr(QdrantLocal(":memory:")) == "<QdrantLocal location=':memory:'>"
+
+
+def test_async_local_repr():
+    assert repr(AsyncQdrantLocal(":memory:")) == "<AsyncQdrantLocal location=':memory:'>"
+
+
+@pytest.mark.parametrize(
+    "client",
+    [
+        QdrantClient("localhost", port=6333, api_key="super-secret-key"),
+        QdrantClient(url="https://api.qdrant.example:443", api_key="super-secret-key"),
+    ],
+)
+def test_api_key_never_appears_in_repr(client):
+    assert "super-secret-key" not in repr(client)
+    assert "super-secret-key" not in repr(client._client)


### PR DESCRIPTION
Closes #1287.

`repr()` on any of the six client classes returned the default `<qdrant_client.qdrant_client.QdrantClient object at 0x10c4a8eb0>`. That shows up in tracebacks, in notebooks, and in structured logging libraries that render objects with `repr()` by default — and none of those places tell you which cluster the client was pointed at.

## After

```python
>>> QdrantClient("localhost", port=6333, prefer_grpc=True)
<QdrantClient mode=remote host='localhost:6333' prefer_grpc=True>
>>> QdrantClient(":memory:")
<QdrantClient mode=local location=':memory:'>
>>> QdrantClient(path="./storage")
<QdrantClient mode=local location='./storage'>
>>> QdrantRemote(url="https://api.qdrant.example:443")
<QdrantRemote scheme=https host='api.qdrant.example:443' prefer_grpc=False>
>>> QdrantLocal(":memory:")
<QdrantLocal location=':memory:'>
```

Async classes render the same way with their own class name, since the repr uses `type(self).__name__`.

**`api_key` is deliberately not in there.** Reprs end up in logs and exception reports, which is exactly where a key should not be. There's a test that constructs a client with an api_key and asserts the value appears in neither the facade's repr nor the inner client's.

## One refactor worth flagging

`QdrantRemote.__init__` already built `f"{self._host}:{self._port}" if self._port is not None else self._host` inline to make the base URL. The repr needs the identical string, so rather than write it twice I pulled it into a small `_address` property and pointed both at it. Behaviour is unchanged — same expression, same call site — but the repr and the base URL can't drift apart later.

## Generated files

`__repr__` isn't on `AsyncQdrantBase`, so the AST transformer leaves it sync in the async mirrors, which is what we want — Python calls `repr()` synchronously. No generator changes were needed. I ran the full generator anyway and confirmed its output matches what's committed here; the only other diffs were pre-existing artifacts of my local ruff version (`for (k, v) in` vs `for k, v in`) and autoflake not being installed, so I applied the `__repr__` blocks to the generated files by hand rather than committing that noise.

## Tests

`tests/test_repr.py` — 11 cases covering local and remote, sync and async, all six classes, plus the api_key leak check. No server needed.

Note: `tests/test_local_persistence.py` has 4 failures on my machine, but they reproduce on a clean `master` checkout too (a Windows `PermissionError` on the storage teardown), so they're unrelated to this change.



---
Replaces #1330, which was branched from `master` and showed as conflicting against the `dev` base this repo targets. Same change, clean history off `dev`.
