### PR TITLE
fix: do not drop shard keys in delete and payload operations

### DIFF
--- a/qdrant_client/async_qdrant_remote.py
+++ b/qdrant_client/async_qdrant_remote.py
@@ -1108,7 +1108,8 @@ class AsyncQdrantRemote(AsyncQdrantBase):
     ) -> types.UpdateResult:
         if self._prefer_grpc:
             (points_selector, opt_shard_key_selector) = self._try_argument_to_grpc_selector(points)
-            shard_key_selector = shard_key_selector or opt_shard_key_selector
+            if shard_key_selector is None:
+                shard_key_selector = opt_shard_key_selector
             if isinstance(ordering, models.WriteOrdering):
                 ordering = RestToGrpc.convert_write_ordering(ordering)
             if isinstance(shard_key_selector, get_args_subscribed(models.ShardKeySelector)):
@@ -1130,7 +1131,9 @@ class AsyncQdrantRemote(AsyncQdrantBase):
             assert grpc_result is not None, "Delete vectors returned None result"
             return GrpcToRest.convert_update_result(grpc_result)
         else:
-            (_points, _filter) = self._try_argument_to_rest_points_and_filter(points)
+            (_points, _filter, _shard_key) = self._try_argument_to_rest_points_and_filter(points)
+            if shard_key_selector is None:
+                shard_key_selector = _shard_key
             return (
                 await self.openapi_client.points_api.delete_vectors(
                     collection_name=collection_name,
@@ -1260,7 +1263,8 @@ class AsyncQdrantRemote(AsyncQdrantBase):
             points_selector.shard_key = shard_key_selector
         elif isinstance(points, get_args(models.PointsSelector)):
             points_selector = points
-            points_selector.shard_key = shard_key_selector
+            if shard_key_selector is not None:
+                points_selector.shard_key = shard_key_selector
         elif isinstance(points, models.Filter):
             points_selector = construct(
                 models.FilterSelector, filter=points, shard_key=shard_key_selector
@@ -1290,9 +1294,12 @@ class AsyncQdrantRemote(AsyncQdrantBase):
     @classmethod
     def _try_argument_to_rest_points_and_filter(
         cls, points: types.PointsSelector
-    ) -> tuple[list[models.ExtendedPointId] | None, models.Filter | None]:
+    ) -> tuple[
+        list[models.ExtendedPointId] | None, models.Filter | None, types.ShardKeySelector | None
+    ]:
         _points = None
         _filter = None
+        _shard_key = None
         if isinstance(points, list):
             _points = [
                 GrpcToRest.convert_point_id(idx) if isinstance(idx, grpc.PointId) else idx
@@ -1306,15 +1313,17 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                 _filter = selector.filter
         elif isinstance(points, models.PointIdsList):
             _points = points.points
+            _shard_key = points.shard_key
         elif isinstance(points, models.FilterSelector):
             _filter = points.filter
+            _shard_key = points.shard_key
         elif isinstance(points, models.Filter):
             _filter = points
         elif isinstance(points, grpc.Filter):
             _filter = GrpcToRest.convert_filter(points)
         else:
             raise ValueError(f"Unsupported points selector type: {type(points)}")
-        return (_points, _filter)
+        return (_points, _filter, _shard_key)
 
     async def delete(
         self,
@@ -1330,7 +1339,8 @@ class AsyncQdrantRemote(AsyncQdrantBase):
             (points_selector, opt_shard_key_selector) = self._try_argument_to_grpc_selector(
                 points_selector
             )
-            shard_key_selector = shard_key_selector or opt_shard_key_selector
+            if shard_key_selector is None:
+                shard_key_selector = opt_shard_key_selector
             if isinstance(ordering, models.WriteOrdering):
                 ordering = RestToGrpc.convert_write_ordering(ordering)
             if isinstance(shard_key_selector, get_args_subscribed(models.ShardKeySelector)):
@@ -1380,7 +1390,8 @@ class AsyncQdrantRemote(AsyncQdrantBase):
     ) -> types.UpdateResult:
         if self._prefer_grpc:
             (points_selector, opt_shard_key_selector) = self._try_argument_to_grpc_selector(points)
-            shard_key_selector = shard_key_selector or opt_shard_key_selector
+            if shard_key_selector is None:
+                shard_key_selector = opt_shard_key_selector
             if isinstance(ordering, models.WriteOrdering):
                 ordering = RestToGrpc.convert_write_ordering(ordering)
             if isinstance(shard_key_selector, get_args_subscribed(models.ShardKeySelector)):
@@ -1403,7 +1414,9 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                 ).result
             )
         else:
-            (_points, _filter) = self._try_argument_to_rest_points_and_filter(points)
+            (_points, _filter, _shard_key) = self._try_argument_to_rest_points_and_filter(points)
+            if shard_key_selector is None:
+                shard_key_selector = _shard_key
             result: types.UpdateResult | None = (
                 await self.openapi_client.points_api.set_payload(
                     collection_name=collection_name,
@@ -1435,7 +1448,8 @@ class AsyncQdrantRemote(AsyncQdrantBase):
     ) -> types.UpdateResult:
         if self._prefer_grpc:
             (points_selector, opt_shard_key_selector) = self._try_argument_to_grpc_selector(points)
-            shard_key_selector = shard_key_selector or opt_shard_key_selector
+            if shard_key_selector is None:
+                shard_key_selector = opt_shard_key_selector
             if isinstance(ordering, models.WriteOrdering):
                 ordering = RestToGrpc.convert_write_ordering(ordering)
             if isinstance(shard_key_selector, get_args_subscribed(models.ShardKeySelector)):
@@ -1457,7 +1471,9 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                 ).result
             )
         else:
