### PR TITLE
fix(warnings): give the User-Agent override warning a stacklevel

### DIFF
--- a/qdrant_client/async_qdrant_remote.py
+++ b/qdrant_client/async_qdrant_remote.py
@@ -145,7 +145,9 @@ class AsyncQdrantRemote(AsyncQdrantBase):
         user_agent = f"python-client/{client_version} python/{python_version}"
         if "User-Agent" in self._rest_headers:
             show_warning_once(
-                f"`User-Agent` has been passed in `headers`, but it will be overridden with the builtin value: `{user_agent}`."
+                message=f"`User-Agent` has been passed in `headers`, but it will be overridden with the builtin value: `{user_agent}`.",
+                category=UserWarning,
+                stacklevel=4,
             )
         if grpc_options is not None and "grpc.primary_user_agent" in grpc_options:
             show_warning_once(

--- a/qdrant_client/qdrant_remote.py
+++ b/qdrant_client/qdrant_remote.py
@@ -178,8 +178,10 @@ class QdrantRemote(QdrantBase):
         user_agent = f"python-client/{client_version} python/{python_version}"
         if "User-Agent" in self._rest_headers:
             show_warning_once(
-                "`User-Agent` has been passed in `headers`, but "
-                f"it will be overridden with the builtin value: `{user_agent}`."
+                message="`User-Agent` has been passed in `headers`, but "
+                f"it will be overridden with the builtin value: `{user_agent}`.",
+                category=UserWarning,
+                stacklevel=4,
             )
 
         if grpc_options is not None and "grpc.primary_user_agent" in grpc_options:


### PR DESCRIPTION
### What

`show_warning_once` defaults to `stacklevel=1`. The `User-Agent`-in-`headers` warning in `QdrantRemote.__init__` is the one call site that does not override that default, so `warnings.warn` attributes it to `qdrant_client/common/client_warnings.py:7` — the warning helper itself — rather than to the caller.

### Why this site and no other

Of the 20 `show_warning_once` call sites in the package, 19 pass an explicit `stacklevel` (`4`, `5`, `6` or `10`, depending on how deeply the call is nested). This is the only one that omits it, and it is bracketed by two siblings in the *same* `__init__` that both pass `stacklevel=4`:

| site | stacklevel |
|---|---|
| `qdrant_remote.py:167` — `api-key` passed in `headers` | `4` |
| `qdrant_remote.py:180` — `User-Agent` passed in `headers` | **(none → 1)** |
| `qdrant_remote.py:186` — `grpc.primary_user_agent` overridden | `4` |

So the file's own convention fixes the value: `4`.

### Measured effect

Constructing a client with `headers={"User-Agent": ...}` and recording the warning:

```
before:  .../qdrant_client/common/client_warnings.py:7: UserWarning: `User-Agent` ...
after:   .../qdrant_client/qdrant_client.py:134:        UserWarning: `User-Agent` ...
```

`qdrant_client.py:134` is exactly where the two sibling warnings already land, so after this change all three construction warnings report the same location. The async client behaves the same way (`async_qdrant_client.py:129`).

Nothing else changes: `category=UserWarning` was already the default, and `show_warning_once`'s dedup key is the message, which is untouched.

### Scope

Deliberately limited to the one inconsistent site. I did **not** re-tune the other 19 call sites — several of them (`4` vs `5` vs `6` vs `10`) reflect their own nesting depth, and changing them would be a separate judgement call rather than a defect fix.

### Notes

- Base branch is `dev`, per the contribution guide.
- `qdrant_client/async_qdrant_remote.py` is generated from the sync source. I ran `tools/generate_async_client.sh`'s remote step with `ruff` pinned to the `0.4.3` in `pyproject.toml` and confirmed the emitted hunk is byte-identical to the one committed here, so a future regeneration is a no-op.
- `ruff format --line-length 99 --check` is clean on both files.
- `tests/test_in_memory.py`, `tests/test_common.py` pass. The 4 failures in `tests/test_local_persistence.py` are a pre-existing Windows-only `PermissionError: [WinError 32]` on tempdir cleanup — identical on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
