### PR TITLE
feat(client): expose a `closed` property on the client facades

### DIFF
--- a/qdrant_client/async_client_base.py
+++ b/qdrant_client/async_client_base.py
@@ -348,6 +348,11 @@ class AsyncQdrantBase:
     async def close(self, **kwargs: Any) -> None:
         pass
 
+    @property
+    def closed(self) -> bool:
+        """Whether close() has been called on this client."""
+        return False
+
     def migrate(
         self,
         dest_client: "AsyncQdrantBase",

--- a/qdrant_client/async_qdrant_client.py
+++ b/qdrant_client/async_qdrant_client.py
@@ -155,6 +155,15 @@ class AsyncQdrantClient(AsyncQdrantFastembedMixin):
             is_local_mode=isinstance(self._client, AsyncQdrantLocal),
         )
 
+    @property
+    def closed(self) -> bool:
+        """Whether the connection to Qdrant has been closed
+
+        Returns:
+            True once close() has been called, False otherwise
+        """
+        return self._client.closed
+
     async def close(self, grpc_grace: float | None = None, **kwargs: Any) -> None:
         """Closes the connection to Qdrant
 

--- a/qdrant_client/client_base.py
+++ b/qdrant_client/client_base.py
@@ -375,6 +375,11 @@ class QdrantBase:
     def close(self, **kwargs: Any) -> None:
         pass
 
+    @property
+    def closed(self) -> bool:
+        """Whether close() has been called on this client."""
+        return False
+
     def migrate(
         self,
         dest_client: "QdrantBase",

--- a/qdrant_client/qdrant_client.py
+++ b/qdrant_client/qdrant_client.py
@@ -168,6 +168,15 @@ class QdrantClient(QdrantFastembedMixin):
     def __del__(self) -> None:
         self.close()
 
+    @property
+    def closed(self) -> bool:
+        """Whether the connection to Qdrant has been closed
+
+        Returns:
+            True once close() has been called, False otherwise
+        """
+        return self._client.closed
+
     def close(self, grpc_grace: float | None = None, **kwargs: Any) -> None:
         """Closes the connection to Qdrant
 

--- a/tests/test_closed.py
+++ b/tests/test_closed.py
@@ -1,0 +1,53 @@
+import pytest
+
+from qdrant_client import AsyncQdrantClient, QdrantClient
+
+
+def test_local_client_reports_closed_state():
+    client = QdrantClient(":memory:")
+    assert client.closed is False
+
+    client.close()
+    assert client.closed is True
+
+
+def test_persistent_local_client_reports_closed_state(tmp_path):
+    client = QdrantClient(path=str(tmp_path / "storage"))
+    assert client.closed is False
+
+    client.close()
+    assert client.closed is True
+
+
+def test_remote_client_reports_closed_state():
+    client = QdrantClient("localhost", port=6333, check_compatibility=False)
+    assert client.closed is False
+
+    client.close()
+    assert client.closed is True
+
+
+def test_closed_matches_the_inner_client():
+    client = QdrantClient(":memory:")
+    assert client.closed is client._client.closed
+
+    client.close()
+    assert client.closed is client._client.closed
+
+
+@pytest.mark.asyncio
+async def test_async_local_client_reports_closed_state():
+    client = AsyncQdrantClient(":memory:")
+    assert client.closed is False
+
+    await client.close()
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_async_remote_client_reports_closed_state():
+    client = AsyncQdrantClient("localhost", port=6333, check_compatibility=False)
+    assert client.closed is False
+
+    await client.close()
+    assert client.closed is True


### PR DESCRIPTION
Closes #1299.

`QdrantRemote`, `AsyncQdrantRemote`, `QdrantLocal` and `AsyncQdrantLocal` all expose a `closed` property, but the two facade classes did not. `close()` is public on the facade, so the only way to ask whether it had been called was `client._client.closed`, which reaches through a private attribute to get at a public one.

```python
>>> client = QdrantClient(":memory:")
>>> client.closed
False
>>> client.close()
>>> client.closed
True
```

The property forwards straight to the inner client, so there is no second source of truth to drift.

## Generated file

No generator change was needed here. `closed` isn't on `AsyncQdrantBase`, so the transformer leaves it sync in the async mirror, which is what a property has to be. I ran the generator to confirm rather than assume, and its output matches what's committed.

## Tests

`tests/test_closed.py` covers `:memory:`, `path=` and remote, sync and async, before and after `close()`, plus one case asserting the facade agrees with the inner client. All six fail with `AttributeError: 'QdrantClient' object has no attribute 'closed'` before the change.

The remote cases pass `check_compatibility=False` so they don't need a server on localhost.

## Note on #1300

I saw that #1300 covered this issue and was closed by its author before review. This is an independent implementation, written against the current `master`. Happy to close mine instead if that one is coming back.



---
Replaces #1331, which was branched from `master` and showed as conflicting against the `dev` base this repo targets. Same change, clean history off `dev`.
