### PR TITLE
fix(snapshots): fix get_snapshots trying to parse tar as JSON

### DIFF
--- a/qdrant_client/http/api/snapshots_api.py
+++ b/qdrant_client/http/api/snapshots_api.py
@@ -12,7 +12,7 @@ Model = TypeVar("Model", bound="BaseModel")
 
 SetIntStr = Set[Union[int, str]]
 DictIntStrAny = Dict[Union[int, str], Any]
-file = None
+file = bytes
 
 
 def to_json(model: BaseModel, *args: Any, **kwargs: Any) -> str:

--- a/qdrant_client/http/api_client.py
+++ b/qdrant_client/http/api_client.py
@@ -126,6 +126,8 @@ class ApiClient:
                 raise ResourceExhaustedResponse(message, retry_after_s)
 
         if response.status_code in [200, 201, 202]:
+            if type_ is bytes:
+                return response.content
             try:
                 return parse_as_type(response.json(), type_)
             except ValidationError as e:
@@ -215,6 +217,8 @@ class AsyncApiClient:
                 raise ResourceExhaustedResponse(message, retry_after_s)
 
         if response.status_code in [200, 201, 202]:
+            if type_ is bytes:
+                return response.content
             try:
                 return parse_as_type(response.json(), type_)
             except ValidationError as e:


### PR DESCRIPTION
This PR fixes #1360.

The fix is rather simple, but I'm not sure if it is the best way to do it, as I have no in-depth insights into the project. I assumed `file=None` has no specific meaning
and thus changed it to `file=bytes` and added a special handling for `type_==bytes` that passes the response content
through without trying to parse as JSON.

`pytest` passes with:
```
563 passed
29 skipped
17927 warnings
```

A simple local roundtrip test worked: `client.create_snapshot` -> `client.http.snapshots_api.get_snapshot` -> `client.http.snapshots_api.recover_from_uploaded_snapshot`
