### PR TITLE
fix: fix local single prefetch

### DIFF
--- a/qdrant_client/local/async_qdrant_local.py
+++ b/qdrant_client/local/async_qdrant_local.py
@@ -320,9 +320,6 @@ class AsyncQdrantLocal(AsyncQdrantBase):
         prefetches = []
         if isinstance(prefetch, types.Prefetch):
             prefetches = [prefetch]
-            prefetches.extend(
-                prefetch.prefetch if isinstance(prefetch.prefetch, list) else [prefetch.prefetch]
-            )
         elif isinstance(prefetch, Sequence):
             prefetches = list(prefetch)
         return [

--- a/qdrant_client/local/qdrant_local.py
+++ b/qdrant_client/local/qdrant_local.py
@@ -351,10 +351,9 @@ class QdrantLocal(QdrantBase):
 
         prefetches = []
         if isinstance(prefetch, types.Prefetch):
+            # nested prefetches are resolved recursively in `_resolve_prefetch_input`,
+            # they must not be hoisted to this level
             prefetches = [prefetch]
-            prefetches.extend(
-                prefetch.prefetch if isinstance(prefetch.prefetch, list) else [prefetch.prefetch]
-            )
         elif isinstance(prefetch, Sequence):
             prefetches = list(prefetch)
 

--- a/tests/congruence_tests/test_query.py
+++ b/tests/congruence_tests/test_query.py
@@ -799,6 +799,47 @@ class TestSimpleSearcher:
             using="text",
         )
 
+    def dense_query_text_nested_single_prefetch(self, client: QdrantBase) -> models.QueryResponse:
+        # a single prefetch object instead of a list of one: the nested prefetch must only feed
+        # the prefetch it belongs to, it is not an extra source of the root query
+        return client.query_points(
+            collection_name=COLLECTION_NAME,
+            prefetch=models.Prefetch(
+                prefetch=models.Prefetch(
+                    query=self.dense_vector_query_text,
+                    using="text",
+                    limit=10,
+                ),
+                query=self.dense_vector_query_code,
+                using="code",
+                limit=5,
+            ),
+            query=models.FusionQuery(fusion=models.Fusion.RRF),
+            with_payload=True,
+            limit=10,
+        )
+
+    def dense_query_text_nested_single_prefetch_rescore(
+        self, client: QdrantBase
+    ) -> models.QueryResponse:
+        return client.query_points(
+            collection_name=COLLECTION_NAME,
+            prefetch=models.Prefetch(
+                prefetch=models.Prefetch(
+                    query=self.dense_vector_query_text,
+                    using="text",
+                    limit=10,
+                ),
+                query=self.dense_vector_query_code,
+                using="code",
+                limit=5,
+            ),
+            query=self.dense_vector_query_text,
+            using="text",
+            with_payload=True,
+            limit=10,
+        )
+
     @classmethod
     def dense_recommend_image(cls, client: QdrantBase) -> models.QueryResponse:
         return client.query_points(
@@ -1206,6 +1247,20 @@ def test_dense_query_nested_prefetch():
     compare_clients_results(
         local_client, http_client, grpc_client, searcher.dense_query_text_nested_prefetch
     )
+
+
+def test_dense_query_nested_single_prefetch():
+    fixture_points = generate_fixtures()
+
+    searcher = TestSimpleSearcher()
+
+    local_client, http_client, grpc_client = init_clients(fixture_points)
+
+    for query in (
+        searcher.dense_query_text_nested_single_prefetch,
+        searcher.dense_query_text_nested_single_prefetch_rescore,
+    ):
+        compare_clients_results(local_client, http_client, grpc_client, query)
 
 
 def test_dense_query_filtered_prefetch():


### PR DESCRIPTION
Local mode returns wrong scores and extra points when `prefetch` is a single `Prefetch` object (not a list) that carries a nested `prefetch`.

`_resolve_prefetches_input` hoisted the nested prefetch to the top level alongside its parent, while `_resolve_prefetch_input` already resolves it recursively. The inner prefetch was therefore evaluated twice: once as a source of its parent, and once as an extra source of the root query. Under RRF the duplicate source doubles the contribution of every point it returns.

Repro against a server, dot distance, 4 points:

```python
client.query_points(
    "t",
    query=models.FusionQuery(fusion=models.Fusion.RRF),
    prefetch=models.Prefetch(
        prefetch=models.Prefetch(query=[0.1, 0.3], limit=2),
        query=[0.9, 0.2],
        limit=2,
    ),
    limit=5,
)
# local  [(7, 0.75), (9, 0.75), (1, 0.667)]
# server [(7, 0.5), (1, 0.333), (9, 0.25)]