-            (_points, _filter) = self._try_argument_to_rest_points_and_filter(points)
+            (_points, _filter, _shard_key) = self._try_argument_to_rest_points_and_filter(points)
+            if shard_key_selector is None:
+                shard_key_selector = _shard_key
             result: types.UpdateResult | None = (
                 await self.openapi_client.points_api.overwrite_payload(
                     collection_name=collection_name,
@@ -1488,7 +1504,8 @@ class AsyncQdrantRemote(AsyncQdrantBase):
     ) -> types.UpdateResult:
         if self._prefer_grpc:
             (points_selector, opt_shard_key_selector) = self._try_argument_to_grpc_selector(points)
-            shard_key_selector = shard_key_selector or opt_shard_key_selector
+            if shard_key_selector is None:
+                shard_key_selector = opt_shard_key_selector
             if isinstance(ordering, models.WriteOrdering):
                 ordering = RestToGrpc.convert_write_ordering(ordering)
             if isinstance(shard_key_selector, get_args_subscribed(models.ShardKeySelector)):
@@ -1510,7 +1527,9 @@ class AsyncQdrantRemote(AsyncQdrantBase):
                 ).result
             )
         else:
-            (_points, _filter) = self._try_argument_to_rest_points_and_filter(points)
+            (_points, _filter, _shard_key) = self._try_argument_to_rest_points_and_filter(points)
+            if shard_key_selector is None:
+                shard_key_selector = _shard_key
             result: types.UpdateResult | None = (
                 await self.openapi_client.points_api.delete_payload(
                     collection_name=collection_name,
@@ -1539,7 +1558,8 @@ class AsyncQdrantRemote(AsyncQdrantBase):
             (points_selector, opt_shard_key_selector) = self._try_argument_to_grpc_selector(
                 points_selector
             )
-            shard_key_selector = shard_key_selector or opt_shard_key_selector
+            if shard_key_selector is None:
+                shard_key_selector = opt_shard_key_selector
             if isinstance(ordering, models.WriteOrdering):
                 ordering = RestToGrpc.convert_write_ordering(ordering)
             if isinstance(shard_key_selector, get_args_subscribed(models.ShardKeySelector)):

--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -1254,7 +1254,8 @@ class QdrantRemote(QdrantBase):
     ) -> types.UpdateResult:
         if self._prefer_grpc:
             points_selector, opt_shard_key_selector = self._try_argument_to_grpc_selector(points)
-            shard_key_selector = shard_key_selector or opt_shard_key_selector
+            if shard_key_selector is None:
+                shard_key_selector = opt_shard_key_selector
 
             if isinstance(ordering, models.WriteOrdering):
                 ordering = RestToGrpc.convert_write_ordering(ordering)
@@ -1281,7 +1282,9 @@ class QdrantRemote(QdrantBase):
 
             return GrpcToRest.convert_update_result(grpc_result)
         else:
-            _points, _filter = self._try_argument_to_rest_points_and_filter(points)
+            _points, _filter, _shard_key = self._try_argument_to_rest_points_and_filter(points)
+            if shard_key_selector is None:
+                shard_key_selector = _shard_key
             return self.openapi_client.points_api.delete_vectors(
                 collection_name=collection_name,
                 wait=wait,
@@ -1423,7 +1426,8 @@ class QdrantRemote(QdrantBase):
             points_selector.shard_key = shard_key_selector
         elif isinstance(points, get_args(models.PointsSelector)):
             points_selector = points
-            points_selector.shard_key = shard_key_selector
+            if shard_key_selector is not None:
+                points_selector.shard_key = shard_key_selector
         elif isinstance(points, models.Filter):
             points_selector = construct(
                 models.FilterSelector, filter=points, shard_key=shard_key_selector
@@ -1455,9 +1459,14 @@ class QdrantRemote(QdrantBase):
     @classmethod
     def _try_argument_to_rest_points_and_filter(
         cls, points: types.PointsSelector
-    ) -> tuple[list[models.ExtendedPointId] | None, models.Filter | None]:
+    ) -> tuple[
+        list[models.ExtendedPointId] | None,
+        models.Filter | None,
+        types.ShardKeySelector | None,
+    ]:
         _points = None
         _filter = None
+        _shard_key = None
         if isinstance(points, list):
             _points = [
                 (GrpcToRest.convert_point_id(idx) if isinstance(idx, grpc.PointId) else idx)
@@ -1471,8 +1480,10 @@ class QdrantRemote(QdrantBase):
                 _filter = selector.filter
         elif isinstance(points, models.PointIdsList):
             _points = points.points
+            _shard_key = points.shard_key
         elif isinstance(points, models.FilterSelector):
             _filter = points.filter
+            _shard_key = points.shard_key
         elif isinstance(points, models.Filter):
             _filter = points
         elif isinstance(points, grpc.Filter):
@@ -1480,7 +1491,7 @@ class QdrantRemote(QdrantBase):
         else:
             raise ValueError(f"Unsupported points selector type: {type(points)}")
 
-        return _points, _filter
+        return _points, _filter, _shard_key
 
     def delete(
         self,
@@ -1496,7 +1507,8 @@ class QdrantRemote(QdrantBase):
             points_selector, opt_shard_key_selector = self._try_argument_to_grpc_selector(
                 points_selector
             )
-            shard_key_selector = shard_key_selector or opt_shard_key_selector
+            if shard_key_selector is None:
+                shard_key_selector = opt_shard_key_selector
 
             if isinstance(ordering, models.WriteOrdering):
                 ordering = RestToGrpc.convert_write_ordering(ordering)
@@ -1545,7 +1557,8 @@ class QdrantRemote(QdrantBase):
     ) -> types.UpdateResult:
         if self._prefer_grpc:
             points_selector, opt_shard_key_selector = self._try_argument_to_grpc_selector(points)
-            shard_key_selector = shard_key_selector or opt_shard_key_selector
+            if shard_key_selector is None:
+                shard_key_selector = opt_shard_key_selector
 
             if isinstance(ordering, models.WriteOrdering):
                 ordering = RestToGrpc.convert_write_ordering(ordering)
@@ -1569,7 +1582,9 @@ class QdrantRemote(QdrantBase):
                 ).result
             )
         else:
-            _points, _filter = self._try_argument_to_rest_points_and_filter(points)
+            _points, _filter, _shard_key = self._try_argument_to_rest_points_and_filter(points)
+            if shard_key_selector is None:
+                shard_key_selector = _shard_key
             result: types.UpdateResult | None = self.openapi_client.points_api.set_payload(
                 collection_name=collection_name,
                 wait=wait,
@@ -1599,7 +1614,8 @@ class QdrantRemote(QdrantBase):
     ) -> types.UpdateResult:
         if self._prefer_grpc:
             points_selector, opt_shard_key_selector = self._try_argument_to_grpc_selector(points)
-            shard_key_selector = shard_key_selector or opt_shard_key_selector
+            if shard_key_selector is None:
+                shard_key_selector = opt_shard_key_selector
 
             if isinstance(ordering, models.WriteOrdering):
                 ordering = RestToGrpc.convert_write_ordering(ordering)
@@ -1622,7 +1638,9 @@ class QdrantRemote(QdrantBase):
                 ).result
             )
         else:
