### PR TITLE
fix(conversion): keep an absent UpdateResult.operation_id as None over gRPC

### DIFF
--- a/qdrant_client/conversions/conversion.py
+++ b/qdrant_client/conversions/conversion.py
@@ -498,7 +498,7 @@ class GrpcToRest:
     @classmethod
     def convert_update_result(cls, model: grpc.UpdateResult) -> rest.UpdateResult:
         return rest.UpdateResult(
-            operation_id=model.operation_id,
+            operation_id=model.operation_id if model.HasField("operation_id") else None,
             status=cls.convert_update_status(model.status),
         )
 

--- a/tests/conversions/fixtures.py
+++ b/tests/conversions/fixtures.py
@@ -1088,6 +1088,9 @@ update_status_wait_timeout = grpc.UpdateStatus.WaitTimeout
 
 update_result_completed = grpc.UpdateResult(operation_id=201, status=update_status_completed)
 update_result_wait_timeout = grpc.UpdateResult(operation_id=201, status=update_status_wait_timeout)
+# `operation_id` is `optional` in the proto: the server omits it, e.g. when a
+# delete-by-filter matches nothing or when an update is clock-rejected.
+update_result_no_operation_id = grpc.UpdateResult(status=update_status_completed)
 
 delete_alias = grpc.DeleteAlias(alias_name="col3")
 
