### PR TITLE
fix: show server error text, fix upload retry warning

### DIFF
--- a/qdrant_client/http/exceptions.py
+++ b/qdrant_client/http/exceptions.py
@@ -33,9 +33,20 @@ class UnexpectedResponse(ApiException):
         else:
             reason_phrase_str = f"({self.reason_phrase})"
         status_str = f"{status_code_str} {reason_phrase_str}".strip()
+        error = self._server_error()
+        if error is not None:
+            return f"Unexpected Response: {status_str}\nError: {error}"
         short_content = self.content if len(self.content) <= MAX_CONTENT else self.content[: MAX_CONTENT - 3] + b" ..."
         raw_content_str = f"Raw response content:\n{short_content!r}"
         return f"Unexpected Response: {status_str}\n{raw_content_str}"
+
+    def _server_error(self) -> Optional[str]:
+        """Return `status.error` from a Qdrant JSON error body, or None if absent or unparsable."""
+        try:
+            error = json.loads(self.content).get("status", {}).get("error")
+        except (ValueError, TypeError, AttributeError):
+            return None
+        return error if isinstance(error, str) and error else None
 
     def structured(self) -> Dict[str, Any]:
         return json.loads(self.content)

--- a/qdrant_client/uploader/grpc_uploader.py
+++ b/qdrant_client/uploader/grpc_uploader.py
@@ -67,15 +67,14 @@ def upload_batch_grpc(
             sleep(ex.retry_after_s)
 
         except Exception as e:
+            if attempt == max_retries - 1:
+                raise
+
             show_warning(
-                message=f"Batch upload failed {attempt + 1} times. Retrying...",
+                message=f"Batch upload failed {attempt + 1} times ({type(e).__name__}: {e}). Retrying...",
                 category=UserWarning,
                 stacklevel=8,
             )
-
-            if attempt == max_retries - 1:
-                raise e
-
             attempt += 1
     return True
 

--- a/qdrant_client/uploader/rest_uploader.py
+++ b/qdrant_client/uploader/rest_uploader.py
@@ -62,15 +62,14 @@ def upload_batch(
             sleep(ex.retry_after_s)
 
         except Exception as e:
+            if attempt == max_retries - 1:
+                raise
+
             show_warning(
-                message=f"Batch upload failed {attempt + 1} times. Retrying...",
+                message=f"Batch upload failed {attempt + 1} times ({type(e).__name__}: {e}). Retrying...",
                 category=UserWarning,
                 stacklevel=7,
             )
-
-            if attempt == max_retries - 1:
-                raise e
-
             attempt += 1
     return True
 


### PR DESCRIPTION
### summary 

fix: show server error text in UnexpectedResponse and fix upload retry warning


- `UnexpectedResponse.__str__` now prints the `status.error` text from the qdrant json body instead of raw bytes cut at 200 chars. falls back to the old raw output if the body is not json. `.content` and `.structured()` unchanged
- in `rest_uploader.py` and `grpc_uploader.py` the retry loop said `Retrying...` on the last attempt right before raising, and did not say what failed. now the last attempt raises directly and the warning includes the exception type and message

tested with unit tests for the parsed and fallback paths, a fake client for the retry loop, and the repo pre-commit hooks on the changed files


### All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you installed `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