-            _points, _filter = self._try_argument_to_rest_points_and_filter(points)
+            _points, _filter, _shard_key = self._try_argument_to_rest_points_and_filter(points)
+            if shard_key_selector is None:
+                shard_key_selector = _shard_key
             result: types.UpdateResult | None = self.openapi_client.points_api.overwrite_payload(
                 collection_name=collection_name,
                 wait=wait,
@@ -1651,7 +1669,8 @@ class QdrantRemote(QdrantBase):
     ) -> types.UpdateResult:
         if self._prefer_grpc:
             points_selector, opt_shard_key_selector = self._try_argument_to_grpc_selector(points)
-            shard_key_selector = shard_key_selector or opt_shard_key_selector
+            if shard_key_selector is None:
+                shard_key_selector = opt_shard_key_selector
             if isinstance(ordering, models.WriteOrdering):
                 ordering = RestToGrpc.convert_write_ordering(ordering)
 
@@ -1673,7 +1692,9 @@ class QdrantRemote(QdrantBase):
                 ).result
             )
         else:
-            _points, _filter = self._try_argument_to_rest_points_and_filter(points)
+            _points, _filter, _shard_key = self._try_argument_to_rest_points_and_filter(points)
+            if shard_key_selector is None:
+                shard_key_selector = _shard_key
             result: types.UpdateResult | None = self.openapi_client.points_api.delete_payload(
                 collection_name=collection_name,
                 wait=wait,
@@ -1703,7 +1724,8 @@ class QdrantRemote(QdrantBase):
             points_selector, opt_shard_key_selector = self._try_argument_to_grpc_selector(
                 points_selector
             )
-            shard_key_selector = shard_key_selector or opt_shard_key_selector
+            if shard_key_selector is None:
+                shard_key_selector = opt_shard_key_selector
 
             if isinstance(ordering, models.WriteOrdering):
                 ordering = RestToGrpc.convert_write_ordering(ordering)

--- a/tests/test_shard_key_selector.py
+++ b/tests/test_shard_key_selector.py
@@ -196,7 +196,12 @@ def test_rest_embedded_shard_key_propagates(api_call, api_method, request_kwarg)
 @pytest.mark.parametrize("shard_key", FALSY_SHARD_KEYS)
 @pytest.mark.parametrize("api_call,api_method,request_kwarg", REST_CASES)
 def test_rest_explicit_falsy_shard_key_propagates(api_call, api_method, request_kwarg, shard_key):
+    # embedded shard key present to also assert explicit falsy keys take precedence
     client, api = make_rest_client()
-    api_call(client, models.PointIdsList(points=[1]), {"shard_key_selector": shard_key})
+    api_call(
+        client,
+        models.PointIdsList(points=[1], shard_key="us"),
+        {"shard_key_selector": shard_key},
+    )
     request = getattr(api, api_method).call_args.kwargs[request_kwarg]
     assert request.shard_key == shard_key, f"{api_method} dropped falsy shard key {shard_key!r}"

--- a/tests/test_shard_key_selector.py
+++ b/tests/test_shard_key_selector.py
@@ -144,13 +144,59 @@ def test_rest_points_and_filter_returns_embedded_shard_key():
     assert _shard_key is None
 
 
-def test_rest_delete_vectors_uses_embedded_shard_key():
+def make_rest_client() -> tuple[QdrantClient, MagicMock]:
     client = QdrantClient(check_compatibility=False)
     api = MagicMock()
-    api.delete_vectors.return_value = MagicMock(
+    rest_response = MagicMock(
         result=models.UpdateResult(operation_id=1, status=models.UpdateStatus.COMPLETED)
     )
+    for method in (
+        "delete_points",
+        "delete_vectors",
+        "set_payload",
+        "overwrite_payload",
+        "delete_payload",
+        "clear_payload",
+    ):
+        getattr(api, method).return_value = rest_response
     client._client.openapi_client.points_api = api
-    client.delete_vectors("c", ["v"], models.PointIdsList(points=[1], shard_key="us"))
-    request = api.delete_vectors.call_args.kwargs["delete_vectors"]
-    assert request.shard_key == "us"
+    return client, api
+
+
+REST_CASES = [
+    (lambda c, sel, kw: c.delete("c", sel, **kw), "delete_points", "points_selector"),
+    (
+        lambda c, sel, kw: c.delete_vectors("c", ["v"], sel, **kw),
+        "delete_vectors",
+        "delete_vectors",
+    ),
+    (lambda c, sel, kw: c.set_payload("c", {"a": 1}, sel, **kw), "set_payload", "set_payload"),
+    (
+        lambda c, sel, kw: c.overwrite_payload("c", {"a": 1}, sel, **kw),
+        "overwrite_payload",
+        "set_payload",
+    ),
+    (
+        lambda c, sel, kw: c.delete_payload("c", ["a"], sel, **kw),
+        "delete_payload",
+        "delete_payload",
+    ),
+    (lambda c, sel, kw: c.clear_payload("c", sel, **kw), "clear_payload", "points_selector"),
+]
+
+
+@pytest.mark.parametrize("api_call,api_method,request_kwarg", REST_CASES)
+def test_rest_embedded_shard_key_propagates(api_call, api_method, request_kwarg):
+    client, api = make_rest_client()
+    api_call(client, models.PointIdsList(points=[1], shard_key="us"), {})
+    request = getattr(api, api_method).call_args.kwargs[request_kwarg]
+    assert request.shard_key == "us", f"{api_method} dropped embedded shard key"
+
+
+@pytest.mark.parametrize("shard_key", FALSY_SHARD_KEYS)
+@pytest.mark.parametrize("api_call,api_method,request_kwarg", REST_CASES)
+def test_rest_explicit_falsy_shard_key_propagates(api_call, api_method, request_kwarg, shard_key):
+    client, api = make_rest_client()
+    api_call(client, models.PointIdsList(points=[1]), {"shard_key_selector": shard_key})
+    request = getattr(api, api_method).call_args.kwargs[request_kwarg]
+    assert request.shard_key == shard_key, f"{api_method} dropped falsy shard key {shard_key!r}"

--- a/tests/test_shard_key_selector.py
+++ b/tests/test_shard_key_selector.py
@@ -1,0 +1,156 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from qdrant_client import QdrantClient, grpc, models
+from qdrant_client.qdrant_remote import QdrantRemote
+
+POINTS_RESPONSE = grpc.PointsOperationResponse(
+    result=grpc.UpdateResult(operation_id=1, status=grpc.UpdateStatus.Completed),
+    time=0.0,
+)
+
+FALSY_SHARD_KEYS = [0, ""]
+
+
+def make_grpc_client() -> tuple[QdrantClient, MagicMock]:
+    client = QdrantClient(prefer_grpc=True, check_compatibility=False)
+    stub = MagicMock()
+    for method in (
+        "Delete",
+        "DeleteVectors",
+        "SetPayload",
+        "OverwritePayload",
+        "DeletePayload",
+        "ClearPayload",
+    ):
+        getattr(stub, method).return_value = POINTS_RESPONSE
+    client._client._grpc_points_client_pool = [stub]
+    return client, stub
+
+
+@pytest.mark.parametrize("shard_key", FALSY_SHARD_KEYS)
+@pytest.mark.parametrize(
+    "call,stub_method",
+    [
+        (lambda client, kw: client.delete("c", models.PointIdsList(points=[1]), **kw), "Delete"),
+        (
+            lambda client, kw: client.delete_vectors(
+                "c", ["v"], models.PointIdsList(points=[1]), **kw
+            ),
+            "DeleteVectors",
+        ),
+        (
+            lambda client, kw: client.set_payload(
+                "c", {"a": 1}, models.PointIdsList(points=[1]), **kw
+            ),
+            "SetPayload",
+        ),
+        (
+            lambda client, kw: client.overwrite_payload(
+                "c", {"a": 1}, models.PointIdsList(points=[1]), **kw
+            ),
+            "OverwritePayload",
+        ),
+        (
+            lambda client, kw: client.delete_payload(
+                "c", ["a"], models.PointIdsList(points=[1]), **kw
+            ),
+            "DeletePayload",
+        ),
+        (
+            lambda client, kw: client.clear_payload("c", models.PointIdsList(points=[1]), **kw),
+            "ClearPayload",
+        ),
+    ],
+)
+def test_grpc_falsy_shard_key_selector_is_not_dropped(call, stub_method, shard_key):
+    # 0 and "" are valid shard keys (ShardKey = StrictInt | StrictStr), but used to be
+    # dropped by `shard_key_selector or opt_shard_key_selector`, silently applying
+    # the operation to all shards
+    client, stub = make_grpc_client()
+    call(client, {"shard_key_selector": shard_key})
+    request = getattr(stub, stub_method).call_args[0][0]
+    assert request.HasField(
+        "shard_key_selector"
+    ), f"{stub_method} dropped falsy shard key {shard_key!r}"
+    assert request.shard_key_selector == grpc.ShardKeySelector(
+        shard_keys=[models_shard_key_to_grpc(shard_key)]
+    )
+
+
+def models_shard_key_to_grpc(shard_key: models.ShardKey) -> grpc.ShardKey:
+    if isinstance(shard_key, str):
+        return grpc.ShardKey(keyword=shard_key)
+    return grpc.ShardKey(number=shard_key)
+
+
+def test_grpc_embedded_shard_key_still_used():
+    client, stub = make_grpc_client()
+    client.delete("c", models.PointIdsList(points=[1], shard_key="us"))
+    request = stub.Delete.call_args[0][0]
+    assert request.HasField("shard_key_selector")
+    assert request.shard_key_selector == grpc.ShardKeySelector(
+        shard_keys=[grpc.ShardKey(keyword="us")]
+    )
+
+
+def test_grpc_explicit_shard_key_overrides_embedded():
+    client, stub = make_grpc_client()
+    client.delete("c", models.PointIdsList(points=[1], shard_key="us"), shard_key_selector="eu")
+    request = stub.Delete.call_args[0][0]
+    assert request.shard_key_selector == grpc.ShardKeySelector(
+        shard_keys=[grpc.ShardKey(keyword="eu")]
+    )
+
+
+def test_rest_selector_preserves_embedded_shard_key():
+    # used to be overwritten with None when no explicit shard_key_selector was passed,
+    # silently applying the operation to all shards (while grpc mode kept the shard key)
+    selector = QdrantRemote._try_argument_to_rest_selector(
+        models.PointIdsList(points=[1], shard_key="us"), None
+    )
+    assert selector.shard_key == "us"
+
+    selector = QdrantRemote._try_argument_to_rest_selector(
+        models.PointIdsList(points=[1], shard_key="us"), "eu"
+    )
+    assert selector.shard_key == "eu"
+
+    selector = QdrantRemote._try_argument_to_rest_selector(
+        models.PointIdsList(points=[1], shard_key="us"), 0
+    )
+    assert selector.shard_key == 0
+
+
+def test_rest_points_and_filter_returns_embedded_shard_key():
+    _points, _filter, _shard_key = QdrantRemote._try_argument_to_rest_points_and_filter(
+        models.PointIdsList(points=[1], shard_key="us")
+    )
+    assert _points == [1]
+    assert _filter is None
+    assert _shard_key == "us"
+
+    _points, _filter, _shard_key = QdrantRemote._try_argument_to_rest_points_and_filter(
+        models.FilterSelector(filter=models.Filter(), shard_key=0)
+    )
+    assert _points is None
+    assert _filter is not None
+    assert _shard_key == 0
+
+    _points, _filter, _shard_key = QdrantRemote._try_argument_to_rest_points_and_filter(
+        models.PointIdsList(points=[1])
+    )
+    assert _shard_key is None
+
+
+def test_rest_delete_vectors_uses_embedded_shard_key():
+    client = QdrantClient(check_compatibility=False)
+    api = MagicMock()
+    api.delete_vectors.return_value = MagicMock(
+        result=models.UpdateResult(operation_id=1, status=models.UpdateStatus.COMPLETED)
+    )
+    client._client.openapi_client.points_api = api
+    client.delete_vectors("c", ["v"], models.PointIdsList(points=[1], shard_key="us"))
+    request = api.delete_vectors.call_args.kwargs["delete_vectors"]
+    assert request.shard_key == "us"


### PR DESCRIPTION
Fixes #1358

Write operations (`delete`, `delete_vectors`, `set_payload`, `overwrite_payload`, `delete_payload`, `clear_payload`) could silently run on **all shards** instead of the selected one: with `prefer_grpc=True` a falsy `shard_key_selector` (`0`, `""`) was discarded by `shard_key_selector or opt_shard_key_selector`, and in REST mode a shard key embedded in the points selector (`PointIdsList(shard_key=...)`) was overwritten with `None` or not forwarded, while gRPC mode honored it.

**Changes:** replace the truthiness fallback with an explicit `is None` check; make `_try_argument_to_rest_selector` preserve the embedded shard key unless an explicit selector is given; return the embedded shard key from `_try_argument_to_rest_points_and_filter` and use it as fallback in its callers. Precedence is now identical on both transports: explicit argument (including falsy) > embedded > none. Same bug class as #1260/#1279, which fixed it in the conversion layer — these are the remaining sites in the client methods.

**Async client:** regenerated with `tools/generate_async_client.sh` under Python 3.10 (not hand-edited); `tests/async-client-consistency-check.sh` → "No diffs found" for all generated files.

**Tests:** new `tests/test_shard_key_selector.py` — parametrized over all six methods × falsy keys `0`/`""` asserting the gRPC request carries the shard key, plus embedded-key preservation, explicit-override, and REST-path tests. 15 fail without the fix, all pass with it; `tests/conversions/` 39 passed total; `ruff format --check --line-length=99` clean; mypy clean on touched files.

Disclosure: prepared with AI assistance (Claude Code); I reviewed the change and take responsibility for it.