### PR TITLE
fix(local): compare score_threshold in the query's own score direction (#1370)

### DIFF
--- a/qdrant_client/local/local_collection.py
+++ b/qdrant_client/local/local_collection.py
@@ -654,7 +654,10 @@ class LocalCollection:
 
         required_order = distance_to_order(distance)
 
-        if required_order == DistanceOrder.BIGGER_IS_BETTER or isinstance(
+        # Recommend/discovery/context queries score through a sigmoid, so bigger is
+        # always better for them, whatever the collection's distance is. Both the sort
+        # order and the score_threshold comparison below have to follow this flag.
+        bigger_is_better = required_order == DistanceOrder.BIGGER_IS_BETTER or isinstance(
             query_vector,
             (
                 DiscoveryQuery,
@@ -664,7 +667,9 @@ class LocalCollection:
                 MultiContextQuery,
                 MultiRecoQuery,
             ),  # sparse structures are not required, sparse always uses DOT
-        ):
+        )
+
+        if bigger_is_better:
             order = np.argsort(scores)[::-1]
         else:
             order = np.argsort(scores)
@@ -684,7 +689,7 @@ class LocalCollection:
             point_id = self.ids_inv[idx]
 
             if score_threshold is not None:
-                if required_order == DistanceOrder.BIGGER_IS_BETTER:
+                if bigger_is_better:
                     if score < score_threshold:
                         break
                 else:


### PR DESCRIPTION
Fixes #1370.

## Problem

In local/in-memory mode, `score_threshold` is compared in the wrong direction for **Recommend** (`best_score` / `sum_scores`), **Discover** and **Context** queries whenever the collection's distance is **Euclid** or **Manhattan**. The threshold silently drops every point that should have passed, so `query_points` returns an empty result set.

`LocalCollection.search()` decides the sort order like this:

```python
required_order = distance_to_order(distance)

if required_order == DistanceOrder.BIGGER_IS_BETTER or isinstance(
    query_vector,
    (DiscoveryQuery, ContextQuery, RecoQuery,
     MultiDiscoveryQuery, MultiContextQuery, MultiRecoQuery),
):
    order = np.argsort(scores)[::-1]
else:
    order = np.argsort(scores)
```

The `isinstance(...)` arm is there because `calculate_recommend_best_scores`, `calculate_recommend_sum_scores`, `calculate_discovery_scores` and `calculate_context_scores` all build their score on top of `calculate_distance_core`, which already negates Euclid/Manhattan, and then run it through `scaled_fast_sigmoid` / `fast_sigmoid`. For these query types bigger is always better, whatever the collection's distance is.

The threshold check a few lines below did not repeat that override:

```python
if score_threshold is not None:
    if required_order == DistanceOrder.BIGGER_IS_BETTER:   # <-- ignores query type
        if score < score_threshold:
            break
    else:
        if score > score_threshold:
            break
```

On a Euclid/Manhattan collection `required_order` is `SMALLER_IS_BETTER`, so the points — already sorted biggest-first — are cut with `score > score_threshold`, and the very first point breaks the loop.

## Fix

Hoist the decision into a single `bigger_is_better` flag and use it for both the sort order and the threshold comparison, so the two cannot drift apart again. The flag is the exact expression the sort branch already used, so ordering behaviour is unchanged for every query type (including `NaiveFeedbackQuery`, which keeps following `required_order` as before).

## Reproduction

```python
from qdrant_client import QdrantClient, models

c = QdrantClient(":memory:")
c.create_collection("t", vectors_config=models.VectorParams(size=2, distance=models.Distance.EUCLID))
c.upsert("t", points=[models.PointStruct(id=i, vector=v) for i, v in
         [(1, [1.0, 0.0]), (2, [0.9, 0.1]), (3, [0.0, 1.0]), (4, [-1.0, 0.0])]], wait=True)

q = models.RecommendQuery(recommend=models.RecommendInput(
    positive=[[1.0, 0.0]], negative=[[-1.0, 0.0]],
    strategy=models.RecommendStrategy.BEST_SCORE))

print([(p.id, p.score) for p in c.query_points("t", query=q, limit=10).points])
# [(1, 0.5), (2, 0.4902), (3, -0.1667), (4, -0.5)]

print([p.id for p in c.query_points("t", query=q, limit=10, score_threshold=-0.51).points])
# before: []            <- threshold below every score, yet nothing comes back
# after:  [1, 2, 3, 4]
```

## Verification

Run against `dev`, for `Cosine` / `Euclid` / `Manhattan`:

| check | before | after |
|---|---|---|
| Recommend `best_score`, threshold below every score | Cosine ok; **Euclid/Manhattan return `[]`** | all three return every point |
| Recommend, thresholds that should cut (`0.45`, `0.0`, `-0.2`) | n/a (returned nothing) | matches `score >= threshold` exactly |
| Discover / Context on Euclid, threshold below every score | returned `[]` | returns every point |
| Plain dense search on Euclid (`smaller is better`) | matches `score <= threshold` | unchanged, still matches |

`ruff-format --line-length=99` (v0.4.3, per `.pre-commit-config.yaml`) reports the file already formatted. `tests/test_in_memory.py` and `tests/conversions` pass; the 4 failures in `tests/test_local_persistence.py` are a pre-existing Windows tempfile-locking artifact and reproduce identically on an unmodified tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