@@ -2116,7 +2119,12 @@ fixtures = {
     "SearchMatrixOffsets": [search_matrix_offsets],
     "StrictModeConfig": [strict_mode_config, strict_mode_config_empty],
     "UpdateQueueInfo": [update_queue_info, update_queue_info_deferred],
-    "UpdateResult": [update_result, update_result_completed, update_result_wait_timeout],
+    "UpdateResult": [
+        update_result,
+        update_result_completed,
+        update_result_wait_timeout,
+        update_result_no_operation_id,
+    ],
     "UpdateMode": [update_mode_upsert, update_mode_insert_only, update_mode_update_only],
     "ReplicaState": [
         replica_state_active,

--- a/tests/conversions/test_validate_conversions.py
+++ b/tests/conversions/test_validate_conversions.py
@@ -670,3 +670,22 @@ def test_convert_keyword_index_params_prefix():
     grpc_params, recovered = round_trip(False)
     assert not grpc_params.HasField("prefix")
     assert recovered.prefix is None
+
+
+def test_convert_update_result_operation_id_presence():
+    from qdrant_client import grpc
+    from qdrant_client.conversions.conversion import GrpcToRest, RestToGrpc
+
+    # `optional uint64 operation_id` carries explicit presence: the server leaves it
+    # unset for updates that were not assigned a sequence number (delete-by-filter that
+    # matched nothing, clock-rejected updates, custom sharding with no shard keys yet).
+    absent = grpc.UpdateResult(status=grpc.UpdateStatus.Completed)
+    assert not absent.HasField("operation_id")
+    assert GrpcToRest.convert_update_result(absent).operation_id is None
+    assert not RestToGrpc.convert_update_result(GrpcToRest.convert_update_result(absent)).HasField(
+        "operation_id"
+    )
+
+    # a real operation id of 0 must stay distinguishable from "no operation id"
+    zero = grpc.UpdateResult(operation_id=0, status=grpc.UpdateStatus.Completed)
+    assert GrpcToRest.convert_update_result(zero).operation_id == 0


### PR DESCRIPTION
### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

---

### What

`UpdateResult.operation_id` is declared with explicit presence in `points.proto`:

```proto
message UpdateResult {
  // Number of operation
  optional uint64 operation_id = 1;
  // Operation status
  UpdateStatus status = 2;
}
```

`GrpcToRest.convert_update_result` read it unconditionally, so an absent field
came back as the proto default `0` instead of `None`:

```python
operation_id=model.operation_id,          # before
operation_id=model.operation_id if model.HasField("operation_id") else None,   # after
```

Every neighbouring optional field in this module is already presence-guarded
(`indexed_vectors_count`, `params`, `update_queue`, …); this one was the odd one out.

### Why it matters

The server really does leave `operation_id` unset. In `qdrant`, `UpdateResult.operation_id`
is `Option<SeqNumberType>` and is returned as `None` from at least three paths:

* `lib/collection/src/shards/replica_set/mod.rs` — delete-by-filter that matched no points
* `lib/collection/src/shards/local_shard/shard_ops.rs` — `SubmitOutcome::ClockRejected`
* `lib/storage/src/content_manager/toc/point_ops.rs` — custom sharding with no shard keys yet

On the REST side the field is annotated `#[serde(skip_serializing_if = "Option::is_none")]`,
so the key is simply missing from the body and pydantic yields `None`. Over gRPC the same
update yielded `operation_id=0`. Because `0` is itself a valid operation id (the first
operation in a fresh collection), callers had no way to tell "no operation id" from
"operation 0", and `prefer_grpc=True` silently disagreed with `prefer_grpc=False`.

<details>
<summary>Reproduction and evidence (no server required)</summary>

`repro.py` — the two shapes the client receives for an update that got no sequence number:

```python
from qdrant_client import grpc
from qdrant_client.conversions.conversion import GrpcToRest
from qdrant_client.http.models import models as rest

rest_body = {"status": "completed"}                                # HTTP response body
grpc_msg = grpc.UpdateResult(status=grpc.UpdateStatus.Completed)   # gRPC message

print("REST :", rest.UpdateResult(**rest_body))
print("gRPC :", GrpcToRest.convert_update_result(grpc_msg))
```

Before the fix:

```
REST : operation_id=None status=<UpdateStatus.COMPLETED: 'completed'>
gRPC : operation_id=0 status=<UpdateStatus.COMPLETED: 'completed'>
```

After the fix:

```
REST : operation_id=None status=<UpdateStatus.COMPLETED: 'completed'>
gRPC : operation_id=None status=<UpdateStatus.COMPLETED: 'completed'>
```

**Tests fail before, pass after.** Two independent checks cover it: the new
`update_result_no_operation_id` fixture (which flows through the existing
`test_conversion_completeness` grpc→rest→grpc harness) and a focused unit test.

On the unpatched tree, with the new tests in place:

```
$ python -m pytest tests/conversions/test_validate_conversions.py -q
...
>       assert GrpcToRest.convert_update_result(absent).operation_id is None
E       AssertionError: assert 0 is None
E        +  where 0 = UpdateResult(operation_id=0, status=<UpdateStatus.COMPLETED: 'completed'>).operation_id

FAILED tests/conversions/test_validate_conversions.py::test_conversion_completeness
FAILED tests/conversions/test_validate_conversions.py::test_convert_update_result_operation_id_presence
2 failed, 22 passed in 0.94s
```

With the fix:

```
$ python -m pytest tests/conversions/test_validate_conversions.py -q
........................                                                 [100%]
24 passed in 0.65s
```

Surrounding server-free suites are unaffected:

```
$ python -m pytest tests/conversions tests/test_in_memory.py tests/test_local_persistence.py tests/test_common.py -q
........................................................                 [100%]
56 passed in 0.90s
```

(The rest of `tests/` needs a live Qdrant instance, which was not available in this
environment; nothing outside `conversions/` is touched by this change.)

`ruff-format --line-length=99` is clean on all three touched files.

</details>

<details>
<summary>How it was found</summary>

A static probe over `GrpcToRest`: for every converter whose first argument is annotated
`grpc.<Message>`, cross-reference the proto descriptor's explicit-presence scalar fields
against `HasField(...)` guards in the function body. Seven converters read an
explicit-presence scalar unguarded; five were false positives (`oneof` variants read via
`WhichOneof`, or fields whose REST counterpart is a required `int` that cannot hold `None`).
`UpdateResult.operation_id` was the one where the REST counterpart is `Optional[int]` **and**
the server has real code paths that omit the field.

</details>

Disclosure: prepared with AI assistance (Claude Code); I reviewed the change and take responsibility for it.
