### PR TITLE
fix: include request URL in UnexpectedResponse

### DIFF
--- a/qdrant_client/http/exceptions.py
+++ b/qdrant_client/http/exceptions.py
@@ -11,19 +11,33 @@ class ApiException(Exception):
 
 
 class UnexpectedResponse(ApiException):
-    def __init__(self, status_code: Optional[int], reason_phrase: str, content: bytes, headers: Headers) -> None:
+    def __init__(
+        self,
+        status_code: Optional[int],
+        reason_phrase: str,
+        content: bytes,
+        headers: Headers,
+        url: Optional[str] = None,
+    ) -> None:
         self.status_code = status_code
         self.reason_phrase = reason_phrase
         self.content = content
         self.headers = headers
+        self.url = url
 
     @staticmethod
-    def for_response(response: Response) -> "ApiException":
+    def for_response(response: Response) -> "UnexpectedResponse":
+        try:
+            url = str(response.request.url)
+        except RuntimeError:
+            url = None
+
         return UnexpectedResponse(
             status_code=response.status_code,
             reason_phrase=response.reason_phrase,
             content=response.content,
             headers=response.headers,
+            url=url,
         )
 
     def __str__(self) -> str:
@@ -33,9 +47,14 @@ class UnexpectedResponse(ApiException):
         else:
             reason_phrase_str = f"({self.reason_phrase})"
         status_str = f"{status_code_str} {reason_phrase_str}".strip()
-        short_content = self.content if len(self.content) <= MAX_CONTENT else self.content[: MAX_CONTENT - 3] + b" ..."
+        short_content = (
+            self.content
+            if len(self.content) <= MAX_CONTENT
+            else self.content[: MAX_CONTENT - 3] + b" ..."
+        )
+        request_url_str = f"Request URL: {self.url}\n" if self.url else ""
         raw_content_str = f"Raw response content:\n{short_content!r}"
-        return f"Unexpected Response: {status_str}\n{raw_content_str}"
+        return f"Unexpected Response: {status_str}\n{request_url_str}{raw_content_str}"
 
     def structured(self) -> Dict[str, Any]:
         return json.loads(self.content)

--- a/tests/test_http_exceptions.py
+++ b/tests/test_http_exceptions.py
@@ -1,0 +1,24 @@
+from httpx import Request, Response
+
+from qdrant_client.http.exceptions import UnexpectedResponse
+
+
+def test_unexpected_response_includes_request_url():
+    request = Request("POST", "https://example.com/api/collections?wait=true")
+    response = Response(404, request=request, content=b"not found")
+
+    exception = UnexpectedResponse.for_response(response)
+
+    assert exception.url == "https://example.com/api/collections?wait=true"
+    assert "Request URL: https://example.com/api/collections?wait=true" in str(
+        exception
+    )
+
+
+def test_unexpected_response_without_request_omits_url():
+    response = Response(404, content=b"not found")
+
+    exception = UnexpectedResponse.for_response(response)
+
+    assert exception.url is None
+    assert "Request URL:" not in str(exception)


### PR DESCRIPTION
## Summary

Include the actual request URL in `UnexpectedResponse` so endpoint configuration mistakes are visible directly in the exception text.

The constructor keeps the new URL optional for backwards compatibility. `for_response()` extracts it from the HTTPX request when available and safely omits it for manually constructed responses without a request.

Closes #456.

### All Submissions:

* [x] Contributions target the `dev` branch.
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [ ] Have you installed `pre-commit` and set up hooks? (Ruff checks were run directly.)

### Changes to Core Features:

* [x] Added an explanation of the behavior and motivation.
* [x] Added regression tests for responses with and without an attached request.
* [x] Successfully ran the targeted tests locally.

## Validation

- `ruff check qdrant_client/http/exceptions.py tests/test_http_exceptions.py`
- `ruff format --check qdrant_client/http/exceptions.py tests/test_http_exceptions.py`
- `pytest tests/test_http_exceptions.py -q` - 2 passed