### PR TITLE
fix(http): ApiClient.request_sync must not wrap sync result in event loop

### DIFF
--- a/qdrant_client/http/api_client.py
+++ b/qdrant_client/http/api_client.py
@@ -109,7 +109,7 @@ class ApiClient:
         """
         This method is not used by the generated apis, but is included for convenience
         """
-        return get_event_loop().run_until_complete(self.request(type_=type_, **kwargs))
+        return self.request(type_=type_, **kwargs)
 
     def send(self, request: Request, type_: Type[T]) -> T:
         response = self.middleware(request, self.send_inner)

--- a/tests/test_qdrant_client.py
+++ b/tests/test_qdrant_client.py
@@ -8,6 +8,7 @@ import uuid
 from pprint import pprint
 from tempfile import mkdtemp
 from time import sleep
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -1755,6 +1756,35 @@ def test_timeout_propagation():
     client.create_collection(
         collection_name=COLLECTION_NAME, vectors_config=vectors_config, timeout=10
     )
+
+
+def test_api_client_request_sync_returns_value():
+    # Regression for #1336: ApiClient.request_sync wrapped a synchronous
+    # return value in run_until_complete, so any non-awaitable result
+    # raised TypeError instead of being returned.
+    from qdrant_client.http.api_client import ApiClient
+
+    sync_client = ApiClient("http://localhost:6333")
+    with patch.object(sync_client, "request", return_value={"ok": True}) as mocked:
+        result = sync_client.request_sync(
+            type_=dict,
+            method="GET",
+            url="/collections",
+        )
+
+    assert result == {"ok": True}
+    mocked.assert_called_once_with(type_=dict, method="GET", url="/collections")
+
+    # type_=None path also returns the value as-is.
+    with patch.object(sync_client, "request", return_value=None) as mocked_none:
+        result_none = sync_client.request_sync(
+            type_=None,
+            method="GET",
+            url="/collections",
+        )
+
+    assert result_none is None
+    mocked_none.assert_called_once_with(type_=None, method="GET", url="/collections")
 
 
 def test_grpc_options():

--- a/tests/test_qdrant_client.py
+++ b/tests/test_qdrant_client.py
@@ -1759,9 +1759,8 @@ def test_timeout_propagation():
 
 
 def test_api_client_request_sync_returns_value():
-    # Regression for #1336: ApiClient.request_sync wrapped a synchronous
-    # return value in run_until_complete, so any non-awaitable result
-    # raised TypeError instead of being returned.
+    # Regression for #1336: sync client wrapped the return value in
+    # run_until_complete, so any non-awaitable result raised TypeError.
     from qdrant_client.http.api_client import ApiClient
 
     sync_client = ApiClient("http://localhost:6333")
@@ -1775,7 +1774,6 @@ def test_api_client_request_sync_returns_value():
     assert result == {"ok": True}
     mocked.assert_called_once_with(type_=dict, method="GET", url="/collections")
 
-    # type_=None path also returns the value as-is.
     with patch.object(sync_client, "request", return_value=None) as mocked_none:
         result_none = sync_client.request_sync(
             type_=None,


### PR DESCRIPTION
Fixes #1336

## Problem

`ApiClient.request_sync` is a synchronous convenience wrapper, but it shared its body with `AsyncApiClient.request_sync` — both called `get_event_loop().run_until_complete(self.request(...))`. For the async class that's correct (`self.request` returns a coroutine). For the sync class, `self.request` returns an ordinary value, so every successful response raised `TypeError: An asyncio.Future, a coroutine or an awaitable is required` instead of being returned.

Repro from the issue:

```python
client = ApiClient("http://localhost:6333")
with patch.object(client, "request", return_value={"ok": True}):
    client.request_sync(type_=dict, method="GET", url="/collections")
# TypeError: An asyncio.Future, a coroutine or an awaitable is required
```

## Fix

`qdrant_client/http/api_client.py` — `ApiClient.request_sync` now returns `self.request(...)` directly. The async side (`AsyncApiClient.request_sync`) is unchanged — it still uses `run_until_complete` because its `self.request` is a coroutine.

One-line change, 1 line of context.

## Test

`tests/test_qdrant_client.py::test_api_client_request_sync_returns_value` — pure unit regression that patches `ApiClient.request` to return a plain dict and asserts the dict flows through. Also covers the `type_=None` path. Fails on master (`TypeError`), passes with the fix. No live server required.

## Scope

- 1 production change (1 line replaced in `ApiClient.request_sync`)
- 1 new test (~30 lines)
- 1 import added (`from unittest.mock import patch`)

No API changes (the wrapper is `request_sync` and its signature is unchanged), no behavior change for the existing happy path, no dependency change. Distinct from the previous #1326/#1366 async-side timeout fix.
