### PR TITLE
Guard the datetime timezone fallback

### DIFF
--- a/qdrant_client/local/datetime_utils.py
+++ b/qdrant_client/local/datetime_utils.py
@@ -41,9 +41,11 @@ def parse(date_str: str) -> datetime | None:
     if parsed_dt is not None:
         return parsed_dt
 
-    # Python can't parse timezones containing only hours (+HH), but it can parse timezones with hours and minutes
-    # So we add :00 to the assumed timezone and try parsing it again
-    # dt examples to handle:
-    # "2021-01-01 00:00:00.000+01"
-    # "2021-01-01 00:00:00.000-10"
-    return parse_available_formats(date_str + ":00")
+    # Python can't parse timezones containing only hours (+HH), but it can parse
+    # timezones with hours and minutes. Only retry when the input actually ends
+    # with such an offset; appending to arbitrary invalid dates can make them
+    # look valid (for example, ``2024-06-15 12``).
+    if len(date_str) >= 3 and date_str[-3] in "+-" and date_str[-2:].isdigit():
+        return parse_available_formats(date_str + ":00")
+
+    return None

--- a/qdrant_client/local/tests/test_datetimes.py
+++ b/qdrant_client/local/tests/test_datetimes.py
@@ -55,3 +55,8 @@ from qdrant_client.local.datetime_utils import parse
 )
 def test_parse_dates(date_str: str, expected: datetime):
     assert parse(date_str) == expected
+
+
+@pytest.mark.parametrize("date_str", ["2024-06-15 12", "2024-06-15T12:30"])
+def test_parse_rejects_truncated_dates(date_str: str):
+    assert parse(date_str) is None


### PR DESCRIPTION
## Summary

Fixes #1349 by restricting the `:00` retry in `qdrant_client.local.datetime_utils.parse` to strings that end in an hour-only timezone offset. This prevents truncated datetimes from being accepted while preserving Qdrant Core's `+HH`/`-HH` compatibility.

## Tests

- `python -m pytest qdrant_client/local/tests/test_datetimes.py` (20 passed)
- `ruff check qdrant_client/local/datetime_utils.py qdrant_client/local/tests/test_datetimes.py`
