### PR TITLE
fix(local): skip missing multivectors during search

### DIFF
--- a/qdrant_client/local/multi_distances.py
+++ b/qdrant_client/local/multi_distances.py
@@ -82,6 +82,7 @@ def calculate_multi_distance_core(
     matrices: list[types.NumpyArray],
     distance_type: models.Distance,
 ) -> types.NumpyArray:
+    """Calculate similarities for each candidate multivector matrix."""
     def euclidean(q: types.NumpyArray, m: types.NumpyArray, *_: Any) -> types.NumpyArray:
         return -np.square(m - q, dtype=np.float32).sum(axis=-1, dtype=np.float32)
 

--- a/qdrant_client/local/multi_distances.py
+++ b/qdrant_client/local/multi_distances.py
@@ -100,6 +100,9 @@ def calculate_multi_distance_core(
         dist_func = calculate_distance  # type: ignore
 
     for matrix in matrices:
+        if matrix.size == 0:
+            similarities.append(-np.inf)
+            continue
         sim_matrix = dist_func(query_matrix, matrix, distance_type)
         similarity = float(np.sum(np.max(sim_matrix, axis=-1)))
         similarities.append(similarity)

--- a/qdrant_client/local/tests/test_vectors.py
+++ b/qdrant_client/local/tests/test_vectors.py
@@ -5,6 +5,7 @@ from qdrant_client.local.local_collection import LocalCollection, DEFAULT_VECTOR
 
 
 def test_get_vectors():
+    """Test retrieving vectors from a local collection."""
     collection = LocalCollection(
         models.CreateCollection(
             vectors=models.VectorParams(size=2, distance=models.Distance.MANHATTAN)
@@ -22,6 +23,7 @@ def test_get_vectors():
 
 
 def test_multivector_search_skips_points_without_a_vector():
+    """Test that missing named multivectors are skipped during local search."""
     collection = LocalCollection(
         models.CreateCollection(
             vectors={

--- a/qdrant_client/local/tests/test_vectors.py
+++ b/qdrant_client/local/tests/test_vectors.py
@@ -19,3 +19,30 @@ def test_get_vectors():
     assert collection._get_vectors(idx=1, with_vectors=DEFAULT_VECTOR_NAME)
     assert collection._get_vectors(idx=2, with_vectors=True)
     assert collection._get_vectors(idx=3, with_vectors=False) is None
+
+
+def test_multivector_search_skips_points_without_a_vector():
+    collection = LocalCollection(
+        models.CreateCollection(
+            vectors={
+                "dense": models.VectorParams(size=4, distance=models.Distance.COSINE),
+                "multi": models.VectorParams(
+                    size=4,
+                    distance=models.Distance.COSINE,
+                    multivector_config=models.MultiVectorConfig(
+                        comparator=models.MultiVectorComparator.MAX_SIM
+                    ),
+                ),
+            }
+        )
+    )
+    collection.upsert(
+        points=[
+            models.PointStruct(id=1, vector={}),
+            models.PointStruct(id=2, vector={"dense": [1.0] * 4, "multi": [[1.0] * 4]}),
+        ]
+    )
+
+    result = collection.search(("multi", [[1.0] * 4]), limit=5)
+
+    assert [point.id for point in result] == [2]


### PR DESCRIPTION
Fixes #1383

## Summary
- Treat empty multivector matrices as non-matching points during local distance calculation.
- Preserve normal scoring while allowing the existing deleted-vector mask to skip missing vectors.
- Add a local regression test for searching a named multivector when another point has no value for it.

## Testing
- `pytest -q qdrant_client/local/tests/test_distances.py qdrant_client/local/tests/test_vectors.py`
- `pytest -q qdrant_client/local/tests`
- `uv tool run --from ruff==0.4.3 ruff check qdrant_client/local/multi_distances.py qdrant_client/local/tests/test_vectors.py`
- `git diff --check`

The full test suite reached 78 passed and 2 skipped before `tests/congruence_tests/test_aliases.py` failed because the local Qdrant endpoint at `localhost:6333` returned HTTP 502.