### PR TITLE
fix(http): propagate per-call timeout to httpx in AsyncApiClient

### DIFF
--- a/qdrant_client/http/api_client.py
+++ b/qdrant_client/http/api_client.py
@@ -183,6 +183,8 @@ class AsyncApiClient:
         # in order to do a correct join, url join requires base_url to end with /, and url to not start with /,
         # since url is treated as an absolute path and might truncate prefix in base_url
         url = urljoin(host, url.format(**path_params))
+        if "params" in kwargs and "timeout" in kwargs["params"]:
+            kwargs["timeout"] = int(kwargs["params"]["timeout"])
         request = self._async_client.build_request(method, url, **kwargs)
         return await self.send(request, type_)
 

--- a/tests/test_qdrant_client.py
+++ b/tests/test_qdrant_client.py
@@ -8,6 +8,7 @@ import uuid
 from pprint import pprint
 from tempfile import mkdtemp
 from time import sleep
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -1755,6 +1756,35 @@ def test_timeout_propagation():
     client.create_collection(
         collection_name=COLLECTION_NAME, vectors_config=vectors_config, timeout=10
     )
+
+
+def test_async_rest_timeout_propagation():
+    # Regression for #1325: AsyncApiClient.request dropped the per-call
+    # `timeout=` from kwargs before build_request, so async callers were
+    # bound by httpx's default 5s timeout regardless of what they asked
+    # for. The sync ApiClient.request already promotes that value.
+    from qdrant_client.http.api_client import AsyncApiClient
+
+    captured: dict = {}
+
+    def _capture(method, url, **kwargs):
+        captured["kwargs"] = kwargs
+        return type("DummyRequest", (), {"headers": {}})()
+
+    async_client = AsyncApiClient(host="http://localhost:6333")
+    with patch.object(async_client._async_client, "build_request", _capture):
+        with pytest.raises(Exception):
+            asyncio.run(
+                async_client.request(
+                    type_=None,
+                    method="GET",
+                    url="/collections/{c}",
+                    path_params={"c": "x"},
+                    params={"timeout": "50"},
+                )
+            )
+
+    assert captured["kwargs"].get("timeout") == 50
 
 
 def test_grpc_options():

--- a/tests/test_qdrant_client.py
+++ b/tests/test_qdrant_client.py
@@ -1759,11 +1759,11 @@ def test_timeout_propagation():
 
 
 def test_async_rest_timeout_propagation():
-    # Regression for #1325: AsyncApiClient.request dropped the per-call
-    # `timeout=` from kwargs before build_request, so async callers were
-    # bound by httpx's default 5s timeout regardless of what they asked
-    # for. The sync ApiClient.request already promotes that value.
+    # Regression for #1325: async client dropped the per-call `timeout=`
+    # from kwargs before build_request, leaving callers bound by httpx's
+    # default 5s timeout. Sync ApiClient.request already promotes it.
     from qdrant_client.http.api_client import AsyncApiClient
+    from unittest.mock import AsyncMock
 
     captured: dict = {}
 
@@ -1772,17 +1772,17 @@ def test_async_rest_timeout_propagation():
         return type("DummyRequest", (), {"headers": {}})()
 
     async_client = AsyncApiClient(host="http://localhost:6333")
-    with patch.object(async_client._async_client, "build_request", _capture):
-        with pytest.raises(Exception):
-            asyncio.run(
-                async_client.request(
-                    type_=None,
-                    method="GET",
-                    url="/collections/{c}",
-                    path_params={"c": "x"},
-                    params={"timeout": "50"},
-                )
+    with patch.object(async_client._async_client, "build_request", _capture), \
+         patch.object(async_client, "send", new=AsyncMock()):
+        asyncio.run(
+            async_client.request(
+                type_=None,
+                method="GET",
+                url="/collections/{c}",
+                path_params={"c": "x"},
+                params={"timeout": "50"},
             )
+        )
 
     assert captured["kwargs"].get("timeout") == 50
 


### PR DESCRIPTION
Fixes #1325

## Problem

`AsyncApiClient.request` (REST) dropped the per-call `timeout=` argument before handing the request to `httpx.AsyncClient.build_request`, so async callers were silently bound by httpx's default 5s timeout regardless of what they asked for. Slow operations on `AsyncQdrantClient` could fail with a spurious `ReadTimeout` even when the caller explicitly set `timeout=`.

The sync `ApiClient.request` already promotes the timeout up to httpx (added in #534). The async path was never ported.

Repro from the issue:

```python
sync build_request kwargs:  {'params': {'timeout': '50'}, 'timeout': 50}
async build_request kwargs: {'params': {'timeout': '50'}}
```

## Fix

`qdrant_client/http/api_client.py` — `AsyncApiClient.request` now mirrors the sync block:

```python
if "params" in kwargs and "timeout" in kwargs["params"]:
    kwargs["timeout"] = int(kwargs["params"]["timeout"])
```

Two lines, same logic as the sync client.

## Test

`tests/test_qdrant_client.py::test_async_rest_timeout_propagation` — a pure-unit regression that patches `httpx.AsyncClient.build_request` and asserts the timeout kwarg reaches it. Fails on master, passes with the fix. No live server required, so it runs in CI without docker.

The existing sync `test_timeout_propagation` (line 1740) already covers the sync path against a live server.

## Scope

- 1 production change (2 lines in `AsyncApiClient.request`)
- 1 new test (~28 lines)
- 1 import added (`from unittest.mock import patch`)

No API changes, no dependency changes, no behavior changes for the existing path. Distinct from #948 (gRPC timeout propagation), which is out of scope here.
