### PR TITLE
fix(local): keep facet bool and int values distinct

### DIFF
--- a/qdrant_client/local/local_collection.py
+++ b/qdrant_client/local/local_collection.py
@@ -1262,6 +1262,13 @@ class LocalCollection:
         facet_filter: types.Filter | None = None,
         limit: int = 10,
     ) -> types.FacetResponse:
+        # (bool, int, str). A value's position in this tuple is used as a type tag, so
+        # that `False`/`0` and `True`/`1` (equal and same-hash in python) don't collapse
+        # into a single bucket, and so that values of different types stay totally
+        # ordered when their counts tie. The server never mixes types in one facet (it
+        # reads a single payload index), so this cross-type order is local-mode only.
+        value_types = get_args_subscribed(types.FacetValue)
+
         facet_hits: dict[tuple[int, types.FacetValue], int] = defaultdict(int)
 
         mask = self._payload_and_non_deleted_mask(facet_filter)
@@ -1283,7 +1290,7 @@ class LocalCollection:
 
             # Sanitize to use only valid values
             for v in values:
-                if type(v) not in get_args_subscribed(types.FacetValue):
+                if type(v) not in value_types:
                     continue
 
                 # If values are UUIDs, format with hyphens
@@ -1291,7 +1298,7 @@ class LocalCollection:
                 if as_uuid:
                     v = str(as_uuid)
 
-                values_set.add(self._facet_value_identity(v))
+                values_set.add((value_types.index(type(v)), v))
 
             for v in values_set:
                 facet_hits[v] += 1
@@ -1967,17 +1974,6 @@ class LocalCollection:
         elif isinstance(point_id, int):
             return "", point_id
         raise TypeError(f"Incompatible point id type: {type(point_id)}")
-
-    @staticmethod
-    def _facet_value_identity(value: types.FacetValue) -> tuple[int, types.FacetValue]:
-        """Build a sortable key that preserves JSON scalar type identity."""
-        if isinstance(value, bool):
-            return 0, value
-        if isinstance(value, int):
-            return 1, value
-        if isinstance(value, str):
-            return 2, value
-        raise TypeError(f"Incompatible facet value type: {type(value)}")
 
     def scroll(
         self,

--- a/qdrant_client/local/local_collection.py
+++ b/qdrant_client/local/local_collection.py
@@ -1262,7 +1262,7 @@ class LocalCollection:
         facet_filter: types.Filter | None = None,
         limit: int = 10,
     ) -> types.FacetResponse:
-        facet_hits: dict[types.FacetValue, int] = defaultdict(int)
+        facet_hits: dict[tuple[int, types.FacetValue], int] = defaultdict(int)
 
         mask = self._payload_and_non_deleted_mask(facet_filter)
 
@@ -1279,7 +1279,7 @@ class LocalCollection:
                 continue
 
             # Only count the same value for each point once
-            values_set: set[types.FacetValue] = set()
+            values_set: set[tuple[int, types.FacetValue]] = set()
 
             # Sanitize to use only valid values
             for v in values:
@@ -1291,14 +1291,14 @@ class LocalCollection:
                 if as_uuid:
                     v = str(as_uuid)
 
-                values_set.add(v)
+                values_set.add(self._facet_value_identity(v))
 
             for v in values_set:
                 facet_hits[v] += 1
 
         hits = [
             models.FacetValueHit(value=value, count=count)
-            for value, count in sorted(
+            for (_, value), count in sorted(
                 facet_hits.items(),
                 # order by count descending, then by value ascending
                 key=lambda x: (-x[1], x[0]),
@@ -1967,6 +1967,17 @@ class LocalCollection:
         elif isinstance(point_id, int):
             return "", point_id
         raise TypeError(f"Incompatible point id type: {type(point_id)}")
+
+    @staticmethod
+    def _facet_value_identity(value: types.FacetValue) -> tuple[int, types.FacetValue]:
+        """Build a sortable key that preserves JSON scalar type identity."""
+        if isinstance(value, bool):
+            return 0, value
+        if isinstance(value, int):
+            return 1, value
+        if isinstance(value, str):
+            return 2, value
+        raise TypeError(f"Incompatible facet value type: {type(value)}")
 
     def scroll(
         self,

--- a/qdrant_client/local/tests/test_facet.py
+++ b/qdrant_client/local/tests/test_facet.py
@@ -1,0 +1,74 @@
+from qdrant_client.http import models
+from qdrant_client.local.qdrant_local import QdrantLocal
+
+COLLECTION_NAME = "test_facet"
+
+
+def facet_of(points: list[models.PointStruct]) -> list[tuple[type, models.FacetValue, int]]:
+    client = QdrantLocal(":memory:")
+    client.create_collection(COLLECTION_NAME, vectors_config={})
+    client.upsert(COLLECTION_NAME, points=points)
+
+    hits = client.facet(COLLECTION_NAME, key="a").hits
+
+    return [(type(hit.value), hit.value, hit.count) for hit in hits]
+
+
+def test_facet_keeps_scalar_types_distinct():
+    """`False == 0` and `True == 1` in python, but they are distinct facet values.
+
+    A facet on the server reads a single payload index, so a bool index only ever
+    returns bools and an integer index only ever returns ints. Local mode facets the
+    raw payload, so it has to keep the types apart on its own.
+    """
+    # every bucket ties at one point, so this also pins the tie-break order
+    assert facet_of(
+        [
+            models.PointStruct(id=1, vector={}, payload={"a": [False, 0]}),
+            models.PointStruct(id=2, vector={}, payload={"a": True}),
+            models.PointStruct(id=3, vector={}, payload={"a": 1}),
+            models.PointStruct(id=4, vector={}, payload={"a": "0"}),
+        ]
+    ) == [
+        (bool, False, 1),
+        (bool, True, 1),
+        (int, 0, 1),
+        (int, 1, 1),
+        (str, "0", 1),
+    ]
+
+
+def test_facet_does_not_compare_values_of_different_types():
+    """Ties on count fall through to the value, and `"a" < 1` raises in python."""
+    assert facet_of(
+        [
+            models.PointStruct(id=1, vector={}, payload={"a": 1}),
+            models.PointStruct(id=2, vector={}, payload={"a": "a"}),
+        ]
+    ) == [
+        (int, 1, 1),
+        (str, "a", 1),
+    ]
+
+
+def test_facet_normalizes_uuids_before_deduplicating():
+    """Both spellings of one uuid are a single value, counted once for the point.
+
+    This matches a uuid index on the server. Local mode has no index awareness, so it
+    normalizes unconditionally; a keyword index on the server would instead keep the
+    two spellings as two separate values.
+    """
+    assert facet_of(
+        [
+            models.PointStruct(
+                id=1,
+                vector={},
+                payload={
+                    "a": [
+                        "550e8400e29b41d4a716446655440000",
+                        "550e8400-e29b-41d4-a716-446655440000",
+                    ]
+                },
+            ),
+        ]
+    ) == [(str, "550e8400-e29b-41d4-a716-446655440000", 1)]

--- a/tests/congruence_tests/test_facet.py
+++ b/tests/congruence_tests/test_facet.py
@@ -206,3 +206,58 @@ def test_other_types_in_local():
 
     # Assertion is that it doesn't raise an exception
     client.facet(collection_name=collection_name, key="a")
+
+
+# `False == 0` and `True == 1` in python, so a key holding both bools and ints is where
+# local mode risks merging them into a single bucket. Every key below carries the same
+# mixed values, but gets a different payload index on the server: (key, the index to
+# build on it, the type of value that faceting through that index yields).
+MIXED_TYPE_INDEXES = [
+    ("mixed_bool", models.PayloadSchemaType.BOOL, bool),
+    ("mixed_int", models.PayloadSchemaType.INTEGER, int),
+    ("mixed_str", models.PayloadSchemaType.KEYWORD, str),
+]
+MIXED_TYPE_VALUES = [[False, 0], True, 1, "0", [True, 1], [True, True]]
+
+
+def test_mixed_scalar_types():
+    """Facet a key whose values span bools, ints and strings.
+
+    A facet on the server reads a single payload index, so it only ever returns values
+    of that index's type. Local mode facets the raw payload and returns every type at
+    once, so its hits are compared per type against the matching indexed key.
+    """
+    collection_name = f"{COLLECTION_NAME}_mixed_facet"
+    points = [
+        models.PointStruct(
+            id=idx,
+            vector=[0.1, 0.2],
+            payload={key: values for key, _, _ in MIXED_TYPE_INDEXES},
+        )
+        for idx, values in enumerate(MIXED_TYPE_VALUES)
+    ]
+    vectors_config = models.VectorParams(size=2, distance=models.Distance.DOT)
+
+    local_client = init_local()
+    init_client(local_client, points, collection_name, vectors_config=vectors_config)
+
+    remote_client = init_remote()
+    init_client(remote_client, points, collection_name, vectors_config=vectors_config)
+    for key, schema, _ in MIXED_TYPE_INDEXES:
+        remote_client.create_payload_index(collection_name, key, field_schema=schema)
+
+    def hits(client: QdrantBase, facet_key: str) -> list[models.FacetValueHit]:
+        return client.facet(
+            collection_name=collection_name, key=facet_key, limit=100, exact=True
+        ).hits
+
+    for key, _, value_type in MIXED_TYPE_INDEXES:
+        remote_hits = hits(remote_client, key)
+        local_hits = [hit for hit in hits(local_client, key) if type(hit.value) is value_type]
+
+        # compare the types explicitly: pydantic considers FacetValueHit(value=True)
+        # and FacetValueHit(value=1) equal, which is the very thing under test here
+        assert [(type(hit.value), hit.value, hit.count) for hit in local_hits] == [
+            (type(hit.value), hit.value, hit.count) for hit in remote_hits
+        ]
+        assert remote_hits, f"no {value_type.__name__} values were faceted for {key}"

--- a/tests/test_in_memory.py
+++ b/tests/test_in_memory.py
@@ -208,47 +208,6 @@ def test_fusion_rrf_score_threshold(qdrant: QdrantClient):
     )
 
 
-def test_facet_keeps_bool_and_int_values_distinct(qdrant: QdrantClient):
-    """Keep scalar types distinct while retaining UUID normalization and dedupe."""
-    qdrant.create_collection(
-        collection_name="facet_identity",
-        vectors_config=models.VectorParams(size=2, distance=models.Distance.DOT),
-    )
-
-    qdrant.upsert(
-        collection_name="facet_identity",
-        wait=True,
-        points=[
-            models.PointStruct(id=1, vector=[0.1, 0.2], payload={"k": [False, 0]}),
-            models.PointStruct(id=2, vector=[0.2, 0.3], payload={"k": True}),
-            models.PointStruct(id=3, vector=[0.3, 0.4], payload={"k": 1}),
-            models.PointStruct(id=4, vector=[0.4, 0.5], payload={"k": "0"}),
-            models.PointStruct(
-                id=5,
-                vector=[0.5, 0.6],
-                payload={
-                    "k": [
-                        "550e8400e29b41d4a716446655440000",
-                        "550e8400-e29b-41d4-a716-446655440000",
-                    ]
-                },
-            ),
-        ],
-    )
-
-    result = qdrant.facet(collection_name="facet_identity", key="k", exact=True, limit=10)
-
-    hits = {(type(hit.value), hit.value): hit.count for hit in result.hits}
-    assert hits == {
-        (bool, False): 1,
-        (int, 0): 1,
-        (bool, True): 1,
-        (int, 1): 1,
-        (str, "0"): 1,
-        (str, "550e8400-e29b-41d4-a716-446655440000"): 1,
-    }
-
-
 def test_fusion_dbsf_score_threshold(qdrant: QdrantClient):
     """Test that DBSF fusion with score_threshold correctly filters results.
 

--- a/tests/test_in_memory.py
+++ b/tests/test_in_memory.py
@@ -208,6 +208,47 @@ def test_fusion_rrf_score_threshold(qdrant: QdrantClient):
     )
 
 
+def test_facet_keeps_bool_and_int_values_distinct(qdrant: QdrantClient):
+    """Keep scalar types distinct while retaining UUID normalization and dedupe."""
+    qdrant.create_collection(
+        collection_name="facet_identity",
+        vectors_config=models.VectorParams(size=2, distance=models.Distance.DOT),
+    )
+
+    qdrant.upsert(
+        collection_name="facet_identity",
+        wait=True,
+        points=[
+            models.PointStruct(id=1, vector=[0.1, 0.2], payload={"k": [False, 0]}),
+            models.PointStruct(id=2, vector=[0.2, 0.3], payload={"k": True}),
+            models.PointStruct(id=3, vector=[0.3, 0.4], payload={"k": 1}),
+            models.PointStruct(id=4, vector=[0.4, 0.5], payload={"k": "0"}),
+            models.PointStruct(
+                id=5,
+                vector=[0.5, 0.6],
+                payload={
+                    "k": [
+                        "550e8400e29b41d4a716446655440000",
+                        "550e8400-e29b-41d4-a716-446655440000",
+                    ]
+                },
+            ),
+        ],
+    )
+
+    result = qdrant.facet(collection_name="facet_identity", key="k", exact=True, limit=10)
+
+    hits = {(type(hit.value), hit.value): hit.count for hit in result.hits}
+    assert hits == {
+        (bool, False): 1,
+        (int, 0): 1,
+        (bool, True): 1,
+        (int, 1): 1,
+        (str, "0"): 1,
+        (str, "550e8400-e29b-41d4-a716-446655440000"): 1,
+    }
+
+
 def test_fusion_dbsf_score_threshold(qdrant: QdrantClient):
     """Test that DBSF fusion with score_threshold correctly filters results.
 


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

## Summary

Fixes #1388.

Local-mode faceting currently uses raw Python values as both the per-point de-duplication key and the global aggregation key. Because `False == 0` and `True == 1`, boolean and integer payload values collapse into the same bucket before sorting.

This change switches local faceting to a type-tagged identity `(type_tag, value)` so that:

- `False` and `0` stay distinct
- `True` and `1` stay distinct
- per-point de-duplication and global counts use the same typed identity
- UUID normalization still happens before the identity is built
- facet sorting stays deterministic even when different scalar types tie on count

## Testing

- `pytest -q tests/test_in_memory.py`
- manual local reproduction of the issue now returns five distinct buckets for `False`, `0`, `True`, `1`, and `"0"`
